### PR TITLE
Attempting to improve compiler error messages related to tag_invoke

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/algorithms/partial_sort.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/partial_sort.hpp
@@ -346,15 +346,6 @@ namespace hpx::parallel {
         hpx::future<Iter> parallel_partial_sort(ExPolicy&& policy, Iter first,
             Iter middle, Iter last, std::uint32_t level, Comp&& comp = Comp());
 
-        HPX_CXX_EXPORT struct sort_thread_helper
-        {
-            template <typename... Ts>
-            decltype(auto) operator()(Ts&&... ts) const
-            {
-                return sort_thread(HPX_FORWARD(Ts, ts)...);
-            }
-        };
-
         HPX_CXX_EXPORT struct parallel_partial_sort_helper
         {
             template <typename... Ts>
@@ -399,15 +390,15 @@ namespace hpx::parallel {
                         policy.parameters(), policy.executor(),
                         hpx::chrono::null_duration, cores, nelem);
 
-                hpx::future<Iter> left = execution::async_execute(
-                    policy.executor(), sort_thread_helper(), policy, first,
-                    c_last, comp, chunk_size);
+                hpx::future<Iter> left =
+                    execution::async_execute(policy.executor(), sort_thread{},
+                        policy, first, c_last, comp, chunk_size);
 
                 hpx::future<Iter> right;
                 if (middle != c_last)
                 {
                     right = execution::async_execute(policy.executor(),
-                        parallel_partial_sort_helper(), policy, c_last + 1,
+                        parallel_partial_sort_helper{}, policy, c_last + 1,
                         middle, last, level - 1, comp);
                 }
                 else

--- a/libs/core/executors/include/hpx/executors/parallel_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/parallel_executor.hpp
@@ -644,7 +644,8 @@ namespace hpx::execution {
     // support all properties exposed by the embedded policy
     HPX_CXX_EXPORT template <typename Tag, typename Policy, typename Property,
         HPX_CONCEPT_REQUIRES_(
-            hpx::execution::experimental::is_scheduling_property_v<Tag>)>
+            hpx::execution::experimental::is_scheduling_property_v<Tag>&&
+                hpx::functional::is_tag_invocable_v<Tag, Policy, Property&&>)>
     auto tag_invoke(
         Tag tag, parallel_policy_executor<Policy> const& exec, Property&& prop)
         -> decltype(std::declval<parallel_policy_executor<Policy>>().policy(
@@ -659,7 +660,8 @@ namespace hpx::execution {
 
     HPX_CXX_EXPORT template <typename Tag, typename Policy,
         HPX_CONCEPT_REQUIRES_(
-            hpx::execution::experimental::is_scheduling_property_v<Tag>)>
+            hpx::execution::experimental::is_scheduling_property_v<Tag>&&
+                hpx::functional::is_tag_invocable_v<Tag, Policy>)>
     auto tag_invoke(Tag tag, parallel_policy_executor<Policy> const& exec)
         -> decltype(std::declval<Tag>()(std::declval<Policy>()))
     {

--- a/libs/core/tag_invoke/include/hpx/functional/detail/tag_fallback_invoke.hpp
+++ b/libs/core/tag_invoke/include/hpx/functional/detail/tag_fallback_invoke.hpp
@@ -326,7 +326,7 @@ namespace hpx::functional::detail {
                     !is_nothrow_tag_invocable_v<Tag, Args&&...> &&
                     meta::value<meta::invoke<Enable,
                         enable_tag_fallback_invoke_t, Args&&...>>>>
-            HPX_HOST_DEVICE HPX_FORCEINLINE constexpr auto operator()(
+            HPX_HOST_DEVICE HPX_FORCEINLINE constexpr decltype(auto) operator()(
                 Args&&... args) const noexcept
             {
                 if constexpr (is_nothrow_tag_fallback_invocable_v<Tag,

--- a/libs/core/tag_invoke/include/hpx/functional/detail/tag_priority_invoke.hpp
+++ b/libs/core/tag_invoke/include/hpx/functional/detail/tag_priority_invoke.hpp
@@ -324,8 +324,7 @@ namespace hpx::functional::detail {
                     static_cast<Tag const&>(*this), HPX_FORWARD(Args, args)...);
             }
 
-            // Is not nothrow tag-override-invocable, but nothrow
-            // tag-invocable
+            // Is not nothrow tag-override-invocable, but nothrow tag-invocable
             template <typename... Args,
                 typename = std::enable_if_t<
                     !is_nothrow_tag_override_invocable_v<Tag, Args&&...> &&
@@ -340,8 +339,8 @@ namespace hpx::functional::detail {
                     static_cast<Tag const&>(*this), HPX_FORWARD(Args, args)...);
             }
 
-            // Is not nothrow tag-override-invocable, not nothrow
-            // tag-invocable, but nothrow tag-fallback-invocable
+            // Is not nothrow tag-override-invocable, not nothrow tag-invocable,
+            // but nothrow tag-fallback-invocable
             template <typename... Args,
                 typename = std::enable_if_t<
                     !is_nothrow_tag_override_invocable_v<Tag, Args&&...> &&


### PR DESCRIPTION
This is an experiment of how to best improve generated error messages if no appropriate `tag_invoke` overloads are being available. 

The main idea is to add explicit `operator()()` overload(s) to the customization point object that concept-check all arguments. These `operator()()` overloads simply forward to the base-class dispatch logic. This has the additional benefit of centralized argument concept-checking for all `tag_invoke` overloads provided.

If this proves to be applicable it opens up a path to fixing #6718.