### PR TITLE
Implement minmax_element to use less comparisons

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/algorithms/minmax.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/minmax.hpp
@@ -889,21 +889,71 @@ namespace hpx::parallel {
 
             element_type min_value = HPX_INVOKE(proj, *it);
             element_type max_value = min_value;
-            util::const_loop_n<std::decay_t<ExPolicy>>(
-                ++it, count - 1, [&](FwdIter const& curr) -> void {
-                    element_type curr_value = HPX_INVOKE(proj, *curr);
+            element_type next_value = HPX_INVOKE(proj, *++it);
+
+            if (HPX_INVOKE(f, next_value, min_value))
+            {
+                result.min = it;
+                min_value = HPX_MOVE(next_value);
+            }
+            else
+            {
+                result.max = it;
+                max_value = HPX_MOVE(next_value);
+            }
+
+            std::size_t remaining = count - 2;
+            while (remaining != 0)
+            {
+                FwdIter curr = ++it;
+                element_type curr_value = HPX_INVOKE(proj, *curr);
+                if (remaining != 1)
+                {
+                    remaining -= 2;
+                    element_type next_value = HPX_INVOKE(proj, *++it);
+                    if (HPX_INVOKE(f, curr_value, next_value))
+                    {
+                        if (HPX_INVOKE(f, curr_value, min_value))
+                        {
+                            result.min = curr;
+                            min_value = HPX_MOVE(curr_value);
+                        }
+                        if (!HPX_INVOKE(f, next_value, max_value))
+                        {
+                            result.max = it;
+                            max_value = HPX_MOVE(next_value);
+                        }
+                    }
+                    else
+                    {
+                        if (HPX_INVOKE(f, next_value, min_value))
+                        {
+                            result.min = it;
+                            min_value = HPX_MOVE(next_value);
+                        }
+                        if (!HPX_INVOKE(f, curr_value, max_value))
+                        {
+                            result.max = curr;
+                            max_value = HPX_MOVE(curr_value);
+                        }
+                    }
+                }
+                else
+                {
                     if (HPX_INVOKE(f, curr_value, min_value))
                     {
                         result.min = curr;
                         min_value = curr_value;
                     }
-
                     if (!HPX_INVOKE(f, curr_value, max_value))
                     {
                         result.max = curr;
                         max_value = HPX_MOVE(curr_value);
                     }
-                });
+
+                    break;
+                }
+            }
 
             return result;
         }
@@ -923,21 +973,71 @@ namespace hpx::parallel {
 
             element_type min_value = *it;
             element_type max_value = min_value;
-            util::const_loop_n<std::decay_t<ExPolicy>>(
-                ++it, count - 1, [&](FwdIter const& curr) -> void {
-                    element_type curr_value = *curr;
+            element_type next_value = *++it;
+
+            if (HPX_INVOKE(f, next_value, min_value))
+            {
+                result.min = it;
+                min_value = HPX_MOVE(next_value);
+            }
+            else
+            {
+                result.max = it;
+                max_value = HPX_MOVE(next_value);
+            }
+
+            std::size_t remaining = count - 2;
+            while (remaining != 0)
+            {
+                FwdIter curr = ++it;
+                element_type curr_value = *curr;
+                if (remaining != 1)
+                {
+                    remaining -= 2;
+                    element_type next_value = *++it;
+                    if (HPX_INVOKE(f, curr_value, next_value))
+                    {
+                        if (HPX_INVOKE(f, curr_value, min_value))
+                        {
+                            result.min = curr;
+                            min_value = HPX_MOVE(curr_value);
+                        }
+                        if (!HPX_INVOKE(f, next_value, max_value))
+                        {
+                            result.max = it;
+                            max_value = HPX_MOVE(next_value);
+                        }
+                    }
+                    else
+                    {
+                        if (HPX_INVOKE(f, next_value, min_value))
+                        {
+                            result.min = it;
+                            min_value = HPX_MOVE(next_value);
+                        }
+                        if (!HPX_INVOKE(f, curr_value, max_value))
+                        {
+                            result.max = curr;
+                            max_value = HPX_MOVE(curr_value);
+                        }
+                    }
+                }
+                else
+                {
                     if (HPX_INVOKE(f, curr_value, min_value))
                     {
                         result.min = curr;
                         min_value = curr_value;
                     }
-
                     if (!HPX_INVOKE(f, curr_value, max_value))
                     {
                         result.max = curr;
                         max_value = HPX_MOVE(curr_value);
                     }
-                });
+
+                    break;
+                }
+            }
 
             return result;
         }
