### PR TITLE
feat(algorithms): implement P2300 allocator support for when_all_vector

### DIFF
--- a/libs/core/algorithms/tests/unit/algorithms/partial_sort_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/partial_sort_sender.cpp
@@ -9,6 +9,8 @@
 #include <hpx/init.hpp>
 #include <hpx/modules/testing.hpp>
 
+#if !defined(HPX_CLANG_VERSION) || ((HPX_CLANG_VERSION / 10000) > 22)
+
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
@@ -117,3 +119,10 @@ int main(int argc, char* argv[])
 
     return hpx::util::report_errors();
 }
+
+#else
+int main()
+{
+    return 0;
+}
+#endif

--- a/libs/core/algorithms/tests/unit/algorithms/partial_sort_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/partial_sort_sender.cpp
@@ -9,8 +9,6 @@
 #include <hpx/init.hpp>
 #include <hpx/modules/testing.hpp>
 
-#if !defined(HPX_CLANG_VERSION) || ((HPX_CLANG_VERSION / 10000) > 22)
-
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
@@ -119,10 +117,3 @@ int main(int argc, char* argv[])
 
     return hpx::util::report_errors();
 }
-
-#else
-int main()
-{
-    return 0;
-}
-#endif

--- a/libs/core/execution/include/hpx/execution/algorithms/when_all_vector.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/when_all_vector.hpp
@@ -43,6 +43,35 @@ namespace hpx::when_all_vector_detail {
         }
     };
 
