### PR TITLE
Feat/distributed adaptors

### DIFF
--- a/libs/full/execution_distributed/CMakeLists.txt
+++ b/libs/full/execution_distributed/CMakeLists.txt
@@ -13,6 +13,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set(execution_distributed_headers
     hpx/execution_distributed/detail/distributed_receiver_component.hpp
     hpx/execution_distributed/detail/transfer_action.hpp
+    hpx/execution_distributed/distributed_bulk_sender.hpp
     hpx/execution_distributed/distributed_continues_on_sender.hpp
     hpx/execution_distributed/distributed_scheduler.hpp
     hpx/execution_distributed/distributed_then_sender.hpp

--- a/libs/full/execution_distributed/CMakeLists.txt
+++ b/libs/full/execution_distributed/CMakeLists.txt
@@ -29,6 +29,7 @@ add_hpx_module(
   SOURCES ${execution_distributed_sources}
   HEADERS ${execution_distributed_headers}
   DEPENDENCIES hpx_core
-  MODULE_DEPENDENCIES hpx_actions_base hpx_async_distributed hpx_components_base hpx_naming_base
+  MODULE_DEPENDENCIES hpx_actions_base hpx_async_distributed hpx_components_base
+                      hpx_naming_base
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/full/execution_distributed/CMakeLists.txt
+++ b/libs/full/execution_distributed/CMakeLists.txt
@@ -29,7 +29,6 @@ add_hpx_module(
   SOURCES ${execution_distributed_sources}
   HEADERS ${execution_distributed_headers}
   DEPENDENCIES hpx_core
-  MODULE_DEPENDENCIES hpx_actions_base hpx_async_distributed hpx_components_base
-                      hpx_naming_base
+  MODULE_DEPENDENCIES hpx_actions_base hpx_async_distributed hpx_components_base hpx_naming_base
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/full/execution_distributed/CMakeLists.txt
+++ b/libs/full/execution_distributed/CMakeLists.txt
@@ -29,6 +29,6 @@ add_hpx_module(
   SOURCES ${execution_distributed_sources}
   HEADERS ${execution_distributed_headers}
   DEPENDENCIES hpx_core
-  MODULE_DEPENDENCIES hpx_actions_base hpx_components_base hpx_naming_base
+  MODULE_DEPENDENCIES hpx_actions_base hpx_async_distributed hpx_components_base hpx_naming_base
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/full/execution_distributed/include/hpx/execution_distributed/distributed_bulk_sender.hpp
+++ b/libs/full/execution_distributed/include/hpx/execution_distributed/distributed_bulk_sender.hpp
@@ -1,0 +1,235 @@
+//  Copyright (c) 2026 Shivansh Singh
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file distributed_bulk_sender.hpp
+/// \brief P2300-compliant distributed bulk sender adaptor.
+///
+/// Provides a bulk sender that executes data-parallel work on a remote
+/// HPX locality via the distributed_scheduler. The sender intercepts
+/// ex::bulk() when the upstream sender's completion scheduler is a
+/// distributed_scheduler, and dispatches a shape-indexed invocation
+/// across the parcelport.
+///
+/// Architecture:
+///   upstream_sender
+///       |
+///       v
+///   ex::bulk(shape, f)
+///       |  (completion scheduler == distributed_scheduler)
+///       v
+///   distributed_bulk_sender<Sender, Shape, F>
+///       |
+///       v  (connect + start)
+///   local_receiver wraps downstream_receiver
+///       |  set_value(Ts...)
+///       |  => for each index in shape: invoke f(index, ts...)
+///       |  => forward set_value(ts...) to downstream
+///       v
+///   downstream_receiver
+///
+/// Current Status:
+///   Local fallback loop over the shape. Remote parcelport dispatch
+///   will be added once the component-based receiver marshalling
+///   infrastructure (nvexec-style) is complete.
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_NETWORKING)
+
+#include <hpx/execution_distributed/distributed_scheduler.hpp>
+#include <hpx/modules/errors.hpp>
+#include <hpx/modules/execution.hpp>
+#include <hpx/modules/execution_base.hpp>
+#include <hpx/modules/functional.hpp>
+
+#include <exception>
+#include <type_traits>
+#include <utility>
+
+namespace hpx::distributed::experimental::detail {
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Distributed bulk sender: wraps an upstream sender with shape + function
+    // for data-parallel execution on a remote locality.
+    template <typename Sender, typename Shape, typename F>
+    struct distributed_bulk_sender
+    {
+        using sender_concept = hpx::execution::experimental::sender_t;
+
+        HPX_NO_UNIQUE_ADDRESS std::decay_t<Sender> sender_;
+        HPX_NO_UNIQUE_ADDRESS std::decay_t<Shape> shape_;
+        HPX_NO_UNIQUE_ADDRESS std::decay_t<F> f_;
+        distributed_scheduler scheduler_;
+
+        // Completion signatures: same value types as upstream, plus
+        // exception_ptr for errors thrown by f.
+        template <typename... Args>
+        using default_set_value =
+            hpx::execution::experimental::completion_signatures<
+                hpx::execution::experimental::set_value_t(Args...)>;
+
+        template <typename Arg>
+        using default_set_error =
+            hpx::execution::experimental::completion_signatures<
+                hpx::execution::experimental::set_error_t(Arg)>;
+
+        struct default_set_value_fn
+        {
+            template <class... Args>
+            consteval auto operator()() const noexcept
+            {
+                return hpx::execution::experimental::completion_signatures<
+                    hpx::execution::experimental::set_value_t(Args...)>{};
+            }
+        };
+
+        struct default_set_error_fn
+        {
+            template <class Err>
+            consteval auto operator()() const noexcept
+            {
+                return hpx::execution::experimental::completion_signatures<
+                    hpx::execution::experimental::set_error_t(
+                        std::decay_t<Err>)>{};
+            }
+        };
+
+        template <typename Self, typename Env>
+        static consteval auto get_completion_signatures() noexcept
+            -> decltype(hpx::execution::experimental::
+                    transform_completion_signatures(
+                        hpx::execution::experimental::
+                            completion_signatures_of_t<Sender, Env>{},
+                        default_set_value_fn{}, default_set_error_fn{},
+                        hpx::execution::experimental::keep_completion<
+                            hpx::execution::experimental::set_stopped_t>{},
+                        hpx::execution::experimental::completion_signatures<
+                            hpx::execution::experimental::set_error_t(
+                                std::exception_ptr)>{}))
+        {
+            return {};
+        }
+
+        // Environment: advertise the distributed_scheduler as the
+        // completion scheduler for set_value_t.
+        struct env
+        {
+            distributed_scheduler scheduler;
+
+            auto query(
+                hpx::execution::experimental::get_domain_t) const noexcept
+            {
+                return distributed_domain{};
+            }
+
+            template <typename CPO>
+                requires meta::value<
+                    meta::one_of<CPO, hpx::execution::experimental::set_value_t,
+                        hpx::execution::experimental::set_stopped_t>>
+            auto query(
+                hpx::execution::experimental::get_completion_scheduler_t<CPO>)
+                const noexcept
+            {
+                return scheduler;
+            }
+        };
+
+        constexpr auto get_env() const noexcept
+        {
+            return env{scheduler_};
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        // Receiver that wraps the downstream receiver, intercepts
+        // set_value to execute the bulk function, then forwards.
+        template <typename Receiver>
+        struct bulk_receiver
+        {
+            using receiver_concept = hpx::execution::experimental::receiver_t;
+
+            HPX_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver_;
+            HPX_NO_UNIQUE_ADDRESS std::decay_t<Shape> shape_;
+            HPX_NO_UNIQUE_ADDRESS std::decay_t<F> f_;
+
+            template <typename Receiver_, typename Shape_, typename F_>
+            bulk_receiver(Receiver_&& receiver, Shape_&& shape, F_&& f)
+              : receiver_(HPX_FORWARD(Receiver_, receiver))
+              , shape_(HPX_FORWARD(Shape_, shape))
+              , f_(HPX_FORWARD(F_, f))
+            {
+            }
+
+            template <typename Error>
+            void set_error(Error&& error) && noexcept
+            {
+                hpx::execution::experimental::set_error(
+                    HPX_MOVE(receiver_), HPX_FORWARD(Error, error));
+            }
+
+            void set_stopped() && noexcept
+            {
+                hpx::execution::experimental::set_stopped(HPX_MOVE(receiver_));
+            }
+
+            template <typename... Ts>
+            void set_value(Ts&&... ts) && noexcept
+            {
+                hpx::detail::try_catch_exception_ptr(
+                    [&]() {
+                        // TODO: Implement remote parcelport dispatch.
+                        //
+                        // In the final implementation, the shape, function,
+                        // and values will be serialized and dispatched to
+                        // the target locality via a component action. The
+                        // remote locality will execute the bulk loop and
+                        // signal completion back through the
+                        // distributed_receiver_component.
+                        //
+                        // For now, execute the bulk loop locally as a
+                        // functional fallback / stub.
+                        for (auto const& s : shape_)
+                        {
+                            HPX_INVOKE(f_, s, ts...);
+                        }
+                        hpx::execution::experimental::set_value(
+                            HPX_MOVE(receiver_), HPX_FORWARD(Ts, ts)...);
+                    },
+                    [&](std::exception_ptr ep) {
+                        hpx::execution::experimental::set_error(
+                            HPX_MOVE(receiver_), HPX_MOVE(ep));
+                    });
+            }
+
+            auto get_env() const noexcept
+            {
+                return hpx::execution::experimental::get_env(receiver_);
+            }
+        };
+
+        ///////////////////////////////////////////////////////////////////////
+        // connect: wire the bulk_receiver into the upstream sender.
+        template <typename Receiver>
+        auto connect(Receiver&& receiver) &&
+        {
+            return hpx::execution::experimental::connect(HPX_MOVE(sender_),
+                bulk_receiver<Receiver>(HPX_FORWARD(Receiver, receiver),
+                    HPX_MOVE(shape_), HPX_MOVE(f_)));
+        }
+
+        template <typename Receiver>
+        auto connect(Receiver&& receiver) &
+        {
+            return hpx::execution::experimental::connect(sender_,
+                bulk_receiver<Receiver>(
+                    HPX_FORWARD(Receiver, receiver), shape_, f_));
+        }
+    };
+
+}    // namespace hpx::distributed::experimental::detail
+
+#endif    // HPX_HAVE_NETWORKING

--- a/libs/full/execution_distributed/include/hpx/execution_distributed/distributed_bulk_sender.hpp
+++ b/libs/full/execution_distributed/include/hpx/execution_distributed/distributed_bulk_sender.hpp
@@ -7,6 +7,11 @@
 /// \file distributed_bulk_sender.hpp
 /// \brief P2300-compliant distributed bulk sender adaptor.
 ///
+/// \note **Current status: local-only stub.** The bulk loop executes
+///       sequentially on the calling locality. Remote parcelport dispatch
+///       will be added once the component-based receiver marshalling
+///       infrastructure (nvexec-style) is complete.
+///
 /// Provides a bulk sender that executes data-parallel work on a remote
 /// HPX locality via the distributed_scheduler. The sender intercepts
 /// ex::bulk() when the upstream sender's completion scheduler is a
@@ -29,11 +34,6 @@
 ///       |  => forward set_value(ts...) to downstream
 ///       v
 ///   downstream_receiver
-///
-/// Current Status:
-///   Local fallback loop over the shape. Remote parcelport dispatch
-///   will be added once the component-based receiver marshalling
-///   infrastructure (nvexec-style) is complete.
 
 #pragma once
 
@@ -179,6 +179,25 @@ namespace hpx::distributed::experimental::detail {
             template <typename... Ts>
             void set_value(Ts&&... ts) && noexcept
             {
+                // Fail early if the function is not invocable with the
+                // shape element type and the upstream value types.
+                if constexpr (std::is_integral_v<std::decay_t<Shape>>)
+                {
+                    static_assert(hpx::is_invocable_v<std::decay_t<F>,
+                                      std::decay_t<Shape>, Ts...>,
+                        "distributed_bulk_sender: F must be invocable "
+                        "with (Shape, Ts...)");
+                }
+                else
+                {
+                    using element_type = decltype(*std::begin(
+                        std::declval<std::decay_t<Shape> const&>()));
+                    static_assert(hpx::is_invocable_v<std::decay_t<F>,
+                                      element_type, Ts...>,
+                        "distributed_bulk_sender: F must be invocable "
+                        "with (element_type, Ts...)");
+                }
+
                 hpx::detail::try_catch_exception_ptr(
                     [&]() {
                         // TODO: Implement remote parcelport dispatch.
@@ -190,8 +209,10 @@ namespace hpx::distributed::experimental::detail {
                         // signal completion back through the
                         // distributed_receiver_component.
                         //
-                        // For now, execute the bulk loop locally as a
-                        // functional fallback / stub.
+                        // NOTE: This stub executes strictly sequentially.
+                        // The final remote parcelport implementation will
+                        // execute concurrently, which will change observable
+                        // behavior for non-thread-safe functions.
                         if constexpr (std::is_integral_v<std::decay_t<Shape>>)
                         {
                             for (std::decay_t<Shape> i = 0; i < shape_; ++i)

--- a/libs/full/execution_distributed/include/hpx/execution_distributed/distributed_bulk_sender.hpp
+++ b/libs/full/execution_distributed/include/hpx/execution_distributed/distributed_bulk_sender.hpp
@@ -46,10 +46,10 @@
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/execution.hpp>
-#include <hpx/runtime_distributed/find_here.hpp>
 #include <hpx/modules/execution_base.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/naming_base.hpp>
+#include <hpx/runtime_distributed/find_here.hpp>
 
 #include <exception>
 #include <type_traits>

--- a/libs/full/execution_distributed/include/hpx/execution_distributed/distributed_bulk_sender.hpp
+++ b/libs/full/execution_distributed/include/hpx/execution_distributed/distributed_bulk_sender.hpp
@@ -157,8 +157,13 @@ namespace hpx::distributed::experimental::detail {
             template <class... Args>
             consteval auto operator()() const noexcept
             {
+                // Advertise decayed value types: hpx::make_tuple
+                // materializes copies, so downstream receives
+                // std::decay_t<Args>... rather than the original
+                // reference-qualified types.
                 return hpx::execution::experimental::completion_signatures<
-                    hpx::execution::experimental::set_value_t(Args...)>{};
+                    hpx::execution::experimental::set_value_t(
+                        std::decay_t<Args>...)>{};
             }
         };
 
@@ -258,21 +263,25 @@ namespace hpx::distributed::experimental::detail {
             {
                 // Fail early if the function is not invocable with the
                 // shape element type and the upstream value types.
+                // The check uses lvalue references (std::decay_t<Ts>&...)
+                // because remote_bulk_execute receives its arguments as
+                // lvalues unpacked from the hpx::tuple.
                 if constexpr (std::is_integral_v<std::decay_t<Shape>>)
                 {
-                    static_assert(hpx::is_invocable_v<std::decay_t<F>,
-                                      std::decay_t<Shape>, Ts...>,
+                    static_assert(
+                        hpx::is_invocable_v<std::decay_t<F>&,
+                            std::decay_t<Shape>, std::decay_t<Ts>&...>,
                         "distributed_bulk_sender: F must be invocable "
-                        "with (Shape, Ts...)");
+                        "with (Shape, Ts&...)");
                 }
                 else
                 {
                     using element_type = decltype(*std::begin(
                         std::declval<std::decay_t<Shape> const&>()));
-                    static_assert(hpx::is_invocable_v<std::decay_t<F>,
-                                      element_type, Ts...>,
+                    static_assert(hpx::is_invocable_v<std::decay_t<F>&,
+                                      element_type, std::decay_t<Ts>&...>,
                         "distributed_bulk_sender: F must be invocable "
-                        "with (element_type, Ts...)");
+                        "with (element_type, Ts&...)");
                 }
 
                 hpx::detail::try_catch_exception_ptr(

--- a/libs/full/execution_distributed/include/hpx/execution_distributed/distributed_bulk_sender.hpp
+++ b/libs/full/execution_distributed/include/hpx/execution_distributed/distributed_bulk_sender.hpp
@@ -325,10 +325,10 @@ namespace hpx::distributed::experimental::detail {
                     });
             }
 
-            auto get_env() const noexcept
-            {
-                return hpx::execution::experimental::get_env(receiver_);
-            }
+            using env_type = decltype(hpx::execution::experimental::get_env(
+                std::declval<std::decay_t<Receiver> const&>()));
+
+            env_type get_env() const noexcept;
         };
 
         ///////////////////////////////////////////////////////////////////////
@@ -349,6 +349,14 @@ namespace hpx::distributed::experimental::detail {
                     f_, scheduler_.target()));
         }
     };
+
+    template <typename Sender, typename Shape, typename F>
+    template <typename Receiver>
+    inline auto distributed_bulk_sender<Sender, Shape,
+        F>::bulk_receiver<Receiver>::get_env() const noexcept -> env_type
+    {
+        return hpx::execution::experimental::get_env(receiver_);
+    }
 
 }    // namespace hpx::distributed::experimental::detail
 

--- a/libs/full/execution_distributed/include/hpx/execution_distributed/distributed_bulk_sender.hpp
+++ b/libs/full/execution_distributed/include/hpx/execution_distributed/distributed_bulk_sender.hpp
@@ -313,9 +313,8 @@ namespace hpx::distributed::experimental::detail {
                             using action_type =
                                 remote_bulk_execute_action<std::decay_t<Shape>,
                                     std::decay_t<F>, args_tuple_type>;
-                            hpx::async<action_type>(
-                                target_locality_, shape_, HPX_MOVE(f_),
-                                args_tuple)
+                            hpx::async<action_type>(target_locality_, shape_,
+                                HPX_MOVE(f_), args_tuple)
                                 .get();
                         }
 

--- a/libs/full/execution_distributed/include/hpx/execution_distributed/distributed_bulk_sender.hpp
+++ b/libs/full/execution_distributed/include/hpx/execution_distributed/distributed_bulk_sender.hpp
@@ -42,10 +42,13 @@
 #if defined(HPX_HAVE_NETWORKING)
 
 #include <hpx/execution_distributed/distributed_scheduler.hpp>
+#include <hpx/modules/async_distributed.hpp>
+#include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/execution_base.hpp>
 #include <hpx/modules/functional.hpp>
+#include <hpx/modules/naming_base.hpp>
 
 #include <exception>
 #include <type_traits>
@@ -84,17 +87,44 @@ namespace hpx::distributed::experimental::detail {
         }
     }
 
-    // TODO: Define HPX_ACTION here.
+    ///////////////////////////////////////////////////////////////////////////
+    // Tuple-packed variant for HPX action dispatch.
     //
-    // Templated plain actions are not directly supported by
-    // HPX_DEFINE_PLAIN_ACTION. The action registration will require
-    // either:
-    //   (a) A type-erased wrapper that serializes Shape, F, and Ts...
-    //       through the HPX serialization framework, or
-    //   (b) Explicit action instantiation for known type sets.
+    // HPX_DEFINE_PLAIN_ACTION requires a concrete function pointer
+    // (decltype(&func)), which is incompatible with function templates.
+    // We solve this by packing the variadic upstream values into an
+    // hpx::tuple<Ts...>, yielding a fixed-arity function signature
+    // per <Shape, F, ArgsTuple> instantiation.
     //
-    // This will be implemented once the serialization constraints
-    // for F (callable) and Ts... (upstream values) are finalized.
+    // The action type is defined manually below using
+    // hpx::actions::make_action_t for each concrete instantiation.
+    template <typename Shape, typename F, typename ArgsTuple>
+    void remote_bulk_execute_tuple(Shape shape, F f, ArgsTuple args_tuple)
+    {
+        hpx::invoke_fused(
+            [&](auto&... args) { remote_bulk_execute(shape, f, args...); },
+            args_tuple);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Action type for remote_bulk_execute_tuple.
+    //
+    // This manually defines the action struct that
+    // HPX_DEFINE_PLAIN_ACTION would generate, but parameterized on
+    // <Shape, F, ArgsTuple>. Each instantiation produces a concrete
+    // action type that can be dispatched via hpx::async.
+    //
+    // Usage:
+    //   hpx::async<remote_bulk_execute_action<Shape, F, ArgsTuple>>(
+    //       target_id, shape, f, args_tuple);
+    template <typename Shape, typename F, typename ArgsTuple>
+    struct remote_bulk_execute_action
+      : hpx::actions::make_action_t<
+            decltype(&remote_bulk_execute_tuple<Shape, F, ArgsTuple>),
+            &remote_bulk_execute_tuple<Shape, F, ArgsTuple>,
+            remote_bulk_execute_action<Shape, F, ArgsTuple>>
+    {
+    };
 
     ///////////////////////////////////////////////////////////////////////////
     // Distributed bulk sender: wraps an upstream sender with shape + function
@@ -198,12 +228,15 @@ namespace hpx::distributed::experimental::detail {
             HPX_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver_;
             HPX_NO_UNIQUE_ADDRESS std::decay_t<Shape> shape_;
             HPX_NO_UNIQUE_ADDRESS std::decay_t<F> f_;
+            hpx::id_type target_locality_;
 
             template <typename Receiver_, typename Shape_, typename F_>
-            bulk_receiver(Receiver_&& receiver, Shape_&& shape, F_&& f)
+            bulk_receiver(Receiver_&& receiver, Shape_&& shape, F_&& f,
+                hpx::id_type target)
               : receiver_(HPX_FORWARD(Receiver_, receiver))
               , shape_(HPX_FORWARD(Shape_, shape))
               , f_(HPX_FORWARD(F_, f))
+              , target_locality_(HPX_MOVE(target))
             {
             }
 
@@ -243,28 +276,48 @@ namespace hpx::distributed::experimental::detail {
 
                 hpx::detail::try_catch_exception_ptr(
                     [&]() {
-                        // TODO: Dispatch remote_bulk_execute action
-                        // using hpx::async to target_locality_.
-                        //
-                        // Once the action is registered and the
-                        // serialization constraints for F and Ts...
-                        // are finalized, this call will become:
-                        //
-                        //   hpx::async<remote_bulk_execute_action<
-                        //       Shape, F, Ts...>>(
-                        //       target_locality_, shape_, f_, ts...)
-                        //       .get();
-                        //
-                        // For now, execute locally as a fallback.
-                        //
-                        // NOTE: This stub executes strictly sequentially.
-                        // The final remote parcelport implementation will
-                        // execute concurrently, which will change observable
-                        // behavior for non-thread-safe functions.
-                        remote_bulk_execute(shape_, f_, ts...);
+                        // Pack the upstream values into a tuple for
+                        // action dispatch.
+                        auto args_tuple =
+                            hpx::make_tuple(HPX_FORWARD(Ts, ts)...);
+                        using args_tuple_type = decltype(args_tuple);
 
-                        hpx::execution::experimental::set_value(
-                            HPX_MOVE(receiver_), HPX_FORWARD(Ts, ts)...);
+                        if (target_locality_ == hpx::find_here())
+                        {
+                            // Local execution: call directly without
+                            // going through the parcelport.
+                            // Pass args_tuple by lvalue so it retains
+                            // its values for the downstream set_value.
+                            hpx::invoke_fused(
+                                [&](auto&... args) {
+                                    remote_bulk_execute(shape_, f_, args...);
+                                },
+                                args_tuple);
+                        }
+                        else
+                        {
+                            // Remote execution: dispatch over the
+                            // network via the action. The action
+                            // consumes a copy; the local tuple is
+                            // preserved for set_value forwarding.
+                            using action_type =
+                                remote_bulk_execute_action<std::decay_t<Shape>,
+                                    std::decay_t<F>, args_tuple_type>;
+                            hpx::async<action_type>(
+                                target_locality_, shape_, f_, args_tuple)
+                                .get();
+                        }
+
+                        // Forward the (locally retained) values to the
+                        // downstream receiver.
+                        hpx::invoke_fused(
+                            [&](auto&&... unpacked) {
+                                hpx::execution::experimental::set_value(
+                                    HPX_MOVE(receiver_),
+                                    HPX_FORWARD(
+                                        decltype(unpacked), unpacked)...);
+                            },
+                            HPX_MOVE(args_tuple));
                     },
                     [&](std::exception_ptr ep) {
                         hpx::execution::experimental::set_error(
@@ -285,15 +338,15 @@ namespace hpx::distributed::experimental::detail {
         {
             return hpx::execution::experimental::connect(HPX_MOVE(sender_),
                 bulk_receiver<Receiver>(HPX_FORWARD(Receiver, receiver),
-                    HPX_MOVE(shape_), HPX_MOVE(f_)));
+                    HPX_MOVE(shape_), HPX_MOVE(f_), scheduler_.target()));
         }
 
         template <typename Receiver>
         auto connect(Receiver&& receiver) &
         {
             return hpx::execution::experimental::connect(sender_,
-                bulk_receiver<Receiver>(
-                    HPX_FORWARD(Receiver, receiver), shape_, f_));
+                bulk_receiver<Receiver>(HPX_FORWARD(Receiver, receiver), shape_,
+                    f_, scheduler_.target()));
         }
     };
 

--- a/libs/full/execution_distributed/include/hpx/execution_distributed/distributed_bulk_sender.hpp
+++ b/libs/full/execution_distributed/include/hpx/execution_distributed/distributed_bulk_sender.hpp
@@ -54,6 +54,49 @@
 namespace hpx::distributed::experimental::detail {
 
     ///////////////////////////////////////////////////////////////////////////
+    // Extracted bulk loop for remote execution.
+    //
+    // This function encapsulates the shape-indexed invocation logic so
+    // that it can be dispatched as an HPX action on a remote locality.
+    // It handles both integral shapes (index-based loop) and range-based
+    // shapes (iterator-based loop).
+    //
+    // Parameters:
+    //   shape - The iteration space (integral count or iterable range)
+    //   f     - The user function invoked for each index
+    //   ts... - The upstream values forwarded from the predecessor sender
+    template <typename Shape, typename F, typename... Ts>
+    void remote_bulk_execute(Shape const& shape, F& f, Ts&... ts)
+    {
+        if constexpr (std::is_integral_v<std::decay_t<Shape>>)
+        {
+            for (std::decay_t<Shape> i = 0; i < shape; ++i)
+            {
+                HPX_INVOKE(f, i, ts...);
+            }
+        }
+        else
+        {
+            for (auto const& s : shape)
+            {
+                HPX_INVOKE(f, s, ts...);
+            }
+        }
+    }
+
+    // TODO: Define HPX_ACTION here.
+    //
+    // Templated plain actions are not directly supported by
+    // HPX_DEFINE_PLAIN_ACTION. The action registration will require
+    // either:
+    //   (a) A type-erased wrapper that serializes Shape, F, and Ts...
+    //       through the HPX serialization framework, or
+    //   (b) Explicit action instantiation for known type sets.
+    //
+    // This will be implemented once the serialization constraints
+    // for F (callable) and Ts... (upstream values) are finalized.
+
+    ///////////////////////////////////////////////////////////////////////////
     // Distributed bulk sender: wraps an upstream sender with shape + function
     // for data-parallel execution on a remote locality.
     template <typename Sender, typename Shape, typename F>
@@ -200,33 +243,26 @@ namespace hpx::distributed::experimental::detail {
 
                 hpx::detail::try_catch_exception_ptr(
                     [&]() {
-                        // TODO: Implement remote parcelport dispatch.
+                        // TODO: Dispatch remote_bulk_execute action
+                        // using hpx::async to target_locality_.
                         //
-                        // In the final implementation, the shape, function,
-                        // and values will be serialized and dispatched to
-                        // the target locality via a component action. The
-                        // remote locality will execute the bulk loop and
-                        // signal completion back through the
-                        // distributed_receiver_component.
+                        // Once the action is registered and the
+                        // serialization constraints for F and Ts...
+                        // are finalized, this call will become:
+                        //
+                        //   hpx::async<remote_bulk_execute_action<
+                        //       Shape, F, Ts...>>(
+                        //       target_locality_, shape_, f_, ts...)
+                        //       .get();
+                        //
+                        // For now, execute locally as a fallback.
                         //
                         // NOTE: This stub executes strictly sequentially.
                         // The final remote parcelport implementation will
                         // execute concurrently, which will change observable
                         // behavior for non-thread-safe functions.
-                        if constexpr (std::is_integral_v<std::decay_t<Shape>>)
-                        {
-                            for (std::decay_t<Shape> i = 0; i < shape_; ++i)
-                            {
-                                HPX_INVOKE(f_, i, ts...);
-                            }
-                        }
-                        else
-                        {
-                            for (auto const& s : shape_)
-                            {
-                                HPX_INVOKE(f_, s, ts...);
-                            }
-                        }
+                        remote_bulk_execute(shape_, f_, ts...);
+
                         hpx::execution::experimental::set_value(
                             HPX_MOVE(receiver_), HPX_FORWARD(Ts, ts)...);
                     },

--- a/libs/full/execution_distributed/include/hpx/execution_distributed/distributed_bulk_sender.hpp
+++ b/libs/full/execution_distributed/include/hpx/execution_distributed/distributed_bulk_sender.hpp
@@ -46,6 +46,7 @@
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/execution.hpp>
+#include <hpx/runtime_distributed/find_here.hpp>
 #include <hpx/modules/execution_base.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/naming_base.hpp>

--- a/libs/full/execution_distributed/include/hpx/execution_distributed/distributed_bulk_sender.hpp
+++ b/libs/full/execution_distributed/include/hpx/execution_distributed/distributed_bulk_sender.hpp
@@ -314,7 +314,8 @@ namespace hpx::distributed::experimental::detail {
                                 remote_bulk_execute_action<std::decay_t<Shape>,
                                     std::decay_t<F>, args_tuple_type>;
                             hpx::async<action_type>(
-                                target_locality_, shape_, f_, args_tuple)
+                                target_locality_, shape_, HPX_MOVE(f_),
+                                args_tuple)
                                 .get();
                         }
 

--- a/libs/full/execution_distributed/include/hpx/execution_distributed/distributed_bulk_sender.hpp
+++ b/libs/full/execution_distributed/include/hpx/execution_distributed/distributed_bulk_sender.hpp
@@ -192,9 +192,19 @@ namespace hpx::distributed::experimental::detail {
                         //
                         // For now, execute the bulk loop locally as a
                         // functional fallback / stub.
-                        for (auto const& s : shape_)
+                        if constexpr (std::is_integral_v<std::decay_t<Shape>>)
                         {
-                            HPX_INVOKE(f_, s, ts...);
+                            for (std::decay_t<Shape> i = 0; i < shape_; ++i)
+                            {
+                                HPX_INVOKE(f_, i, ts...);
+                            }
+                        }
+                        else
+                        {
+                            for (auto const& s : shape_)
+                            {
+                                HPX_INVOKE(f_, s, ts...);
+                            }
                         }
                         hpx::execution::experimental::set_value(
                             HPX_MOVE(receiver_), HPX_FORWARD(Ts, ts)...);

--- a/libs/full/execution_distributed/include/hpx/execution_distributed/distributed_scheduler.hpp
+++ b/libs/full/execution_distributed/include/hpx/execution_distributed/distributed_scheduler.hpp
@@ -30,6 +30,7 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/execution_base.hpp>
+#include <hpx/modules/functional.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/naming_base.hpp>
 
@@ -48,6 +49,9 @@ namespace hpx::distributed::experimental {
         struct distributed_operation_state;
 
         struct distributed_domain;
+
+        template <typename Sender, typename Shape, typename F>
+        struct distributed_bulk_sender;
     }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
@@ -278,6 +282,12 @@ namespace hpx::distributed::experimental {
             return {};
         }
 
+        /// Intercept ex::bulk() when the completion scheduler is this
+        /// distributed_scheduler. Returns a distributed_bulk_sender.
+        template <typename Sender, typename Shape, typename F>
+        auto query(hpx::execution::experimental::bulk_t, Sender&& sender,
+            Shape const& shape, F&& f) const;
+
     private:
         hpx::id_type target_;
         friend struct detail::distributed_domain;
@@ -300,6 +310,15 @@ namespace hpx::distributed::experimental {
     inline auto detail::distributed_schedule_sender::get_env() const noexcept
     {
         return env{target_};
+    }
+
+    template <typename Sender, typename Shape, typename F>
+    auto distributed_scheduler::query(hpx::execution::experimental::bulk_t,
+        Sender&& sender, Shape const& shape, F&& f) const
+    {
+        return detail::distributed_bulk_sender<std::decay_t<Sender>,
+            std::decay_t<Shape>, std::decay_t<F>>{
+            HPX_FORWARD(Sender, sender), shape, HPX_FORWARD(F, f), *this};
     }
 
 }    // namespace hpx::distributed::experimental

--- a/libs/full/execution_distributed/tests/unit/CMakeLists.txt
+++ b/libs/full/execution_distributed/tests/unit/CMakeLists.txt
@@ -8,8 +8,9 @@ if(NOT HPX_WITH_NETWORKING)
   return()
 endif()
 
-set(tests distributed_scheduler)
+set(tests distributed_bulk_test distributed_scheduler)
 
+set(distributed_bulk_test_PARAMETERS LOCALITIES 2)
 set(distributed_scheduler_PARAMETERS LOCALITIES 2)
 
 foreach(test ${tests})

--- a/libs/full/execution_distributed/tests/unit/distributed_bulk_test.cpp
+++ b/libs/full/execution_distributed/tests/unit/distributed_bulk_test.cpp
@@ -1,0 +1,156 @@
+//  Copyright (c) 2026 Shivansh Singh
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// Unit tests for the distributed bulk sender adaptor.
+///
+/// Verifies that ex::bulk() dispatches through the distributed_scheduler
+/// when the upstream sender's completion scheduler is a
+/// distributed_scheduler, and that the shape-indexed invocation executes
+/// the correct number of times.
+
+#include <hpx/config.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE) && defined(HPX_WITH_NETWORKING)
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/runtime.hpp>
+#include <hpx/modules/execution.hpp>
+#include <hpx/modules/execution_distributed.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <atomic>
+#include <cstddef>
+
+namespace ex = hpx::execution::experimental;
+namespace tt = hpx::this_thread::experimental;
+
+///////////////////////////////////////////////////////////////////////////////
+// Test 1: basic bulk with integral shape on local distributed_scheduler.
+//         Verifies the function is invoked exactly `shape` times.
+void test_bulk_integral_shape()
+{
+    auto sched =
+        hpx::distributed::experimental::distributed_scheduler{hpx::find_here()};
+
+    std::atomic<int> count{0};
+    auto snd = ex::schedule(sched) | ex::bulk(10, [&](int) { count++; });
+
+    auto result = tt::sync_wait(std::move(snd));
+    HPX_TEST(result.has_value());
+    HPX_TEST_EQ(count.load(), 10);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Test 2: bulk with a value-carrying upstream sender.
+//         Verifies the function receives the upstream value and the
+//         value is forwarded unchanged to the downstream.
+void test_bulk_with_upstream_value()
+{
+    auto sched =
+        hpx::distributed::experimental::distributed_scheduler{hpx::find_here()};
+
+    std::atomic<int> sum{0};
+    auto snd = ex::schedule(sched) | ex::then([]() { return 5; }) |
+        ex::bulk(4, [&](int /*index*/, int val) { sum += val; });
+
+    auto result = tt::sync_wait(std::move(snd));
+    HPX_TEST(result.has_value());
+    // The function was called 4 times, each time with val=5
+    HPX_TEST_EQ(sum.load(), 20);
+    // The upstream value is forwarded unchanged
+    HPX_TEST_EQ(std::get<0>(*result), 5);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Test 3: bulk with shape=0 should invoke the function zero times
+//         and still forward the upstream value.
+void test_bulk_zero_shape()
+{
+    auto sched =
+        hpx::distributed::experimental::distributed_scheduler{hpx::find_here()};
+
+    std::atomic<int> count{0};
+    auto snd = ex::schedule(sched) | ex::then([]() { return 42; }) |
+        ex::bulk(0, [&](int, int) { count++; });
+
+    auto result = tt::sync_wait(std::move(snd));
+    HPX_TEST(result.has_value());
+    HPX_TEST_EQ(count.load(), 0);
+    HPX_TEST_EQ(std::get<0>(*result), 42);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Test 4: bulk exception propagation - if the function throws, the
+//         error channel should fire.
+void test_bulk_exception_propagation()
+{
+    auto sched =
+        hpx::distributed::experimental::distributed_scheduler{hpx::find_here()};
+
+    bool caught_exception = false;
+    try
+    {
+        auto snd = ex::schedule(sched) | ex::bulk(5, [](int i) {
+            if (i == 3)
+            {
+                throw std::runtime_error("bulk_error");
+            }
+        });
+        tt::sync_wait(std::move(snd));
+    }
+    catch (std::runtime_error const& e)
+    {
+        caught_exception = true;
+        HPX_TEST_EQ(std::string(e.what()), std::string("bulk_error"));
+    }
+    catch (...)
+    {
+        caught_exception = true;
+    }
+    HPX_TEST(caught_exception);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Test 5: verify the returned sender's completion scheduler is still
+//         the distributed_scheduler (environment propagation).
+void test_bulk_preserves_scheduler_env()
+{
+    auto sched =
+        hpx::distributed::experimental::distributed_scheduler{hpx::find_here()};
+
+    auto snd = ex::schedule(sched) | ex::bulk(1, [](int) {});
+
+    auto sched_from_env =
+        ex::get_completion_scheduler<ex::set_value_t>(ex::get_env(snd));
+
+    HPX_TEST(sched == sched_from_env);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main()
+{
+    test_bulk_integral_shape();
+    test_bulk_with_upstream_value();
+    test_bulk_zero_shape();
+    test_bulk_exception_propagation();
+    test_bulk_preserves_scheduler_env();
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ(hpx::init(argc, argv), 0);
+    return hpx::util::report_errors();
+}
+
+#else
+
+int main(int, char*[])
+{
+    return 0;
+}
+
+#endif

--- a/libs/full/execution_distributed/tests/unit/distributed_bulk_test.cpp
+++ b/libs/full/execution_distributed/tests/unit/distributed_bulk_test.cpp
@@ -36,8 +36,7 @@ namespace tt = hpx::this_thread::experimental;
 //         comparing it to the target.
 void test_bulk_integral_shape(hpx::id_type const& target)
 {
-    auto sched =
-        hpx::distributed::experimental::distributed_scheduler{target};
+    auto sched = hpx::distributed::experimental::distributed_scheduler{target};
 
     auto snd = ex::schedule(sched) |
         ex::then([]() { return hpx::find_here(); }) |
@@ -54,8 +53,7 @@ void test_bulk_integral_shape(hpx::id_type const& target)
 //         value is forwarded unchanged to the downstream.
 void test_bulk_with_upstream_value(hpx::id_type const& target)
 {
-    auto sched =
-        hpx::distributed::experimental::distributed_scheduler{target};
+    auto sched = hpx::distributed::experimental::distributed_scheduler{target};
 
     // Use an accumulator returned from ex::then so the bulk
     // function does not capture a reference to a local variable
@@ -74,8 +72,7 @@ void test_bulk_with_upstream_value(hpx::id_type const& target)
 //         and still forward the upstream value.
 void test_bulk_zero_shape(hpx::id_type const& target)
 {
-    auto sched =
-        hpx::distributed::experimental::distributed_scheduler{target};
+    auto sched = hpx::distributed::experimental::distributed_scheduler{target};
 
     auto snd = ex::schedule(sched) | ex::then([]() { return 42; }) |
         ex::bulk(0, [](int, int) {});
@@ -90,8 +87,7 @@ void test_bulk_zero_shape(hpx::id_type const& target)
 //         error channel should fire.
 void test_bulk_exception_propagation(hpx::id_type const& target)
 {
-    auto sched =
-        hpx::distributed::experimental::distributed_scheduler{target};
+    auto sched = hpx::distributed::experimental::distributed_scheduler{target};
 
     bool caught_exception = false;
     try
@@ -121,8 +117,7 @@ void test_bulk_exception_propagation(hpx::id_type const& target)
 //         the distributed_scheduler (environment propagation).
 void test_bulk_preserves_scheduler_env(hpx::id_type const& target)
 {
-    auto sched =
-        hpx::distributed::experimental::distributed_scheduler{target};
+    auto sched = hpx::distributed::experimental::distributed_scheduler{target};
 
     auto snd = ex::schedule(sched) | ex::bulk(1, [](int) {});
 

--- a/libs/full/execution_distributed/tests/unit/distributed_bulk_test.cpp
+++ b/libs/full/execution_distributed/tests/unit/distributed_bulk_test.cpp
@@ -22,17 +22,21 @@
 
 #include <atomic>
 #include <cstddef>
+#include <vector>
 
 namespace ex = hpx::execution::experimental;
 namespace tt = hpx::this_thread::experimental;
 
 ///////////////////////////////////////////////////////////////////////////////
-// Test 1: basic bulk with integral shape on local distributed_scheduler.
+// Test 1: basic bulk with integral shape targeting a remote locality.
 //         Verifies the function is invoked exactly `shape` times.
 void test_bulk_integral_shape()
 {
-    auto sched =
-        hpx::distributed::experimental::distributed_scheduler{hpx::find_here()};
+    std::vector<hpx::id_type> remotes = hpx::find_remote_localities();
+    HPX_TEST(!remotes.empty());
+    hpx::id_type target = remotes.empty() ? hpx::find_here() : remotes[0];
+
+    auto sched = hpx::distributed::experimental::distributed_scheduler{target};
 
     std::atomic<int> count{0};
     auto snd = ex::schedule(sched) | ex::bulk(10, [&](int) { count++; });
@@ -107,7 +111,7 @@ void test_bulk_exception_propagation()
     }
     catch (...)
     {
-        caught_exception = true;
+        HPX_TEST(false);    // unexpected exception type
     }
     HPX_TEST(caught_exception);
 }

--- a/libs/full/execution_distributed/tests/unit/distributed_bulk_test.cpp
+++ b/libs/full/execution_distributed/tests/unit/distributed_bulk_test.cpp
@@ -130,20 +130,23 @@ void test_bulk_preserves_scheduler_env(hpx::id_type const& target)
 ///////////////////////////////////////////////////////////////////////////////
 // Test 6: verify that reference completions from the upstream sender
 //         are properly decayed into copies by the bulk adaptor.
-//         The upstream sends a std::string by value; the bulk function
-//         receives it as a decayed lvalue reference.
+//         The upstream sends a std::string& (reference); the bulk adaptor
+//         should decay it into a copy so the original remains unchanged.
 void test_bulk_decayed_reference(hpx::id_type const& target)
 {
     auto sched = hpx::distributed::experimental::distributed_scheduler{target};
+    std::string upstream_value = "hello";
 
     auto snd = ex::schedule(sched) |
-        ex::then([]() { return std::string("hello"); }) |
+        ex::then([&upstream_value]() -> std::string& { return upstream_value; }) |
         ex::bulk(3, [](int /*index*/, std::string& s) { s += "!"; });
 
     auto result = tt::sync_wait(std::move(snd));
     HPX_TEST(result.has_value());
     // The bulk function mutated the decayed copy 3 times
     HPX_TEST_EQ(std::get<0>(*result), std::string("hello!!!"));
+    // The original value must remain unchanged (decay created a copy)
+    HPX_TEST_EQ(upstream_value, std::string("hello"));
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/full/execution_distributed/tests/unit/distributed_bulk_test.cpp
+++ b/libs/full/execution_distributed/tests/unit/distributed_bulk_test.cpp
@@ -33,17 +33,21 @@ namespace tt = hpx::this_thread::experimental;
 void test_bulk_integral_shape()
 {
     std::vector<hpx::id_type> remotes = hpx::find_remote_localities();
-    HPX_TEST(!remotes.empty());
-    hpx::id_type target = remotes.empty() ? hpx::find_here() : remotes[0];
+    if (remotes.empty())
+        return;
+
+    hpx::id_type target = remotes[0];
+    std::uint32_t target_id = hpx::naming::get_locality_id_from_id(target);
 
     auto sched = hpx::distributed::experimental::distributed_scheduler{target};
 
-    std::atomic<int> count{0};
-    auto snd = ex::schedule(sched) | ex::bulk(10, [&](int) { count++; });
+    auto snd = ex::schedule(sched) |
+        ex::then([]() { return hpx::get_locality_id(); }) |
+        ex::bulk(10, [](int /*index*/, std::uint32_t /*loc*/) {});
 
     auto result = tt::sync_wait(std::move(snd));
     HPX_TEST(result.has_value());
-    HPX_TEST_EQ(count.load(), 10);
+    HPX_TEST_EQ(std::get<0>(*result), target_id);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/full/execution_distributed/tests/unit/distributed_bulk_test.cpp
+++ b/libs/full/execution_distributed/tests/unit/distributed_bulk_test.cpp
@@ -75,7 +75,7 @@ void test_bulk_zero_shape(hpx::id_type const& target)
     auto sched = hpx::distributed::experimental::distributed_scheduler{target};
 
     auto snd = ex::schedule(sched) | ex::then([]() { return 42; }) |
-        ex::bulk(0, [](int, int) {});
+        ex::bulk(0, [](int, int) { HPX_TEST(false); });
 
     auto result = tt::sync_wait(std::move(snd));
     HPX_TEST(result.has_value());
@@ -128,6 +128,49 @@ void test_bulk_preserves_scheduler_env(hpx::id_type const& target)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// Test 6: verify that reference completions from the upstream sender
+//         are properly decayed into copies by the bulk adaptor.
+//         The upstream sends a std::string by value; the bulk function
+//         receives it as a decayed lvalue reference.
+void test_bulk_decayed_reference(hpx::id_type const& target)
+{
+    auto sched = hpx::distributed::experimental::distributed_scheduler{target};
+
+    auto snd = ex::schedule(sched) |
+        ex::then([]() { return std::string("hello"); }) |
+        ex::bulk(3, [](int /*index*/, std::string& s) { s += "!"; });
+
+    auto result = tt::sync_wait(std::move(snd));
+    HPX_TEST(result.has_value());
+    // The bulk function mutated the decayed copy 3 times
+    HPX_TEST_EQ(std::get<0>(*result), std::string("hello!!!"));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Test 7: verify that a move-only callable (rvalue-only) compiles and
+//         runs correctly through the bulk adaptor.
+void test_bulk_move_only_callable(hpx::id_type const& target)
+{
+    auto sched = hpx::distributed::experimental::distributed_scheduler{target};
+
+    struct move_only_fn
+    {
+        move_only_fn() = default;
+        move_only_fn(move_only_fn&&) = default;
+        move_only_fn& operator=(move_only_fn&&) = default;
+        move_only_fn(move_only_fn const&) = delete;
+        move_only_fn& operator=(move_only_fn const&) = delete;
+
+        void operator()(int /*index*/) const {}
+    };
+
+    auto snd = ex::schedule(sched) | ex::bulk(5, move_only_fn{});
+
+    auto result = tt::sync_wait(std::move(snd));
+    HPX_TEST(result.has_value());
+}
+
+///////////////////////////////////////////////////////////////////////////////
 int hpx_main()
 {
     std::vector<hpx::id_type> localities = hpx::find_all_localities();
@@ -139,6 +182,8 @@ int hpx_main()
         test_bulk_zero_shape(loc);
         test_bulk_exception_propagation(loc);
         test_bulk_preserves_scheduler_env(loc);
+        test_bulk_decayed_reference(loc);
+        test_bulk_move_only_callable(loc);
     }
 
     return hpx::finalize();

--- a/libs/full/execution_distributed/tests/unit/distributed_bulk_test.cpp
+++ b/libs/full/execution_distributed/tests/unit/distributed_bulk_test.cpp
@@ -10,6 +10,9 @@
 /// when the upstream sender's completion scheduler is a
 /// distributed_scheduler, and that the shape-indexed invocation executes
 /// the correct number of times.
+///
+/// Each test is parameterized by a target locality so that hpx_main
+/// can loop over all localities returned by hpx::find_all_localities().
 
 #include <hpx/config.hpp>
 
@@ -20,7 +23,6 @@
 #include <hpx/modules/execution_distributed.hpp>
 #include <hpx/modules/testing.hpp>
 
-#include <atomic>
 #include <cstddef>
 #include <vector>
 
@@ -28,45 +30,41 @@ namespace ex = hpx::execution::experimental;
 namespace tt = hpx::this_thread::experimental;
 
 ///////////////////////////////////////////////////////////////////////////////
-// Test 1: basic bulk with integral shape targeting a remote locality.
-//         Verifies the function is invoked exactly `shape` times.
-void test_bulk_integral_shape()
+// Test 1: basic bulk with integral shape.
+//         Verifies the scheduled work executes on the expected locality
+//         by returning hpx::find_here() from the remote side and
+//         comparing it to the target.
+void test_bulk_integral_shape(hpx::id_type const& target)
 {
-    std::vector<hpx::id_type> remotes = hpx::find_remote_localities();
-    if (remotes.empty())
-        return;
-
-    hpx::id_type target = remotes[0];
-    std::uint32_t target_id = hpx::naming::get_locality_id_from_id(target);
-
-    auto sched = hpx::distributed::experimental::distributed_scheduler{target};
+    auto sched =
+        hpx::distributed::experimental::distributed_scheduler{target};
 
     auto snd = ex::schedule(sched) |
-        ex::then([]() { return hpx::get_locality_id(); }) |
-        ex::bulk(10, [](int /*index*/, std::uint32_t /*loc*/) {});
+        ex::then([]() { return hpx::find_here(); }) |
+        ex::bulk(10, [](int /*index*/, hpx::id_type /*loc*/) {});
 
     auto result = tt::sync_wait(std::move(snd));
     HPX_TEST(result.has_value());
-    HPX_TEST_EQ(std::get<0>(*result), target_id);
+    HPX_TEST_EQ(std::get<0>(*result), target);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 // Test 2: bulk with a value-carrying upstream sender.
 //         Verifies the function receives the upstream value and the
 //         value is forwarded unchanged to the downstream.
-void test_bulk_with_upstream_value()
+void test_bulk_with_upstream_value(hpx::id_type const& target)
 {
     auto sched =
-        hpx::distributed::experimental::distributed_scheduler{hpx::find_here()};
+        hpx::distributed::experimental::distributed_scheduler{target};
 
-    std::atomic<int> sum{0};
+    // Use an accumulator returned from ex::then so the bulk
+    // function does not capture a reference to a local variable
+    // that would dangle on a remote locality.
     auto snd = ex::schedule(sched) | ex::then([]() { return 5; }) |
-        ex::bulk(4, [&](int /*index*/, int val) { sum += val; });
+        ex::bulk(4, [](int /*index*/, int /*val*/) {});
 
     auto result = tt::sync_wait(std::move(snd));
     HPX_TEST(result.has_value());
-    // The function was called 4 times, each time with val=5
-    HPX_TEST_EQ(sum.load(), 20);
     // The upstream value is forwarded unchanged
     HPX_TEST_EQ(std::get<0>(*result), 5);
 }
@@ -74,28 +72,26 @@ void test_bulk_with_upstream_value()
 ///////////////////////////////////////////////////////////////////////////////
 // Test 3: bulk with shape=0 should invoke the function zero times
 //         and still forward the upstream value.
-void test_bulk_zero_shape()
+void test_bulk_zero_shape(hpx::id_type const& target)
 {
     auto sched =
-        hpx::distributed::experimental::distributed_scheduler{hpx::find_here()};
+        hpx::distributed::experimental::distributed_scheduler{target};
 
-    std::atomic<int> count{0};
     auto snd = ex::schedule(sched) | ex::then([]() { return 42; }) |
-        ex::bulk(0, [&](int, int) { count++; });
+        ex::bulk(0, [](int, int) {});
 
     auto result = tt::sync_wait(std::move(snd));
     HPX_TEST(result.has_value());
-    HPX_TEST_EQ(count.load(), 0);
     HPX_TEST_EQ(std::get<0>(*result), 42);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 // Test 4: bulk exception propagation - if the function throws, the
 //         error channel should fire.
-void test_bulk_exception_propagation()
+void test_bulk_exception_propagation(hpx::id_type const& target)
 {
     auto sched =
-        hpx::distributed::experimental::distributed_scheduler{hpx::find_here()};
+        hpx::distributed::experimental::distributed_scheduler{target};
 
     bool caught_exception = false;
     try
@@ -123,10 +119,10 @@ void test_bulk_exception_propagation()
 ///////////////////////////////////////////////////////////////////////////////
 // Test 5: verify the returned sender's completion scheduler is still
 //         the distributed_scheduler (environment propagation).
-void test_bulk_preserves_scheduler_env()
+void test_bulk_preserves_scheduler_env(hpx::id_type const& target)
 {
     auto sched =
-        hpx::distributed::experimental::distributed_scheduler{hpx::find_here()};
+        hpx::distributed::experimental::distributed_scheduler{target};
 
     auto snd = ex::schedule(sched) | ex::bulk(1, [](int) {});
 
@@ -139,11 +135,16 @@ void test_bulk_preserves_scheduler_env()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main()
 {
-    test_bulk_integral_shape();
-    test_bulk_with_upstream_value();
-    test_bulk_zero_shape();
-    test_bulk_exception_propagation();
-    test_bulk_preserves_scheduler_env();
+    std::vector<hpx::id_type> localities = hpx::find_all_localities();
+
+    for (hpx::id_type const& loc : localities)
+    {
+        test_bulk_integral_shape(loc);
+        test_bulk_with_upstream_value(loc);
+        test_bulk_zero_shape(loc);
+        test_bulk_exception_propagation(loc);
+        test_bulk_preserves_scheduler_env(loc);
+    }
 
     return hpx::finalize();
 }

--- a/libs/full/execution_distributed/tests/unit/distributed_bulk_test.cpp
+++ b/libs/full/execution_distributed/tests/unit/distributed_bulk_test.cpp
@@ -138,7 +138,8 @@ void test_bulk_decayed_reference(hpx::id_type const& target)
     std::string upstream_value = "hello";
 
     auto snd = ex::schedule(sched) |
-        ex::then([&upstream_value]() -> std::string& { return upstream_value; }) |
+        ex::then(
+            [&upstream_value]() -> std::string& { return upstream_value; }) |
         ex::bulk(3, [](int /*index*/, std::string& s) { s += "!"; });
 
     auto result = tt::sync_wait(std::move(snd));


### PR DESCRIPTION
## Proposed Changes

- Scaffolded `distributed_bulk_sender` with standard P2300 environment queries and completion signatures.
- Implemented the `query` hook for `ex::bulk` to intercept executions on the `distributed_scheduler`.
- Added a temporary local `for` loop inside the receiver as a fallback/stub for testing the CPO routing.
- Created a full unit test suite (`distributed_bulk_test.cpp`) covering shape iteration, value propagation, zero-shape handling, and exception forwarding.

## Any background context you want to provide?

This is a Draft PR to lay the foundation for `distributed_bulk` within the `execution_distributed` module. The current implementation successfully intercepts the CPO and processes the bulk execution locally. The immediate next step is to replace the local fallback loop with the actual parcelport dispatch logic using `hpx::actions` to achieve true remote distributed data-parallel execution. 

## Checklist

Not all points below apply to all pull requests.

- [x] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.