@@ -1043,31 +1143,77 @@ namespace hpx::parallel {
 
                 // NOLINTNEXTLINE(bugprone-inc-dec-in-conditions)
                 if (first == last || ++first == last)
-                {
                     return minmax_element_result<FwdIter>{min, max};
-                }
 
                 using element_type = hpx::traits::proxy_value_t<
                     std::decay_t<std::invoke_result_t<Proj,
                         hpx::traits::iter_reference_t<FwdIter>>>>;
 
                 element_type min_value = HPX_INVOKE(proj, *min);
-                element_type max_value = HPX_INVOKE(proj, *max);
-                util::const_loop(HPX_FORWARD(ExPolicy, policy), first, last,
-                    [&](FwdIter const& curr) -> void {
-                        element_type curr_value = HPX_INVOKE(proj, *curr);
+                element_type max_value = min_value;
+                element_type next_value = HPX_INVOKE(proj, *first);
+
+                if (HPX_INVOKE(f, next_value, min_value))
+                {
+                    min = first;
+                    min_value = HPX_MOVE(next_value);
+                }
+                else
+                {
+                    max = first;
+                    max_value = HPX_MOVE(next_value);
+                }
+
+                while (++first != last)
+                {
+                    FwdIter curr = first;
+                    element_type curr_value = HPX_INVOKE(proj, *curr);
+                    if (++first != last)
+                    {
+                        element_type next_value = HPX_INVOKE(proj, *first);
+                        if (HPX_INVOKE(f, curr_value, next_value))
+                        {
+                            if (HPX_INVOKE(f, curr_value, min_value))
+                            {
+                                min = curr;
+                                min_value = HPX_MOVE(curr_value);
+                            }
+                            if (!HPX_INVOKE(f, next_value, max_value))
+                            {
+                                max = first;
+                                max_value = HPX_MOVE(next_value);
+                            }
+                        }
+                        else
+                        {
+                            if (HPX_INVOKE(f, next_value, min_value))
+                            {
+                                min = first;
+                                min_value = HPX_MOVE(next_value);
+                            }
+                            if (!HPX_INVOKE(f, curr_value, max_value))
+                            {
+                                max = curr;
+                                max_value = HPX_MOVE(curr_value);
+                            }
+                        }
+                    }
+                    else
+                    {
                         if (HPX_INVOKE(f, curr_value, min_value))
                         {
                             min = curr;
                             min_value = curr_value;
                         }
-
                         if (!HPX_INVOKE(f, curr_value, max_value))
                         {
                             max = curr;
                             max_value = HPX_MOVE(curr_value);
                         }
-                    });
+
+                        break;
+                    }
+                }
 
                 return minmax_element_result<FwdIter>{min, max};
             }