+    // P2300 allocator support: extract allocator from an environment
+    // via get_allocator, falling back to std::allocator<void> when the
+    // query is not supported.
+    template <typename Env, typename = void>
+    struct env_allocator
+    {
+        using type = std::allocator<void>;
+
+        static type get(Env const&) noexcept
+        {
+            return {};
+        }
+    };
+
+    template <typename Env>
+    struct env_allocator<Env,
+        std::void_t<decltype(hpx::execution::experimental::get_allocator(
+            std::declval<Env const&>()))>>
+    {
+        using type =
+            std::decay_t<decltype(hpx::execution::experimental::get_allocator(
+                std::declval<Env const&>()))>;
+
+        static type get(Env const& env)
+        {
+            return hpx::execution::experimental::get_allocator(env);
+        }
+    };
+
     HPX_CXX_CORE_EXPORT template <typename Sender>
     struct when_all_vector_sender_impl
     {
@@ -292,8 +321,39 @@ namespace hpx::when_all_vector_detail {
             using operation_state_type =
                 hpx::execution::experimental::connect_result_t<Sender,
                     when_all_vector_receiver>;
+
+            // P2300 allocator support: extract allocator from the
+            // receiver's environment, rebind to the element type, and
+            // use a custom deleter so the unique_ptr deallocates
+            // through the allocator.
+            using env_type = decltype(hpx::execution::experimental::get_env(
+                std::declval<receiver_type const&>()));
+            using raw_alloc_type = typename env_allocator<env_type>::type;
+            using element_type = std::optional<operation_state_type>;
+            using alloc_type = typename std::allocator_traits<
+                raw_alloc_type>::template rebind_alloc<element_type>;
+            using alloc_traits_type = std::allocator_traits<alloc_type>;
+
+            struct op_states_deleter
+            {
+                alloc_type alloc{};
+                std::size_t count = 0;
+
+                void operator()(element_type* ptr) noexcept
+                {
+                    if (ptr != nullptr)
+                    {
+                        for (std::size_t i = 0; i < count; ++i)
+                        {
+                            alloc_traits_type::destroy(alloc, ptr + i);
+                        }
+                        alloc_traits_type::deallocate(alloc, ptr, count);
+                    }
+                }
+            };
+
             using operation_states_storage_type =
-                std::unique_ptr<std::optional<operation_state_type>[]>;
+                std::unique_ptr<element_type[], op_states_deleter>;
             operation_states_storage_type op_states = nullptr;
 
             template <typename Receiver_>
@@ -301,9 +361,34 @@ namespace hpx::when_all_vector_detail {
               : num_predecessors(senders.size())
               , receiver(HPX_FORWARD(Receiver_, receiver))
             {
-                op_states =
-                    std::make_unique<std::optional<operation_state_type>[]>(
-                        num_predecessors);
+                {
+                    alloc_type alloc(env_allocator<env_type>::get(
+                        hpx::execution::experimental::get_env(this->receiver)));
+                    element_type* ptr =
+                        alloc_traits_type::allocate(alloc, num_predecessors);
+
+                    std::size_t constructed = 0;
+                    try
+                    {
+                        for (std::size_t j = 0; j < num_predecessors; ++j)
+                        {
+                            alloc_traits_type::construct(alloc, ptr + j);
+                            ++constructed;
+                        }
+                    }
+                    catch (...)
+                    {
+                        for (std::size_t j = 0; j < constructed; ++j)
+                        {
+                            alloc_traits_type::destroy(alloc, ptr + j);
+                        }
+                        alloc_traits_type::deallocate(
+                            alloc, ptr, num_predecessors);
+                        throw;
+                    }
+                    op_states = operation_states_storage_type(
+                        ptr, op_states_deleter{alloc, num_predecessors});
+                }
                 std::size_t i = 0;
                 for (auto&& sender : senders)
                 {
@@ -446,7 +531,7 @@ namespace hpx::when_all_vector_detail {
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #endif
                         hpx::execution::experimental::start(
-                            op_states.get()[i].value());
+                            op_states[i].value());
 #if defined(HPX_CLANG_VERSION)
 #pragma clang diagnostic pop
 #endif

--- a/libs/core/execution/include/hpx/execution/algorithms/when_all_vector.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/when_all_vector.hpp
@@ -198,44 +198,41 @@ namespace hpx::when_all_vector_detail {
                 operation_state& op_state;
                 std::size_t const i;
 
-                template <typename Error, typename OpState = operation_state>
+                template <typename Error>
                 void set_error(Error&& error) && noexcept
                 {
-                    auto& op = static_cast<OpState&>(op_state);
-                    if (!op.set_stopped_error_called.exchange(true))
+                    if (!op_state.set_stopped_error_called.exchange(true))
                     {
-                        op.stop_source_.request_stop();
+                        op_state.stop_source_.request_stop();
                         try
                         {
-                            op.error = HPX_FORWARD(Error, error);
+                            op_state.error = HPX_FORWARD(Error, error);
                         }
                         catch (...)
                         {
                             // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
-                            op.error = std::current_exception();
+                            op_state.error = std::current_exception();
                         }
                     }
 
-                    op.finish();
+                    op_state.finish();
                 }
 
-                template <typename OpState = operation_state>
+                template <typename Dummy = void>
                 void set_stopped() && noexcept
                 {
-                    auto& op = static_cast<OpState&>(op_state);
                     // request stop only if we're not in error state
-                    if (!op.set_stopped_error_called.exchange(true))
+                    if (!op_state.set_stopped_error_called.exchange(true))
                     {
-                        op.stop_source_.request_stop();
+                        op_state.stop_source_.request_stop();
                     }
-                    op.finish();
+                    op_state.finish();
                 }
 
-                template <typename... Ts, typename OpState = operation_state>
+                template <typename... Ts>
                 void set_value(Ts&&... ts) && noexcept
                 {
-                    auto& op = static_cast<OpState&>(op_state);
-                    if (!op.set_stopped_error_called)
+                    if (!op_state.set_stopped_error_called)
                     {
                         try
                         {
@@ -245,27 +242,27 @@ namespace hpx::when_all_vector_detail {
                             // senders that send nothing.
                             if constexpr (sizeof...(Ts) == 1)
                             {
-                                op.ts[i].emplace(HPX_FORWARD(Ts, ts)...);
+                                op_state.ts[i].emplace(HPX_FORWARD(Ts, ts)...);
                             }
                         }
                         catch (...)
                         {
-                            if (!op.set_stopped_error_called.exchange(true))
+                            if (!op_state.set_stopped_error_called.exchange(
+                                    true))
                             {
                                 // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
-                                op.error = std::current_exception();
+                                op_state.error = std::current_exception();
                             }
                         }
                     }
 
-                    op.finish();
+                    op_state.finish();
                 }
 
                 // clang-format off
-                template <typename OpState = operation_state>
+                template <typename Dummy = void>
                 auto get_env() const noexcept
                 {
-                    auto const& op = static_cast<OpState const&>(op_state);
                     /* The new calling convention is:
                      * make_env(old_env, prop(tag, val))*/
 
@@ -275,10 +272,10 @@ namespace hpx::when_all_vector_detail {
                     // temporaries returned by the functions causes wrong
                     // behaviour.
                     auto e = hpx::execution::experimental::get_env(
-                        op.receiver);
+                        op_state.receiver);
                     auto p = hpx::execution::experimental::prop(
                         hpx::execution::experimental::get_stop_token,
-                        op.stop_source_.get_token());
+                        op_state.stop_source_.get_token());
                     return hpx::execution::experimental::make_env(
                         std::move(e), std::move(p));
                 }

--- a/libs/core/execution/include/hpx/execution/algorithms/when_all_vector.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/when_all_vector.hpp
@@ -198,40 +198,44 @@ namespace hpx::when_all_vector_detail {
                 operation_state& op_state;
                 std::size_t const i;
 
-                template <typename Error>
+                template <typename Error, typename OpState = operation_state>
                 void set_error(Error&& error) && noexcept
                 {
-                    if (!op_state.set_stopped_error_called.exchange(true))
+                    auto& op = static_cast<OpState&>(op_state);
+                    if (!op.set_stopped_error_called.exchange(true))
                     {
-                        op_state.stop_source_.request_stop();
+                        op.stop_source_.request_stop();
                         try
                         {
-                            op_state.error = HPX_FORWARD(Error, error);
+                            op.error = HPX_FORWARD(Error, error);
                         }
                         catch (...)
                         {
                             // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
-                            op_state.error = std::current_exception();
+                            op.error = std::current_exception();
                         }
                     }
 
-                    op_state.finish();
+                    op.finish();
                 }
 
+                template <typename OpState = operation_state>
                 void set_stopped() && noexcept
                 {
+                    auto& op = static_cast<OpState&>(op_state);
                     // request stop only if we're not in error state
-                    if (!op_state.set_stopped_error_called.exchange(true))
+                    if (!op.set_stopped_error_called.exchange(true))
                     {
-                        op_state.stop_source_.request_stop();
+                        op.stop_source_.request_stop();
                     }
-                    op_state.finish();
+                    op.finish();
                 }
 
-                template <typename... Ts>
+                template <typename... Ts, typename OpState = operation_state>
                 void set_value(Ts&&... ts) && noexcept
                 {
-                    if (!op_state.set_stopped_error_called)
+                    auto& op = static_cast<OpState&>(op_state);
+                    if (!op.set_stopped_error_called)
                     {
                         try
                         {
@@ -241,26 +245,27 @@ namespace hpx::when_all_vector_detail {
                             // senders that send nothing.
                             if constexpr (sizeof...(Ts) == 1)
                             {
-                                op_state.ts[i].emplace(HPX_FORWARD(Ts, ts)...);
+                                op.ts[i].emplace(HPX_FORWARD(Ts, ts)...);
                             }
                         }
                         catch (...)
                         {
-                            if (!op_state.set_stopped_error_called.exchange(
-                                    true))
+                            if (!op.set_stopped_error_called.exchange(true))
                             {
                                 // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
-                                op_state.error = std::current_exception();
+                                op.error = std::current_exception();
                             }
                         }
                     }
 
-                    op_state.finish();
+                    op.finish();
                 }
 
                 // clang-format off
+                template <typename OpState = operation_state>
                 auto get_env() const noexcept
                 {
+                    auto const& op = static_cast<OpState const&>(op_state);
                     /* The new calling convention is:
                      * make_env(old_env, prop(tag, val))*/
 
@@ -270,10 +275,10 @@ namespace hpx::when_all_vector_detail {
                     // temporaries returned by the functions causes wrong
                     // behaviour.
                     auto e = hpx::execution::experimental::get_env(
-                        op_state.receiver);
+                        op.receiver);
                     auto p = hpx::execution::experimental::prop(
                         hpx::execution::experimental::get_stop_token,
-                        op_state.stop_source_.get_token());
+                        op.stop_source_.get_token());
                     return hpx::execution::experimental::make_env(
                         std::move(e), std::move(p));
                 }

--- a/libs/core/execution/include/hpx/execution/algorithms/when_all_vector.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/when_all_vector.hpp
@@ -199,86 +199,17 @@ namespace hpx::when_all_vector_detail {
                 std::size_t const i;
 
                 template <typename Error>
-                void set_error(Error&& error) && noexcept
-                {
-                    if (!op_state.set_stopped_error_called.exchange(true))
-                    {
-                        op_state.stop_source_.request_stop();
-                        try
-                        {
-                            op_state.error = HPX_FORWARD(Error, error);
-                        }
-                        catch (...)
-                        {
-                            // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
-                            op_state.error = std::current_exception();
-                        }
-                    }
-
-                    op_state.finish();
-                }
+                void set_error(Error&& error) && noexcept;
 
                 template <typename Dummy = void>
-                void set_stopped() && noexcept
-                {
-                    // request stop only if we're not in error state
-                    if (!op_state.set_stopped_error_called.exchange(true))
-                    {
-                        op_state.stop_source_.request_stop();
-                    }
-                    op_state.finish();
-                }
+                void set_stopped() && noexcept;
 
                 template <typename... Ts>
-                void set_value(Ts&&... ts) && noexcept
-                {
-                    if (!op_state.set_stopped_error_called)
-                    {
-                        try
-                        {
-                            // We only have something to store if the
-                            // predecessor sends the single value that it should
-                            // send. We have nothing to store for predecessor
-                            // senders that send nothing.
-                            if constexpr (sizeof...(Ts) == 1)
-                            {
-                                op_state.ts[i].emplace(HPX_FORWARD(Ts, ts)...);
-                            }
-                        }
-                        catch (...)
-                        {
-                            if (!op_state.set_stopped_error_called.exchange(
-                                    true))
-                            {
-                                // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
-                                op_state.error = std::current_exception();
-                            }
-                        }
-                    }
-
-                    op_state.finish();
-                }
+                void set_value(Ts&&... ts) && noexcept;
 
                 // clang-format off
                 template <typename Dummy = void>
-                auto get_env() const noexcept
-                {
-                    /* The new calling convention is:
-                     * make_env(old_env, prop(tag, val))*/
-
-
-                    // Due to the bug described in the get_env.cpp tests,
-                    // returning an env constructed directly with the
-                    // temporaries returned by the functions causes wrong
-                    // behaviour.
-                    auto e = hpx::execution::experimental::get_env(
-                        op_state.receiver);
-                    auto p = hpx::execution::experimental::prop(
-                        hpx::execution::experimental::get_stop_token,
-                        op_state.stop_source_.get_token());
-                    return hpx::execution::experimental::make_env(
-                        std::move(e), std::move(p));
-                }
+                auto get_env() const noexcept;
                 // clang-format on
             };
 
@@ -561,6 +492,100 @@ namespace hpx::when_all_vector_detail {
             return operation_state<Receiver>(receiver, senders);
         }
     };    // namespace hpx::when_all_vector_detail
+
+    template <typename Sender>
+    template <typename Receiver>
+    template <typename Error>
+    void when_all_vector_sender_impl<Sender>::when_all_vector_sender_type::
+        operation_state<Receiver>::when_all_vector_receiver::set_error(
+            Error&& error) && noexcept
+    {
+        if (!op_state.set_stopped_error_called.exchange(true))
+        {
+            op_state.stop_source_.request_stop();
+            try
+            {
+                op_state.error = HPX_FORWARD(Error, error);
+            }
+            catch (...)
+            {
+                // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
+                op_state.error = std::current_exception();
+            }
+        }
+
+        op_state.finish();
+    }
+
+    template <typename Sender>
+    template <typename Receiver>
+    template <typename Dummy>
+    void when_all_vector_sender_impl<
+        Sender>::when_all_vector_sender_type::operation_state<Receiver>::
+        when_all_vector_receiver::set_stopped() && noexcept
+    {
+        // request stop only if we're not in error state
+        if (!op_state.set_stopped_error_called.exchange(true))
+        {
+            op_state.stop_source_.request_stop();
+        }
+        op_state.finish();
+    }
+
+    template <typename Sender>
+    template <typename Receiver>
+    template <typename... Ts>
+    void when_all_vector_sender_impl<Sender>::when_all_vector_sender_type::
+        operation_state<Receiver>::when_all_vector_receiver::set_value(
+            Ts&&... ts) && noexcept
+    {
+        if (!op_state.set_stopped_error_called)
+        {
+            try
+            {
+                // We only have something to store if the
+                // predecessor sends the single value that it should
+                // send. We have nothing to store for predecessor
+                // senders that send nothing.
+                if constexpr (sizeof...(Ts) == 1)
+                {
+                    op_state.ts[i].emplace(HPX_FORWARD(Ts, ts)...);
+                }
+            }
+            catch (...)
+            {
+                if (!op_state.set_stopped_error_called.exchange(true))
+                {
+                    // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
+                    op_state.error = std::current_exception();
+                }
+            }
+        }
+
+        op_state.finish();
+    }
+
+    template <typename Sender>
+    template <typename Receiver>
+    template <typename Dummy>
+    auto when_all_vector_sender_impl<Sender>::when_all_vector_sender_type::
+        operation_state<Receiver>::when_all_vector_receiver::get_env()
+            const noexcept
+    {
+        /* The new calling convention is:
+         * make_env(old_env, prop(tag, val))*/
+
+        // Due to the bug described in the get_env.cpp tests,
+        // returning an env constructed directly with the
+        // temporaries returned by the functions causes wrong
+        // behaviour.
+        auto e = hpx::execution::experimental::get_env(op_state.receiver);
+        auto p = hpx::execution::experimental::prop(
+            hpx::execution::experimental::get_stop_token,
+            op_state.stop_source_.get_token());
+        return hpx::execution::experimental::make_env(
+            std::move(e), std::move(p));
+    }
 }    // namespace hpx::when_all_vector_detail
 
 namespace hpx::execution::experimental {

--- a/libs/core/execution/include/hpx/execution/algorithms/when_all_vector.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/when_all_vector.hpp
@@ -336,7 +336,7 @@ namespace hpx::when_all_vector_detail {
 
             struct op_states_deleter
             {
-                alloc_type alloc{};
+                alloc_type alloc;
                 std::size_t count = 0;
 
                 void operator()(element_type* ptr) noexcept
@@ -354,12 +354,17 @@ namespace hpx::when_all_vector_detail {
 
             using operation_states_storage_type =
                 std::unique_ptr<element_type[], op_states_deleter>;
-            operation_states_storage_type op_states = nullptr;
+            operation_states_storage_type op_states;
 
             template <typename Receiver_>
             operation_state(Receiver_&& receiver, std::vector<Sender>&& senders)
               : num_predecessors(senders.size())
               , receiver(HPX_FORWARD(Receiver_, receiver))
+              , op_states(nullptr,
+                    op_states_deleter{alloc_type(env_allocator<env_type>::get(
+                                          hpx::execution::experimental::get_env(
+                                              this->receiver))),
+                        0})
             {
                 {
                     alloc_type alloc(env_allocator<env_type>::get(
@@ -386,8 +391,9 @@ namespace hpx::when_all_vector_detail {
                             alloc, ptr, num_predecessors);
                         throw;
                     }
-                    op_states = operation_states_storage_type(
+                    operation_states_storage_type temp(
                         ptr, op_states_deleter{alloc, num_predecessors});
+                    op_states = std::move(temp);
                 }
                 std::size_t i = 0;
                 for (auto&& sender : senders)

--- a/libs/core/execution/include/hpx/execution/algorithms/when_all_vector.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/when_all_vector.hpp
@@ -185,96 +185,34 @@ namespace hpx::when_all_vector_detail {
         }
 
         template <typename Receiver>
+        struct operation_state;
+
+        template <typename Receiver>
+        struct when_all_vector_receiver
+        {
+            using receiver_concept = hpx::execution::experimental::receiver_t;
+            operation_state<Receiver>& op_state;
+            std::size_t const i;
+
+            template <typename Error>
+            void set_error(Error&& error) && noexcept;
+
+            void set_stopped() && noexcept;
+
+            template <typename... Ts>
+            void set_value(Ts&&... ts) && noexcept;
+
+            // clang-format off
+            auto get_env() const noexcept;
+            // clang-format on
+        };
+
+        template <typename Receiver>
         struct operation_state
         {
             using receiver_type = std::decay_t<Receiver>;
             using operation_state_concept =
                 hpx::execution::experimental::operation_state_t;
-
-            struct when_all_vector_receiver
-            {
-                using receiver_concept =
-                    hpx::execution::experimental::receiver_t;
-                operation_state& op_state;
-                std::size_t const i;
-
-                template <typename Error>
-                void set_error(Error&& error) && noexcept
-                {
-                    if (!op_state.set_stopped_error_called.exchange(true))
-                    {
-                        op_state.stop_source_.request_stop();
-                        try
-                        {
-                            op_state.error = HPX_FORWARD(Error, error);
-                        }
-                        catch (...)
-                        {
-                            // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
-                            op_state.error = std::current_exception();
-                        }
-                    }
-
-                    op_state.finish();
-                }
-
-                void set_stopped() && noexcept
-                {
-                    // request stop only if we're not in error state
-                    if (!op_state.set_stopped_error_called.exchange(true))
-                    {
-                        op_state.stop_source_.request_stop();
-                    }
-                    op_state.finish();
-                }
-
-                template <typename... Ts>
-                void set_value(Ts&&... ts) && noexcept
-                {
-                    if (!op_state.set_stopped_error_called)
-                    {
-                        try
-                        {
-                            // We only have something to store if the
-                            // predecessor sends the single value that it
-                            // should send. We have nothing to store for
-                            // predecessor senders that send nothing.
-                            if constexpr (sizeof...(Ts) == 1)
-                            {
-                                op_state.ts[i].emplace(HPX_FORWARD(Ts, ts)...);
-                            }
-                        }
-                        catch (...)
-                        {
-                            if (!op_state.set_stopped_error_called.exchange(
-                                    true))
-                            {
-                                // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
-                                op_state.error = std::current_exception();
-                            }
-                        }
-                    }
-
-                    op_state.finish();
-                }
-
-                // clang-format off
-                auto get_env() const noexcept
-                {
-                    // Due to the bug described in the get_env.cpp tests,
-                    // returning an env constructed directly with the
-                    // temporaries returned by the functions causes wrong
-                    // behaviour.
-                    auto e = hpx::execution::experimental::get_env(
-                        op_state.receiver);
-                    auto p = hpx::execution::experimental::prop(
-                        hpx::execution::experimental::get_stop_token,
-                        op_state.stop_source_.get_token());
-                    return hpx::execution::experimental::make_env(
-                        std::move(e), std::move(p));
-                }
-                // clang-format on
-            };
 
             std::size_t const num_predecessors;
             HPX_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
@@ -316,7 +254,7 @@ namespace hpx::when_all_vector_detail {
             // non-copyability of them
             using operation_state_type =
                 hpx::execution::experimental::connect_result_t<Sender,
-                    when_all_vector_receiver>;
+                    when_all_vector_receiver<Receiver>>;
 
             // P2300 allocator support: extract allocator from the
             // receiver's environment, rebind to the element type, and
@@ -400,14 +338,14 @@ namespace hpx::when_all_vector_detail {
                         hpx::util::detail::with_result_of([&]() {
                             return hpx::execution::experimental::connect(
                                 std::move(sender),
-                                when_all_vector_receiver{*this, i});
+                                when_all_vector_receiver<Receiver>{*this, i});
                         }));
 #else
                     op_states[i].emplace(
                         hpx::util::detail::with_result_of([&]() {
                             return hpx::execution::experimental::connect(
                                 HPX_MOVE(sender),
-                                when_all_vector_receiver{*this, i});
+                                when_all_vector_receiver<Receiver>{*this, i});
                         }));
 #endif
 #else
@@ -415,7 +353,7 @@ namespace hpx::when_all_vector_detail {
                     // state must be constructed explicitly directly in place
                     op_states[i].template emplace_f<operation_state_type>(
                         hpx::execution::experimental::connect, HPX_MOVE(sender),
-                        when_all_vector_receiver{*this, i});
+                        when_all_vector_receiver<Receiver>{*this, i});
 #endif
                     ++i;
                 }
@@ -555,6 +493,95 @@ namespace hpx::when_all_vector_detail {
             return operation_state<Receiver>(receiver, senders);
         }
     };    // namespace hpx::when_all_vector_detail
+
+    template <typename Sender>
+    template <typename Receiver>
+    template <typename Error>
+    inline void
+    when_all_vector_sender_impl<Sender>::when_all_vector_sender_type::
+        when_all_vector_receiver<Receiver>::set_error(Error&& error) && noexcept
+    {
+        if (!op_state.set_stopped_error_called.exchange(true))
+        {
+            op_state.stop_source_.request_stop();
+            try
+            {
+                op_state.error = HPX_FORWARD(Error, error);
+            }
+            catch (...)
+            {
+                // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
+                op_state.error = std::current_exception();
+            }
+        }
+
+        op_state.finish();
+    }
+
+    template <typename Sender>
+    template <typename Receiver>
+    inline void
+    when_all_vector_sender_impl<Sender>::when_all_vector_sender_type::
+        when_all_vector_receiver<Receiver>::set_stopped() && noexcept
+    {
+        // request stop only if we're not in error state
+        if (!op_state.set_stopped_error_called.exchange(true))
+        {
+            op_state.stop_source_.request_stop();
+        }
+        op_state.finish();
+    }
+
+    template <typename Sender>
+    template <typename Receiver>
+    template <typename... Ts>
+    inline void
+    when_all_vector_sender_impl<Sender>::when_all_vector_sender_type::
+        when_all_vector_receiver<Receiver>::set_value(Ts&&... ts) && noexcept
+    {
+        if (!op_state.set_stopped_error_called)
+        {
+            try
+            {
+                // We only have something to store if the
+                // predecessor sends the single value that it
+                // should send. We have nothing to store for
+                // predecessor senders that send nothing.
+                if constexpr (sizeof...(Ts) == 1)
+                {
+                    op_state.ts[i].emplace(HPX_FORWARD(Ts, ts)...);
+                }
+            }
+            catch (...)
+            {
+                if (!op_state.set_stopped_error_called.exchange(true))
+                {
+                    // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
+                    op_state.error = std::current_exception();
+                }
+            }
+        }
+
+        op_state.finish();
+    }
+
+    template <typename Sender>
+    template <typename Receiver>
+    inline auto
+    when_all_vector_sender_impl<Sender>::when_all_vector_sender_type::
+        when_all_vector_receiver<Receiver>::get_env() const noexcept
+    {
+        // Due to the bug described in the get_env.cpp tests,
+        // returning an env constructed directly with the
+        // temporaries returned by the functions causes wrong
+        // behaviour.
+        auto e = hpx::execution::experimental::get_env(op_state.receiver);
+        auto p = hpx::execution::experimental::prop(
+            hpx::execution::experimental::get_stop_token,
+            op_state.stop_source_.get_token());
+        return hpx::execution::experimental::make_env(
+            std::move(e), std::move(p));
+    }
 }    // namespace hpx::when_all_vector_detail
 
 namespace hpx::execution::experimental {

--- a/libs/core/execution/include/hpx/execution/algorithms/when_all_vector.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/when_all_vector.hpp
@@ -202,9 +202,19 @@ namespace hpx::when_all_vector_detail {
             template <typename... Ts>
             void set_value(Ts&&... ts) && noexcept;
 
-            // clang-format off
-            auto get_env() const noexcept;
-            // clang-format on
+            using receiver_env_type =
+                decltype(hpx::execution::experimental::get_env(
+                    std::declval<std::decay_t<Receiver> const&>()));
+            using stop_token_type =
+                decltype(std::declval<hpx::experimental::in_place_stop_source>()
+                        .get_token());
+            using prop_type = decltype(hpx::execution::experimental::prop(
+                hpx::execution::experimental::get_stop_token,
+                std::declval<stop_token_type>()));
+            using env_type = decltype(hpx::execution::experimental::make_env(
+                std::declval<receiver_env_type>(), std::declval<prop_type>()));
+
+            env_type get_env() const noexcept;
         };
 
         template <typename Receiver>
@@ -569,7 +579,7 @@ namespace hpx::when_all_vector_detail {
     template <typename Receiver>
     inline auto
     when_all_vector_sender_impl<Sender>::when_all_vector_sender_type::
-        when_all_vector_receiver<Receiver>::get_env() const noexcept
+        when_all_vector_receiver<Receiver>::get_env() const noexcept -> env_type
     {
         // Due to the bug described in the get_env.cpp tests,
         // returning an env constructed directly with the

--- a/libs/core/execution/include/hpx/execution/algorithms/when_all_vector.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/when_all_vector.hpp
@@ -199,17 +199,80 @@ namespace hpx::when_all_vector_detail {
                 std::size_t const i;
 
                 template <typename Error>
-                void set_error(Error&& error) && noexcept;
+                void set_error(Error&& error) && noexcept
+                {
+                    if (!op_state.set_stopped_error_called.exchange(true))
+                    {
+                        op_state.stop_source_.request_stop();
+                        try
+                        {
+                            op_state.error = HPX_FORWARD(Error, error);
+                        }
+                        catch (...)
+                        {
+                            // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
+                            op_state.error = std::current_exception();
+                        }
+                    }
 
-                template <typename Dummy = void>
-                void set_stopped() && noexcept;
+                    op_state.finish();
+                }
+
+                void set_stopped() && noexcept
+                {
+                    // request stop only if we're not in error state
+                    if (!op_state.set_stopped_error_called.exchange(true))
+                    {
+                        op_state.stop_source_.request_stop();
+                    }
+                    op_state.finish();
+                }
 
                 template <typename... Ts>
-                void set_value(Ts&&... ts) && noexcept;
+                void set_value(Ts&&... ts) && noexcept
+                {
+                    if (!op_state.set_stopped_error_called)
+                    {
+                        try
+                        {
+                            // We only have something to store if the
+                            // predecessor sends the single value that it
+                            // should send. We have nothing to store for
+                            // predecessor senders that send nothing.
+                            if constexpr (sizeof...(Ts) == 1)
+                            {
+                                op_state.ts[i].emplace(HPX_FORWARD(Ts, ts)...);
+                            }
+                        }
+                        catch (...)
+                        {
+                            if (!op_state.set_stopped_error_called.exchange(
+                                    true))
+                            {
+                                // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
+                                op_state.error = std::current_exception();
+                            }
+                        }
+                    }
+
+                    op_state.finish();
+                }
 
                 // clang-format off
-                template <typename Dummy = void>
-                auto get_env() const noexcept;
+                auto get_env() const noexcept
+                {
+                    // Due to the bug described in the get_env.cpp tests,
+                    // returning an env constructed directly with the
+                    // temporaries returned by the functions causes wrong
+                    // behaviour.
+                    auto e = hpx::execution::experimental::get_env(
+                        op_state.receiver);
+                    auto p = hpx::execution::experimental::prop(
+                        hpx::execution::experimental::get_stop_token,
+                        op_state.stop_source_.get_token());
+                    return hpx::execution::experimental::make_env(
+                        std::move(e), std::move(p));
+                }
                 // clang-format on
             };
 
@@ -293,15 +356,16 @@ namespace hpx::when_all_vector_detail {
             operation_state(Receiver_&& receiver, std::vector<Sender>&& senders)
               : num_predecessors(senders.size())
               , receiver(HPX_FORWARD(Receiver_, receiver))
-              , op_states(nullptr,
-                    op_states_deleter{alloc_type(env_allocator<env_type>::get(
-                                          hpx::execution::experimental::get_env(
-                                              this->receiver))),
-                        0})
+              , op_states(nullptr, op_states_deleter{alloc_type{}, 0})
             {
                 {
                     alloc_type alloc(env_allocator<env_type>::get(
                         hpx::execution::experimental::get_env(this->receiver)));
+
+                    // Update the deleter's allocator now that we have
+                    // a properly-initialized copy.
+                    op_states.get_deleter().alloc = alloc;
+
                     element_type* ptr =
                         alloc_traits_type::allocate(alloc, num_predecessors);
 
@@ -324,9 +388,8 @@ namespace hpx::when_all_vector_detail {
                             alloc, ptr, num_predecessors);
                         throw;
                     }
-                    operation_states_storage_type temp(
-                        ptr, op_states_deleter{alloc, num_predecessors});
-                    op_states = std::move(temp);
+                    op_states.reset(ptr);
+                    op_states.get_deleter().count = num_predecessors;
                 }
                 std::size_t i = 0;
                 for (auto&& sender : senders)
@@ -492,100 +555,6 @@ namespace hpx::when_all_vector_detail {
             return operation_state<Receiver>(receiver, senders);
         }
     };    // namespace hpx::when_all_vector_detail
-
-    template <typename Sender>
-    template <typename Receiver>
-    template <typename Error>
-    void when_all_vector_sender_impl<Sender>::when_all_vector_sender_type::
-        operation_state<Receiver>::when_all_vector_receiver::set_error(
-            Error&& error) && noexcept
-    {
-        if (!op_state.set_stopped_error_called.exchange(true))
-        {
-            op_state.stop_source_.request_stop();
-            try
-            {
-                op_state.error = HPX_FORWARD(Error, error);
-            }
-            catch (...)
-            {
-                // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
-                op_state.error = std::current_exception();
-            }
-        }
-
-        op_state.finish();
-    }
-
-    template <typename Sender>
-    template <typename Receiver>
-    template <typename Dummy>
-    void when_all_vector_sender_impl<
-        Sender>::when_all_vector_sender_type::operation_state<Receiver>::
-        when_all_vector_receiver::set_stopped() && noexcept
-    {
-        // request stop only if we're not in error state
-        if (!op_state.set_stopped_error_called.exchange(true))
-        {
-            op_state.stop_source_.request_stop();
-        }
-        op_state.finish();
-    }
-
-    template <typename Sender>
-    template <typename Receiver>
-    template <typename... Ts>
-    void when_all_vector_sender_impl<Sender>::when_all_vector_sender_type::
-        operation_state<Receiver>::when_all_vector_receiver::set_value(
-            Ts&&... ts) && noexcept
-    {
-        if (!op_state.set_stopped_error_called)
-        {
-            try
-            {
-                // We only have something to store if the
-                // predecessor sends the single value that it should
-                // send. We have nothing to store for predecessor
-                // senders that send nothing.
-                if constexpr (sizeof...(Ts) == 1)
-                {
-                    op_state.ts[i].emplace(HPX_FORWARD(Ts, ts)...);
-                }
-            }
-            catch (...)
-            {
-                if (!op_state.set_stopped_error_called.exchange(true))
-                {
-                    // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
-                    op_state.error = std::current_exception();
-                }
-            }
-        }
-
-        op_state.finish();
-    }
-
-    template <typename Sender>
-    template <typename Receiver>
-    template <typename Dummy>
-    auto when_all_vector_sender_impl<Sender>::when_all_vector_sender_type::
-        operation_state<Receiver>::when_all_vector_receiver::get_env()
-            const noexcept
-    {
-        /* The new calling convention is:
-         * make_env(old_env, prop(tag, val))*/
-
-        // Due to the bug described in the get_env.cpp tests,
-        // returning an env constructed directly with the
-        // temporaries returned by the functions causes wrong
-        // behaviour.
-        auto e = hpx::execution::experimental::get_env(op_state.receiver);
-        auto p = hpx::execution::experimental::prop(
-            hpx::execution::experimental::get_stop_token,
-            op_state.stop_source_.get_token());
-        return hpx::execution::experimental::make_env(
-            std::move(e), std::move(p));
-    }
 }    // namespace hpx::when_all_vector_detail
 
 namespace hpx::execution::experimental {

--- a/libs/core/execution/tests/unit/CMakeLists.txt
+++ b/libs/core/execution/tests/unit/CMakeLists.txt
@@ -25,6 +25,7 @@ set(tests
     algorithm_transfer_when_all
     algorithm_when_all
     algorithm_when_all_vector
+    algorithm_when_all_vector_allocator
     bulk_async
     environment_queries
     executor_parameters

--- a/libs/core/execution/tests/unit/algorithm_when_all_vector_allocator.cpp
+++ b/libs/core/execution/tests/unit/algorithm_when_all_vector_allocator.cpp
@@ -9,9 +9,6 @@
 
 #include <hpx/config.hpp>
 
-// Clang up to V22 fails compiling when_all_vector tests
-#if !defined(HPX_CLANG_VERSION) || ((HPX_CLANG_VERSION / 10000) > 22)
-
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/testing.hpp>
 
@@ -230,10 +227,3 @@ int main()
 
     return hpx::util::report_errors();
 }
-
-#else
-int main()
-{
-    return 0;
-}
-#endif

--- a/libs/core/execution/tests/unit/algorithm_when_all_vector_allocator.cpp
+++ b/libs/core/execution/tests/unit/algorithm_when_all_vector_allocator.cpp
@@ -156,7 +156,7 @@ int main()
     }
 
     // Test 2: when_all_vector with 0 senders (empty vector).
-    // No allocation should happen for op states.
+    // An allocation of size 0 happens for op states.
     {
         tracking_allocator_counts::reset();
 
@@ -167,11 +167,17 @@ int main()
             HPX_TEST_EQ(v.size(), std::size_t(0));
         };
 
-        allocator_receiver<decltype(f)> r{f, set_value_called};
-        auto os = ex::connect(std::move(s), std::move(r));
-        ex::start(os);
+        {
+            allocator_receiver<decltype(f)> r{f, set_value_called};
+            auto os = ex::connect(std::move(s), std::move(r));
+            ex::start(os);
+        }
 
         HPX_TEST(set_value_called);
+        HPX_TEST_EQ(
+            tracking_allocator_counts::allocate_count.load(), std::size_t(1));
+        HPX_TEST_EQ(
+            tracking_allocator_counts::deallocate_count.load(), std::size_t(1));
     }
 
     // Test 3: when_all_vector with void senders and custom allocator.
@@ -193,6 +199,10 @@ int main()
         HPX_TEST(set_value_called);
         HPX_TEST_LT(
             std::size_t(0), tracking_allocator_counts::allocate_count.load());
+        HPX_TEST_LT(
+            std::size_t(0), tracking_allocator_counts::deallocate_count.load());
+        HPX_TEST_EQ(tracking_allocator_counts::allocate_count.load(),
+            tracking_allocator_counts::deallocate_count.load());
     }
 
     // Test 4: Verify allocate/deallocate counts are balanced.

--- a/libs/core/execution/tests/unit/algorithm_when_all_vector_allocator.cpp
+++ b/libs/core/execution/tests/unit/algorithm_when_all_vector_allocator.cpp
@@ -1,0 +1,229 @@
+//  Copyright (c) 2026 Shivansh Singh
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// This test verifies that when_all_vector correctly uses a custom allocator
+// provided via the P2300 receiver environment (get_allocator query).
+
+#include <hpx/config.hpp>
+
+// Clang up to V22 fails compiling when_all_vector tests
+#if !defined(HPX_CLANG_VERSION) || ((HPX_CLANG_VERSION / 10000) > 22)
+
+#include <hpx/modules/execution.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <atomic>
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+namespace ex = hpx::execution::experimental;
+
+// Shared counters for all tracking_allocator rebinds
+struct tracking_allocator_counts
+{
+    static std::atomic<std::size_t> allocate_count;
+    static std::atomic<std::size_t> deallocate_count;
+
+    static void reset() noexcept
+    {
+        allocate_count.store(0, std::memory_order_relaxed);
+        deallocate_count.store(0, std::memory_order_relaxed);
+    }
+};
+
+std::atomic<std::size_t> tracking_allocator_counts::allocate_count{0};
+std::atomic<std::size_t> tracking_allocator_counts::deallocate_count{0};
+
+// A tracking allocator that satisfies stdexec's __simple_allocator concept.
+// Uses std::byte as value_type so that allocate()/deallocate() are valid.
+// All rebinds share the same static counters.
+template <typename T = std::byte>
+struct tracking_allocator
+{
+    using value_type = T;
+
+    tracking_allocator() noexcept = default;
+
+    template <typename U>
+    // cppcheck-suppress noExplicitConstructor
+    tracking_allocator(tracking_allocator<U> const&) noexcept
+    {
+    }
+
+    T* allocate(std::size_t n)
+    {
+        tracking_allocator_counts::allocate_count.fetch_add(
+            1, std::memory_order_relaxed);
+        return std::allocator<T>{}.allocate(n);
+    }
+
+    void deallocate(T* p, std::size_t n) noexcept
+    {
+        tracking_allocator_counts::deallocate_count.fetch_add(
+            1, std::memory_order_relaxed);
+        std::allocator<T>{}.deallocate(p, n);
+    }
+
+    friend bool operator==(
+        tracking_allocator const&, tracking_allocator const&) noexcept
+    {
+        return true;
+    }
+
+    friend bool operator!=(
+        tracking_allocator const&, tracking_allocator const&) noexcept
+    {
+        return false;
+    }
+};
+
+// A receiver whose environment exposes a tracking_allocator via
+// the P2300 get_allocator query.
+template <typename F>
+struct allocator_receiver
+{
+    using receiver_concept = ex::receiver_t;
+
+    std::decay_t<F> f;
+    std::atomic<bool>& set_value_called;
+
+    template <typename E>
+    void set_error(E&&) && noexcept
+    {
+        HPX_TEST(false);
+    }
+
+    void set_stopped() && noexcept
+    {
+        HPX_TEST(false);
+    }
+
+    template <typename... Ts>
+    void set_value(Ts&&... ts) && noexcept
+    {
+        HPX_INVOKE(f, std::forward<Ts>(ts)...);
+        set_value_called = true;
+    }
+
+    // Environment that provides the tracking allocator
+    struct env_type
+    {
+        auto query(ex::get_allocator_t) const noexcept
+        {
+            return tracking_allocator<>{};
+        }
+    };
+
+    env_type get_env() const noexcept
+    {
+        return {};
+    }
+};
+
+int main()
+{
+    // Test 1: when_all_vector with 3 senders using a custom allocator.
+    // Verify that the tracking allocator's allocate() is called.
+    {
+        tracking_allocator_counts::reset();
+
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::when_all_vector(
+            std::vector{ex::just(10), ex::just(20), ex::just(30)});
+
+        auto f = [](std::vector<int> v) {
+            HPX_TEST_EQ(v.size(), std::size_t(3));
+            HPX_TEST_EQ(v[0], 10);
+            HPX_TEST_EQ(v[1], 20);
+            HPX_TEST_EQ(v[2], 30);
+        };
+
+        {
+            allocator_receiver<decltype(f)> r{f, set_value_called};
+            auto os = ex::connect(std::move(s), std::move(r));
+            ex::start(os);
+        }
+
+        HPX_TEST(set_value_called);
+        HPX_TEST_LT(
+            std::size_t(0), tracking_allocator_counts::allocate_count.load());
+        HPX_TEST_LT(
+            std::size_t(0), tracking_allocator_counts::deallocate_count.load());
+    }
+
+    // Test 2: when_all_vector with 0 senders (empty vector).
+    // No allocation should happen for op states.
+    {
+        tracking_allocator_counts::reset();
+
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::when_all_vector(std::vector<decltype(ex::just(0))>{});
+
+        auto f = [](std::vector<int> v) {
+            HPX_TEST_EQ(v.size(), std::size_t(0));
+        };
+
+        allocator_receiver<decltype(f)> r{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+
+        HPX_TEST(set_value_called);
+    }
+
+    // Test 3: when_all_vector with void senders and custom allocator.
+    {
+        tracking_allocator_counts::reset();
+
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::when_all_vector(
+            std::vector{ex::just(), ex::just(), ex::just()});
+
+        auto f = []() {};
+
+        {
+            allocator_receiver<decltype(f)> r{f, set_value_called};
+            auto os = ex::connect(std::move(s), std::move(r));
+            ex::start(os);
+        }
+
+        HPX_TEST(set_value_called);
+        HPX_TEST_LT(
+            std::size_t(0), tracking_allocator_counts::allocate_count.load());
+    }
+
+    // Test 4: Verify allocate/deallocate counts are balanced.
+    {
+        tracking_allocator_counts::reset();
+
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::when_all_vector(std::vector{ex::just(1), ex::just(2)});
+
+        auto f = [](std::vector<int> v) {
+            HPX_TEST_EQ(v.size(), std::size_t(2));
+        };
+
+        {
+            allocator_receiver<decltype(f)> r{f, set_value_called};
+            auto os = ex::connect(std::move(s), std::move(r));
+            ex::start(os);
+        }
+
+        HPX_TEST(set_value_called);
+        // Every allocate must be paired with a deallocate
+        HPX_TEST_EQ(tracking_allocator_counts::allocate_count.load(),
+            tracking_allocator_counts::deallocate_count.load());
+    }
+
+    return hpx::util::report_errors();
+}
+
+#else
+int main()
+{
+    return 0;
+}
+#endif

--- a/libs/core/execution/tests/unit/algorithm_when_all_vector_allocator.cpp
+++ b/libs/core/execution/tests/unit/algorithm_when_all_vector_allocator.cpp
@@ -9,12 +9,14 @@
 
 #include <hpx/config.hpp>
 
+#include <hpx/functional/invoke.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <atomic>
 #include <cstddef>
 #include <memory>
+#include <utility>
 #include <vector>
 
 namespace ex = hpx::execution::experimental;


### PR DESCRIPTION
## Fixes


## Proposed Changes

This PR refactors `when_all_vector` to fully comply with the **P2300 allocator protocol**. Previously, the algorithm ignored the receiver's environment, resulting in hardcoded heap allocations via `std::make_unique`.

- **Allocator-Aware Allocation:** Replaced `std::make_unique` with logic that extracts the allocator from the receiver's environment via `get_allocator(get_env(receiver))`. It utilizes `std::allocator_traits` to handle allocation and construction.

- **Strong Exception Safety:** Implemented a robust unwind strategy in the `operation_state` constructor. If an exception occurs during the construction of the operation state array, the code now correctly invokes `destroy()` only on the successfully constructed elements and deallocates the raw memory buffer before re-throwing, preventing memory leaks.

- **RAII Compliance:** Introduced a custom `op_states_deleter` to manage the lifetime of the operation state array. This ensures that even in the case of task cancellation or early exit, memory is correctly cleaned up using the associated allocator.

- **Performance:** By enabling custom allocators, pipelines using `when_all_vector` can now leverage stack-based or arena allocators, eliminating heap allocation overhead on performance-critical paths.

## Background Context

The original implementation hardcoded heap allocations, which violates **P2300** semantics regarding environments and allocators. Additionally, the original code lacked an unwind strategy for constructor failures, which could lead to resource leaks if the sender composition failed mid-initialization.

This change aligns `when_all_vector` with the allocator-aware design established in other HPX P2300 primitives.

## Checklist

- [x] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.