@@ -1082,30 +1228,76 @@ namespace hpx::parallel {
 
                 // NOLINTNEXTLINE(bugprone-inc-dec-in-conditions)
                 if (first == last || ++first == last)
-                {
                     return minmax_element_result<FwdIter>{min, max};
-                }
 
                 using element_type = hpx::traits::proxy_value_t<
                     hpx::traits::iter_value_t<FwdIter>>;
 
                 element_type min_value = *min;
-                element_type max_value = *max;
-                util::const_loop(HPX_FORWARD(ExPolicy, policy), first, last,
-                    [&](FwdIter const& curr) -> void {
-                        element_type curr_value = *curr;
+                element_type max_value = min_value;
+                element_type next_value = *first;
+
+                if (HPX_INVOKE(f, next_value, min_value))
+                {
+                    min = first;
+                    min_value = HPX_MOVE(next_value);
+                }
+                else
+                {
+                    max = first;
+                    max_value = HPX_MOVE(next_value);
+                }
+
+                while (++first != last)
+                {
+                    FwdIter curr = first;
+                    element_type curr_value = *curr;
+                    if (++first != last)
+                    {
+                        element_type next_value = *first;
+                        if (HPX_INVOKE(f, curr_value, next_value))
+                        {
+                            if (HPX_INVOKE(f, curr_value, min_value))
+                            {
+                                min = curr;
+                                min_value = HPX_MOVE(curr_value);
+                            }
+                            if (!HPX_INVOKE(f, next_value, max_value))
+                            {
+                                max = first;
+                                max_value = HPX_MOVE(next_value);
+                            }
+                        }
+                        else
+                        {
+                            if (HPX_INVOKE(f, next_value, min_value))
+                            {
+                                min = first;
+                                min_value = HPX_MOVE(next_value);
+                            }
+                            if (!HPX_INVOKE(f, curr_value, max_value))
+                            {
+                                max = curr;
+                                max_value = HPX_MOVE(curr_value);
+                            }
+                        }
+                    }
+                    else
+                    {
                         if (HPX_INVOKE(f, curr_value, min_value))
                         {
                             min = curr;
                             min_value = curr_value;
                         }
-
                         if (!HPX_INVOKE(f, curr_value, max_value))
                         {
                             max = curr;
                             max_value = HPX_MOVE(curr_value);
                         }
-                    });
+
+                        break;
+                    }
+                }
 
                 return minmax_element_result<FwdIter>{min, max};
             }

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/minmax.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/minmax.hpp
@@ -911,7 +911,7 @@ namespace hpx::parallel {
                 {
                     remaining -= 2;
                     element_type next_value = HPX_INVOKE(proj, *++it);
-                    if (HPX_INVOKE(f, curr_value, next_value))
+                    if (!HPX_INVOKE(f, next_value, curr_value))
                     {
                         if (HPX_INVOKE(f, curr_value, min_value))
                         {
@@ -995,7 +995,7 @@ namespace hpx::parallel {
                 {
                     remaining -= 2;
                     element_type next_value = *++it;
-                    if (HPX_INVOKE(f, curr_value, next_value))
+                    if (!HPX_INVOKE(f, next_value, curr_value))
                     {
                         if (HPX_INVOKE(f, curr_value, min_value))
                         {
@@ -1171,7 +1171,7 @@ namespace hpx::parallel {
                     if (++first != last)
                     {
                         element_type next_value = HPX_INVOKE(proj, *first);
-                        if (HPX_INVOKE(f, curr_value, next_value))
+                        if (!HPX_INVOKE(f, next_value, curr_value))
                         {
                             if (HPX_INVOKE(f, curr_value, min_value))
                             {
@@ -1255,7 +1255,7 @@ namespace hpx::parallel {
                     if (++first != last)
                     {
                         element_type next_value = *first;
-                        if (HPX_INVOKE(f, curr_value, next_value))
+                        if (!HPX_INVOKE(f, next_value, curr_value))
                         {
                             if (HPX_INVOKE(f, curr_value, min_value))
                             {

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/minmax.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/minmax.hpp
@@ -1137,7 +1137,7 @@ namespace hpx::parallel {
             template <typename ExPolicy, typename FwdIter, typename Sent,
                 typename F, typename Proj>
             static constexpr minmax_element_result<FwdIter> sequential(
-                ExPolicy&& policy, FwdIter first, Sent last, F&& f, Proj&& proj)
+                ExPolicy&&, FwdIter first, Sent last, F&& f, Proj&& proj)
             {
                 auto min = first, max = first;
 
@@ -1221,8 +1221,7 @@ namespace hpx::parallel {
             template <typename ExPolicy, typename FwdIter, typename Sent,
                 typename F>
             static constexpr minmax_element_result<FwdIter> sequential(
-                ExPolicy&& policy, FwdIter first, Sent last, F&& f,
-                hpx::identity)
+                ExPolicy&&, FwdIter first, Sent last, F&& f, hpx::identity)
             {
                 auto min = first, max = first;
 

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/minmax.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/minmax.hpp
@@ -873,6 +873,7 @@ namespace hpx::parallel {
     namespace detail {
 
         /// \cond NOINTERNAL
+        // used for both scalar and vectorized execution policies
         HPX_CXX_CORE_EXPORT template <typename ExPolicy, typename FwdIter,
             typename F, typename Proj>
         minmax_element_result<FwdIter> sequential_minmax_element(ExPolicy&&,
@@ -889,17 +890,17 @@ namespace hpx::parallel {
 
             element_type min_value = HPX_INVOKE(proj, *it);
             element_type max_value = min_value;
-            element_type next_value = HPX_INVOKE(proj, *++it);
+            element_type second_value = HPX_INVOKE(proj, *++it);
 
-            if (HPX_INVOKE(f, next_value, min_value))
+            if (HPX_INVOKE(f, second_value, min_value))
             {
                 result.min = it;
-                min_value = HPX_MOVE(next_value);
+                min_value = HPX_MOVE(second_value);
             }
             else
             {
                 result.max = it;
-                max_value = HPX_MOVE(next_value);
+                max_value = HPX_MOVE(second_value);
             }
 
             std::size_t remaining = count - 2;
@@ -958,6 +959,7 @@ namespace hpx::parallel {
             return result;
         }
 
+        // used for both scalar and vectorized execution policies
         HPX_CXX_CORE_EXPORT template <typename ExPolicy, typename FwdIter,
             typename F>
         minmax_element_result<FwdIter> sequential_minmax_element(ExPolicy&&,
@@ -973,17 +975,17 @@ namespace hpx::parallel {
 
             element_type min_value = *it;
             element_type max_value = min_value;
-            element_type next_value = *++it;
+            element_type second_value = *++it;
 
-            if (HPX_INVOKE(f, next_value, min_value))
+            if (HPX_INVOKE(f, second_value, min_value))
             {
                 result.min = it;
-                min_value = HPX_MOVE(next_value);
+                min_value = HPX_MOVE(second_value);
             }
             else
             {
                 result.max = it;
-                max_value = HPX_MOVE(next_value);
+                max_value = HPX_MOVE(second_value);
             }
 
             std::size_t remaining = count - 2;
@@ -1134,6 +1136,7 @@ namespace hpx::parallel {
             {
             }
 
+            // used for both scalar and vectorized execution policies
             template <typename ExPolicy, typename FwdIter, typename Sent,
                 typename F, typename Proj>
             static constexpr minmax_element_result<FwdIter> sequential(
@@ -1151,17 +1154,17 @@ namespace hpx::parallel {
 
                 element_type min_value = HPX_INVOKE(proj, *min);
                 element_type max_value = min_value;
-                element_type next_value = HPX_INVOKE(proj, *first);
+                element_type second_value = HPX_INVOKE(proj, *first);
 
-                if (HPX_INVOKE(f, next_value, min_value))
+                if (HPX_INVOKE(f, second_value, min_value))
                 {
                     min = first;
-                    min_value = HPX_MOVE(next_value);
+                    min_value = HPX_MOVE(second_value);
                 }
                 else
                 {
                     max = first;
-                    max_value = HPX_MOVE(next_value);
+                    max_value = HPX_MOVE(second_value);
                 }
 
                 while (++first != last)
@@ -1218,6 +1221,7 @@ namespace hpx::parallel {
                 return minmax_element_result<FwdIter>{min, max};
             }
 
+            // used for both scalar and vectorized execution policies
             template <typename ExPolicy, typename FwdIter, typename Sent,
                 typename F>
             static constexpr minmax_element_result<FwdIter> sequential(
@@ -1234,17 +1238,17 @@ namespace hpx::parallel {
 
                 element_type min_value = *min;
                 element_type max_value = min_value;
-                element_type next_value = *first;
+                element_type second_value = *first;
 
-                if (HPX_INVOKE(f, next_value, min_value))
+                if (HPX_INVOKE(f, second_value, min_value))
                 {
                     min = first;
-                    min_value = HPX_MOVE(next_value);
+                    min_value = HPX_MOVE(second_value);
                 }
                 else
                 {
                     max = first;
-                    max_value = HPX_MOVE(next_value);
+                    max_value = HPX_MOVE(second_value);
                 }
 
                 while (++first != last)

--- a/libs/core/algorithms/tests/unit/algorithms/minmax_element.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/minmax_element.cpp
@@ -49,6 +49,50 @@ void test_minmax_element(IteratorTag)
 
     HPX_TEST_EQ(*ref.first, *r.min);
     HPX_TEST_EQ(*ref.second, *r.max);
+
+    struct set
+    {
+        std::size_t identifier;
+        std::size_t value;
+    };
+
+    typedef typename std::vector<set>::iterator base_set_iterator;
+    typedef test::test_iterator<base_set_iterator, IteratorTag> set_iterator;
+
+    std::vector<set> d = { {0, 100}, {1, 100}, {2, 99}, {3, 99}, {4, 100} };
+
+    set_iterator end2(std::end(d));
+    base_set_iterator ref_end2(std::end(d));
+
+    auto r2 = hpx::minmax_element(
+        set_iterator(std::begin(d)), set_iterator(end2),
+        [](set first, set second) {return first.value < second.value;});
+    HPX_TEST(r2.min != end2 && r2.max != end2);
+
+    auto ref2 = std::minmax_element(std::begin(d), std::end(d),
+        [](set first, set second) {return first.value < second.value;});
+    HPX_TEST(ref2.first != ref_end2 && ref2.second != ref_end2);
+
+    HPX_TEST_EQ(ref2.first->identifier, r2.min->identifier);
+    HPX_TEST_EQ(ref2.second->identifier, r2.max->identifier);
+
+    d = { {0, 99}, {1, 99}, {2, 100}, {3, 100}, {4, 99} };
+
+    end2 = set_iterator(std::end(d));
+    ref_end2 = base_set_iterator(std::end(d));
+
+    r2 = hpx::minmax_element(
+        set_iterator(std::begin(d)), set_iterator(std::end(d)),
+        [](set first, set second) {return first.value < second.value;});
+    HPX_TEST(r2.min != end2 && r2.max != end2);
+
+    ref2 = std::minmax_element(std::begin(d), std::end(d),
+        [](set first, set second) {return first.value < second.value;});
+    HPX_TEST(ref2.first != ref_end2 && ref2.second != ref_end2);
+
+    HPX_TEST_EQ(ref2.first->identifier, r2.min->identifier);
+    HPX_TEST_EQ(ref2.second->identifier, r2.max->identifier);
+
 }
 
 template <typename ExPolicy, typename IteratorTag>
@@ -85,6 +129,49 @@ void test_minmax_element(ExPolicy policy, IteratorTag)
 
     HPX_TEST_EQ(*ref.first, *r.min);
     HPX_TEST_EQ(*ref.second, *r.max);
+
+    struct set
+    {
+        std::size_t identifier;
+        std::size_t value;
+    };
+
+    typedef typename std::vector<set>::iterator base_set_iterator;
+    typedef test::test_iterator<base_set_iterator, IteratorTag> set_iterator;
+
+    std::vector<set> d = { {0, 100}, {1, 100}, {2, 99}, {3, 99}, {4, 100} };
+
+    set_iterator end2(std::end(d));
+    base_set_iterator ref_end2(std::end(d));
+
+    auto r2 = hpx::minmax_element(
+        policy, set_iterator(std::begin(d)), set_iterator(end2),
+        [](set first, set second) {return first.value < second.value;});
+    HPX_TEST(r2.min != end2 && r2.max != end2);
+
+    auto ref2 = std::minmax_element(std::begin(d), std::end(d),
+        [](set first, set second) {return first.value < second.value;});
+    HPX_TEST(ref2.first != ref_end2 && ref2.second != ref_end2);
+
+    HPX_TEST_EQ(ref2.first->identifier, r2.min->identifier);
+    HPX_TEST_EQ(ref2.second->identifier, r2.max->identifier);
+
+    d = { {0, 99}, {1, 99}, {2, 100}, {3, 100}, {4, 99} };
+
+    end2 = set_iterator(std::end(d));
+    ref_end2 = base_set_iterator(std::end(d));
+
+    r2 = hpx::minmax_element(
+        policy, set_iterator(std::begin(d)), set_iterator(std::end(d)),
+        [](set first, set second) {return first.value < second.value;});
+    HPX_TEST(r2.min != end2 && r2.max != end2);
+
+    ref2 = std::minmax_element(std::begin(d), std::end(d),
+        [](set first, set second) {return first.value < second.value;});
+    HPX_TEST(ref2.first != ref_end2 && ref2.second != ref_end2);
+
+    HPX_TEST_EQ(ref2.first->identifier, r2.min->identifier);
+    HPX_TEST_EQ(ref2.second->identifier, r2.max->identifier);
 }
 
 template <typename ExPolicy, typename IteratorTag>

--- a/libs/core/algorithms/tests/unit/algorithms/minmax_element.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/minmax_element.cpp
@@ -64,13 +64,16 @@ void test_minmax_element(IteratorTag)
     set_iterator end2(std::end(d));
     base_set_iterator ref_end2(std::end(d));
 
-    auto r2 =
-        hpx::minmax_element(set_iterator(std::begin(d)), set_iterator(end2),
-            [](set first, set second) { return first.value < second.value; });
+    auto r2 = hpx::minmax_element(set_iterator(std::begin(d)),
+        set_iterator(end2), [](set const& first, set const& second) {
+            return first.value < second.value;
+        });
     HPX_TEST(r2.min != end2 && r2.max != end2);
 
-    auto ref2 = std::minmax_element(std::begin(d), std::end(d),
-        [](set first, set second) { return first.value < second.value; });
+    auto ref2 = std::minmax_element(
+        std::begin(d), std::end(d), [](set const& first, set const& second) {
+            return first.value < second.value;
+        });
     HPX_TEST(ref2.first != ref_end2 && ref2.second != ref_end2);
 
     HPX_TEST_EQ(ref2.first->identifier, r2.min->identifier);
@@ -82,12 +85,75 @@ void test_minmax_element(IteratorTag)
     ref_end2 = base_set_iterator(std::end(d));
 
     r2 = hpx::minmax_element(set_iterator(std::begin(d)),
-        set_iterator(std::end(d)),
-        [](set first, set second) { return first.value < second.value; });
+        set_iterator(std::end(d)), [](set const& first, set const& second) {
+            return first.value < second.value;
+        });
     HPX_TEST(r2.min != end2 && r2.max != end2);
 
-    ref2 = std::minmax_element(std::begin(d), std::end(d),
-        [](set first, set second) { return first.value < second.value; });
+    ref2 = std::minmax_element(
+        std::begin(d), std::end(d), [](set const& first, set const& second) {
+            return first.value < second.value;
+        });
+    HPX_TEST(ref2.first != ref_end2 && ref2.second != ref_end2);
+
+    HPX_TEST_EQ(ref2.first->identifier, r2.min->identifier);
+    HPX_TEST_EQ(ref2.second->identifier, r2.max->identifier);
+
+    d = {{0, 100}, {1, 99}, {2, 100}, {3, 100}};
+
+    end2 = set_iterator(std::end(d));
+    ref_end2 = base_set_iterator(std::end(d));
+
+    r2 = hpx::minmax_element(set_iterator(std::begin(d)),
+        set_iterator(std::end(d)), [](set const& first, set const& second) {
+            return first.value < second.value;
+        });
+    HPX_TEST(r2.min != end2 && r2.max != end2);
+
+    ref2 = std::minmax_element(
+        std::begin(d), std::end(d), [](set const& first, set const& second) {
+            return first.value < second.value;
+        });
+    HPX_TEST(ref2.first != ref_end2 && ref2.second != ref_end2);
+
+    HPX_TEST_EQ(ref2.first->identifier, r2.min->identifier);
+    HPX_TEST_EQ(ref2.second->identifier, r2.max->identifier);
+
+    d = {{0, 100}, {1, 100}, {2, 100}};
+
+    end2 = set_iterator(std::end(d));
+    ref_end2 = base_set_iterator(std::end(d));
+
+    r2 = hpx::minmax_element(set_iterator(std::begin(d)),
+        set_iterator(std::end(d)), [](set const& first, set const& second) {
+            return first.value < second.value;
+        });
+    HPX_TEST(r2.min != end2 && r2.max != end2);
+
+    ref2 = std::minmax_element(
+        std::begin(d), std::end(d), [](set const& first, set const& second) {
+            return first.value < second.value;
+        });
+    HPX_TEST(ref2.first != ref_end2 && ref2.second != ref_end2);
+
+    HPX_TEST_EQ(ref2.first->identifier, r2.min->identifier);
+    HPX_TEST_EQ(ref2.second->identifier, r2.max->identifier);
+
+    d = {{0, 100}, {1, 100}};
+
+    end2 = set_iterator(std::end(d));
+    ref_end2 = base_set_iterator(std::end(d));
+
+    r2 = hpx::minmax_element(set_iterator(std::begin(d)),
+        set_iterator(std::end(d)), [](set const& first, set const& second) {
+            return first.value < second.value;
+        });
+    HPX_TEST(r2.min != end2 && r2.max != end2);
+
+    ref2 = std::minmax_element(
+        std::begin(d), std::end(d), [](set const& first, set const& second) {
+            return first.value < second.value;
+        });
     HPX_TEST(ref2.first != ref_end2 && ref2.second != ref_end2);
 
     HPX_TEST_EQ(ref2.first->identifier, r2.min->identifier);
@@ -144,12 +210,15 @@ void test_minmax_element(ExPolicy policy, IteratorTag)
     base_set_iterator ref_end2(std::end(d));
 
     auto r2 = hpx::minmax_element(policy, set_iterator(std::begin(d)),
-        set_iterator(end2),
-        [](set first, set second) { return first.value < second.value; });
+        set_iterator(end2), [](set const& first, set const& second) {
+            return first.value < second.value;
+        });
     HPX_TEST(r2.min != end2 && r2.max != end2);
 
-    auto ref2 = std::minmax_element(std::begin(d), std::end(d),
-        [](set first, set second) { return first.value < second.value; });
+    auto ref2 = std::minmax_element(
+        std::begin(d), std::end(d), [](set const& first, set const& second) {
+            return first.value < second.value;
+        });
     HPX_TEST(ref2.first != ref_end2 && ref2.second != ref_end2);
 
     HPX_TEST_EQ(ref2.first->identifier, r2.min->identifier);
@@ -161,12 +230,75 @@ void test_minmax_element(ExPolicy policy, IteratorTag)
     ref_end2 = base_set_iterator(std::end(d));
 
     r2 = hpx::minmax_element(policy, set_iterator(std::begin(d)),
-        set_iterator(std::end(d)),
-        [](set first, set second) { return first.value < second.value; });
+        set_iterator(std::end(d)), [](set const& first, set const& second) {
+            return first.value < second.value;
+        });
     HPX_TEST(r2.min != end2 && r2.max != end2);
 
-    ref2 = std::minmax_element(std::begin(d), std::end(d),
-        [](set first, set second) { return first.value < second.value; });
+    ref2 = std::minmax_element(
+        std::begin(d), std::end(d), [](set const& first, set const& second) {
+            return first.value < second.value;
+        });
+    HPX_TEST(ref2.first != ref_end2 && ref2.second != ref_end2);
+
+    HPX_TEST_EQ(ref2.first->identifier, r2.min->identifier);
+    HPX_TEST_EQ(ref2.second->identifier, r2.max->identifier);
+
+    d = {{0, 100}, {1, 99}, {2, 100}, {3, 100}};
+
+    end2 = set_iterator(std::end(d));
+    ref_end2 = base_set_iterator(std::end(d));
+
+    r2 = hpx::minmax_element(policy, set_iterator(std::begin(d)),
+        set_iterator(std::end(d)), [](set const& first, set const& second) {
+            return first.value < second.value;
+        });
+    HPX_TEST(r2.min != end2 && r2.max != end2);
+
+    ref2 = std::minmax_element(
+        std::begin(d), std::end(d), [](set const& first, set const& second) {
+            return first.value < second.value;
+        });
+    HPX_TEST(ref2.first != ref_end2 && ref2.second != ref_end2);
+
+    HPX_TEST_EQ(ref2.first->identifier, r2.min->identifier);
+    HPX_TEST_EQ(ref2.second->identifier, r2.max->identifier);
+
+    d = {{0, 100}, {1, 100}, {2, 100}};
+
+    end2 = set_iterator(std::end(d));
+    ref_end2 = base_set_iterator(std::end(d));
+
+    r2 = hpx::minmax_element(policy, set_iterator(std::begin(d)),
+        set_iterator(std::end(d)), [](set const& first, set const& second) {
+            return first.value < second.value;
+        });
+    HPX_TEST(r2.min != end2 && r2.max != end2);
+
+    ref2 = std::minmax_element(
+        std::begin(d), std::end(d), [](set const& first, set const& second) {
+            return first.value < second.value;
+        });
+    HPX_TEST(ref2.first != ref_end2 && ref2.second != ref_end2);
+
+    HPX_TEST_EQ(ref2.first->identifier, r2.min->identifier);
+    HPX_TEST_EQ(ref2.second->identifier, r2.max->identifier);
+
+    d = {{0, 100}, {1, 100}};
+
+    end2 = set_iterator(std::end(d));
+    ref_end2 = base_set_iterator(std::end(d));
+
+    r2 = hpx::minmax_element(policy, set_iterator(std::begin(d)),
+        set_iterator(std::end(d)), [](set const& first, set const& second) {
+            return first.value < second.value;
+        });
+    HPX_TEST(r2.min != end2 && r2.max != end2);
+
+    ref2 = std::minmax_element(
+        std::begin(d), std::end(d), [](set const& first, set const& second) {
+            return first.value < second.value;
+        });
     HPX_TEST(ref2.first != ref_end2 && ref2.second != ref_end2);
 
     HPX_TEST_EQ(ref2.first->identifier, r2.min->identifier);

--- a/libs/core/algorithms/tests/unit/algorithms/minmax_element.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/minmax_element.cpp
@@ -59,40 +59,39 @@ void test_minmax_element(IteratorTag)
     typedef typename std::vector<set>::iterator base_set_iterator;
     typedef test::test_iterator<base_set_iterator, IteratorTag> set_iterator;
 
-    std::vector<set> d = { {0, 100}, {1, 100}, {2, 99}, {3, 99}, {4, 100} };
+    std::vector<set> d = {{0, 100}, {1, 100}, {2, 99}, {3, 99}, {4, 100}};
 
     set_iterator end2(std::end(d));
     base_set_iterator ref_end2(std::end(d));
 
-    auto r2 = hpx::minmax_element(
-        set_iterator(std::begin(d)), set_iterator(end2),
-        [](set first, set second) {return first.value < second.value;});
+    auto r2 =
+        hpx::minmax_element(set_iterator(std::begin(d)), set_iterator(end2),
+            [](set first, set second) { return first.value < second.value; });
     HPX_TEST(r2.min != end2 && r2.max != end2);
 
     auto ref2 = std::minmax_element(std::begin(d), std::end(d),
-        [](set first, set second) {return first.value < second.value;});
+        [](set first, set second) { return first.value < second.value; });
     HPX_TEST(ref2.first != ref_end2 && ref2.second != ref_end2);
 
     HPX_TEST_EQ(ref2.first->identifier, r2.min->identifier);
     HPX_TEST_EQ(ref2.second->identifier, r2.max->identifier);
 
-    d = { {0, 99}, {1, 99}, {2, 100}, {3, 100}, {4, 99} };
+    d = {{0, 99}, {1, 99}, {2, 100}, {3, 100}, {4, 99}};
 
     end2 = set_iterator(std::end(d));
     ref_end2 = base_set_iterator(std::end(d));
 
-    r2 = hpx::minmax_element(
-        set_iterator(std::begin(d)), set_iterator(std::end(d)),
-        [](set first, set second) {return first.value < second.value;});
+    r2 = hpx::minmax_element(set_iterator(std::begin(d)),
+        set_iterator(std::end(d)),
+        [](set first, set second) { return first.value < second.value; });
     HPX_TEST(r2.min != end2 && r2.max != end2);
 
     ref2 = std::minmax_element(std::begin(d), std::end(d),
-        [](set first, set second) {return first.value < second.value;});
+        [](set first, set second) { return first.value < second.value; });
     HPX_TEST(ref2.first != ref_end2 && ref2.second != ref_end2);
 
     HPX_TEST_EQ(ref2.first->identifier, r2.min->identifier);
     HPX_TEST_EQ(ref2.second->identifier, r2.max->identifier);
-
 }
 
 template <typename ExPolicy, typename IteratorTag>
@@ -139,35 +138,35 @@ void test_minmax_element(ExPolicy policy, IteratorTag)
     typedef typename std::vector<set>::iterator base_set_iterator;
     typedef test::test_iterator<base_set_iterator, IteratorTag> set_iterator;
 
-    std::vector<set> d = { {0, 100}, {1, 100}, {2, 99}, {3, 99}, {4, 100} };
+    std::vector<set> d = {{0, 100}, {1, 100}, {2, 99}, {3, 99}, {4, 100}};
 
     set_iterator end2(std::end(d));
     base_set_iterator ref_end2(std::end(d));
 
-    auto r2 = hpx::minmax_element(
-        policy, set_iterator(std::begin(d)), set_iterator(end2),
-        [](set first, set second) {return first.value < second.value;});
+    auto r2 = hpx::minmax_element(policy, set_iterator(std::begin(d)),
+        set_iterator(end2),
+        [](set first, set second) { return first.value < second.value; });
     HPX_TEST(r2.min != end2 && r2.max != end2);
 
     auto ref2 = std::minmax_element(std::begin(d), std::end(d),
-        [](set first, set second) {return first.value < second.value;});
+        [](set first, set second) { return first.value < second.value; });
     HPX_TEST(ref2.first != ref_end2 && ref2.second != ref_end2);
 
     HPX_TEST_EQ(ref2.first->identifier, r2.min->identifier);
     HPX_TEST_EQ(ref2.second->identifier, r2.max->identifier);
 
-    d = { {0, 99}, {1, 99}, {2, 100}, {3, 100}, {4, 99} };
+    d = {{0, 99}, {1, 99}, {2, 100}, {3, 100}, {4, 99}};
 
     end2 = set_iterator(std::end(d));
     ref_end2 = base_set_iterator(std::end(d));
 
-    r2 = hpx::minmax_element(
-        policy, set_iterator(std::begin(d)), set_iterator(std::end(d)),
-        [](set first, set second) {return first.value < second.value;});
+    r2 = hpx::minmax_element(policy, set_iterator(std::begin(d)),
+        set_iterator(std::end(d)),
+        [](set first, set second) { return first.value < second.value; });
     HPX_TEST(r2.min != end2 && r2.max != end2);
 
     ref2 = std::minmax_element(std::begin(d), std::end(d),
-        [](set first, set second) {return first.value < second.value;});
+        [](set first, set second) { return first.value < second.value; });
     HPX_TEST(ref2.first != ref_end2 && ref2.second != ref_end2);
 
     HPX_TEST_EQ(ref2.first->identifier, r2.min->identifier);


### PR DESCRIPTION
## Proposed Changes

  - Improved `hpx::minmax_element` by now using floor(3/2*(N-1)) comparisons instead of 2*(N-1) comparisons.
  - `hpx::minmax_element` no longer has contradictory information in HPX documentation versus its actual implementation.

## Any background context you want to provide?

The algorithm `std::minmax_element` returns the first reference to the smallest element and the last reference to the largest element of a container using floor(3/2*(N-1)) comparisons. HPX documentation states that `hpx::minmax_element` has the same complexity; however, the current implementation actually uses 2*(N-1) comparisons by explicitly comparing the known minimum and maximum values against each individual element in the container.

This pull request reimplements `hpx::minmax_element` so that all execution policies now use floor(3/2*(N-1)) comparisons. By now iterating over two elements at once, comparing those elements to find which is smaller and which is larger, and then comparing those respective elements to the known minimum and known maximum, there are now three comparisons for every two elements rather than four comparisons for every two elements.

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [x] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it  uses a seed, and that random numbers generated are valid inputs for the tests.