### PR TITLE
actions_base: annotation-driven action registration via C++26 reflection

### DIFF
--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -560,6 +560,14 @@ function(hpx_check_for_cxx26_contracts)
 endfunction()
 
 # ##############################################################################
+function(hpx_check_for_cxx26_reflection_annotations)
+  add_hpx_config_test(
+    HPX_WITH_CXX26_REFLECTION_ANNOTATIONS
+    SOURCE cmake/tests/cxx26_reflection_annotations.cpp
+    FILE ${ARGN}
+  )
+endfunction()
+
 function(hpx_check_for_cxx26_reflection)
   add_hpx_config_test(
     HPX_WITH_CXX26_REFLECTION

--- a/cmake/HPX_PerformCxxFeatureTests.cmake
+++ b/cmake/HPX_PerformCxxFeatureTests.cmake
@@ -122,6 +122,9 @@ function(hpx_perform_cxx_feature_tests)
   )
 
   hpx_check_for_cxx26_reflection(DEFINITIONS HPX_HAVE_CXX26_REFLECTION)
+  hpx_check_for_cxx26_reflection_annotations(
+    DEFINITIONS HPX_HAVE_CXX26_REFLECTION_ANNOTATIONS
+  )
 
   hpx_check_for_cxx26_contracts(DEFINITIONS HPX_HAVE_CXX26_CONTRACTS)
 

--- a/cmake/tests/cxx26_reflection_annotations.cpp
+++ b/cmake/tests/cxx26_reflection_annotations.cpp
@@ -1,0 +1,26 @@
+//  Copyright (c) 2026 Priyanshi Sharma
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#include <meta>
+struct marker
+{
+};
+[[= marker{}]] int f()
+{
+    return 0;
+}
+consteval bool has_annotation()
+{
+    for (auto a : std::meta::annotations_of(^^f))
+        return true;
+    return false;
+}
+static_assert(
+    has_annotation(), "std::meta::annotations_of must report [[=marker{}]]");
+
+int main()
+{
+    return 0;
+}

--- a/libs/full/actions_base/CMakeLists.txt
+++ b/libs/full/actions_base/CMakeLists.txt
@@ -20,6 +20,7 @@ set(actions_base_headers
     hpx/actions_base/basic_action_fwd.hpp
     hpx/actions_base/component_action.hpp
     hpx/actions_base/reflect_action.hpp
+    hpx/actions_base/reflect_annotated_actions.hpp
     hpx/actions_base/detail/action_factory.hpp
     hpx/actions_base/detail/invocation_count_registry.hpp
     hpx/actions_base/detail/per_action_data_counter_registry.hpp

--- a/libs/full/actions_base/include/hpx/actions_base/reflect_annotated_actions.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/reflect_annotated_actions.hpp
@@ -1,0 +1,117 @@
+//  Copyright (c) 2026 Priyanshi Sharma
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file reflect_annotated_actions.hpp
+/// \brief Annotation-driven HPX action registration via C++26 reflection.
+///
+/// Functions decorated with [[=hpx::actions::detail::remote_function{}]] are
+/// automatically discovered and registered as HPX plain actions.
+///
+/// Usage:
+/// \code
+/// namespace my_app {
+///     [[=hpx::actions::detail::remote_function{}]]
+///     int compute(int x) { return x + 1; }
+/// }
+/// HPX_REGISTER_ANNOTATED_ACTIONS(my_app)
+///
+/// \warning This macro must be invoked after all annotated function
+/// definitions in \a Ns are complete. Since C++ namespaces are open,
+/// functions added to \a Ns after this macro is expanded will NOT be
+/// discovered or registered.
+///
+/// // Then dispatch via:
+/// hpx::async<hpx::actions::reflect_action<^^my_app::compute>>(id, 42);
+/// \endcode
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_CXX26_REFLECTION) &&                                      \
+    defined(HPX_HAVE_CXX26_REFLECTION_ANNOTATIONS)
+
+#include <hpx/actions_base/reflect_action.hpp>
+#include <hpx/modules/preprocessor.hpp>
+#include <array>
+#include <cstddef>
+#include <meta>
+
+namespace hpx::actions::detail {
+
+    /// Marker annotation for HPX remote function registration.
+    /// Decorate functions with [[=hpx::actions::detail::remote_function{}]]
+    /// then call HPX_REGISTER_ANNOTATED_ACTIONS(namespace) to register them.
+    struct remote_function
+    {
+        int priority = 0;
+    };
+
+    /// Returns true if fn carries [[=hpx::actions::detail::remote_function{}]].
+    consteval bool is_annotated_remote_fn(std::meta::info fn) noexcept
+    {
+        if (!std::meta::is_function(fn))
+            return false;
+        for (auto a : std::meta::annotations_of(fn))
+            if (std::meta::remove_const(std::meta::type_of(a)) ==
+                ^^hpx::actions::detail::remote_function)
+                return true;
+        return false;
+    }
+
+    /// Count annotated functions in a namespace.
+    consteval std::size_t count_annotated_fns(std::meta::info ns) noexcept
+    {
+        std::size_t n = 0;
+        for (auto m :
+            std::meta::members_of(ns, std::meta::access_context::unchecked()))
+            if (is_annotated_remote_fn(m))
+                ++n;
+        return n;
+    }
+
+    /// Collect all annotated functions in a namespace.
+    template <std::meta::info Ns>
+    consteval auto get_annotated_fns() noexcept
+    {
+        constexpr std::size_t N = count_annotated_fns(Ns);
+        std::array<std::meta::info, N> result{};
+        std::size_t i = 0;
+        for (auto m :
+            std::meta::members_of(Ns, std::meta::access_context::unchecked()))
+            if (is_annotated_remote_fn(m))
+                result[i++] = m;
+        return result;
+    }
+
+    /// Force-instantiate reflect_action<^^fn> for each annotated function.
+    /// Uses static constexpr + template for in function body (GCC trunk
+    /// constraint: template for only works in function bodies, not at
+    /// namespace scope or in class bodies).
+    template <std::meta::info Ns>
+    void register_annotated_actions() noexcept
+    {
+        static constexpr auto fns = get_annotated_fns<Ns>();
+        template for (constexpr auto fn : fns)
+        {
+            // Touching the static registrar forces ODR-use and
+            // triggers HPX action registration at program startup.
+            using action_t = ::hpx::actions::reflect_action<fn>;
+            (void) action_t::invocation_count_registrar_;
+        }
+    }
+
+}    // namespace hpx::actions::detail
+
+/// \brief Register all [[=hpx::actions::detail::remote_function{}]] annotated
+/// functions in namespace \a Ns as HPX plain actions.
+///
+/// Place at namespace scope after all annotated function definitions.
+#define HPX_REGISTER_ANNOTATED_ACTIONS(Ns)                                     \
+    inline bool HPX_PP_CAT(Ns, _annotated_actions_registered_) =               \
+        (::hpx::actions::detail::register_annotated_actions<^^Ns>(),           \
+            true); /**/
+
+#endif    // HPX_HAVE_CXX26_REFLECTION

--- a/libs/full/actions_base/tests/unit/CMakeLists.txt
+++ b/libs/full/actions_base/tests/unit/CMakeLists.txt
@@ -7,7 +7,9 @@
 set(tests)
 
 if(HPX_WITH_CXX26_REFLECTION)
-  set(tests ${tests} reflect_action_test reflect_component_action_test)
+  set(tests ${tests} reflect_action_test reflect_component_action_test
+            reflect_annotated_actions_test
+  )
 endif()
 
 foreach(test ${tests})

--- a/libs/full/actions_base/tests/unit/reflect_annotated_actions_test.cpp
+++ b/libs/full/actions_base/tests/unit/reflect_annotated_actions_test.cpp
@@ -1,0 +1,92 @@
+//  Copyright (c) 2026 Priyanshi Sharma
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#include <hpx/config.hpp>
+#include <hpx/modules/testing.hpp>
+
+#if defined(HPX_HAVE_CXX26_REFLECTION) &&                                      \
+    defined(HPX_HAVE_CXX26_REFLECTION_ANNOTATIONS)
+#include <hpx/modules/actions_base.hpp>
+
+#include <cstddef>
+#include <type_traits>
+
+///////////////////////////////////////////////////////////////////////////////
+// Two annotated functions and one non-annotated function.
+// Tests specifically exercise annotation-based discovery -- these checks
+// would FAIL if annotations were not present or not detected correctly.
+namespace annotated_test {
+
+    [[= hpx::actions::detail::remote_function{}]] int increment(int x)
+    {
+        return x + 1;
+    }
+
+    [[= hpx::actions::detail::remote_function{}]] int add(int x, int y)
+    {
+        return x + y;
+    }
+
+    // Not annotated -- annotation discovery must exclude this function.
+    // If is_annotated_remote_fn incorrectly included it, count would be 3.
+    int local_helper(int x)
+    {
+        return x;
+    }
+
+}    // namespace annotated_test
+
+///////////////////////////////////////////////////////////////////////////////
+// These static_asserts require annotation support to pass.
+// Without [[=hpx::actions::detail::remote_function{}]], count would be 0.
+static_assert(hpx::actions::detail::count_annotated_fns(^^annotated_test) == 2,
+    "annotation discovery must find exactly 2 annotated functions; "
+    "would be 0 without [[=hpx::actions::detail::remote_function{}]]");
+
+// local_helper has no annotation -- must be excluded by discovery.
+// This specifically tests that is_annotated_remote_fn uses annotations,
+// not just any function predicate.
+static_assert(!hpx::actions::detail::is_annotated_remote_fn(
+                  ^^annotated_test::local_helper),
+    "non-annotated function must not be discovered");
+
+// increment IS annotated -- must be included.
+static_assert(
+    hpx::actions::detail::is_annotated_remote_fn(^^annotated_test::increment),
+    "annotated function must be discovered");
+
+// get_annotated_fns returns exactly the annotated subset.
+static_assert(
+    hpx::actions::detail::get_annotated_fns<^^annotated_test>().size() == 2,
+    "get_annotated_fns must return exactly 2 entries");
+
+int main()
+{
+    // Verify reflect_action is well-formed for annotation-discovered functions.
+    // func_ptr invocation confirms the action type resolves correctly.
+    {
+        using inc_action =
+            hpx::actions::reflect_action<^^annotated_test::increment>;
+        // arity=1 confirms the annotation-discovered function signature
+        HPX_TEST_EQ(inc_action::arity, std::size_t(1));
+        HPX_TEST_EQ(inc_action::func_ptr(41), 42);
+    }
+    {
+        using add_action = hpx::actions::reflect_action<^^annotated_test::add>;
+        HPX_TEST_EQ(add_action::arity, std::size_t(2));
+        HPX_TEST_EQ(add_action::func_ptr(20, 22), 42);
+    }
+
+    return hpx::util::report_errors();
+}
+
+#else
+
+int main()
+{
+    return 0;
+}
+
+#endif    // HPX_HAVE_CXX26_REFLECTION && HPX_HAVE_CXX26_REFLECTION_ANNOTATIONS


### PR DESCRIPTION
## Summary

Adds `HPX_REGISTER_ANNOTATED_ACTIONS(Ns)` which auto-discovers and
registers all functions decorated with
`[[=hpx::actions::detail::remote_function{}]]` in a namespace as HPX
plain actions — no per-function macro needed.

## Before / After

```cpp
// Before: one macro call per function
HPX_PLAIN_ACTION(compute, compute_action)
HPX_PLAIN_ACTION(broadcast, broadcast_action)

// After: annotate functions, one namespace-level call
namespace my_app {
    [[=hpx::actions::detail::remote_function{}]]
    int compute(int x) { return x + 1; }

    [[=hpx::actions::detail::remote_function{}]]
    void broadcast(int n) { ... }
}
HPX_REGISTER_ANNOTATED_ACTIONS(my_app)

// Dispatch via reflect_action:
hpx::async<hpx::actions::reflect_action<^^my_app::compute>>(id, 42);
```

## Design

- `is_annotated_remote_fn()` — detects `annotations_of()` matching
  `hpx::actions::detail::remote_function`
- `get_annotated_fns<^^Ns>()` — collects annotated functions into a
  compile-time `std::array`
- `register_annotated_actions<^^Ns>()` — uses `static constexpr` +
  `template for` in a function body to force-instantiate
  `reflect_action<^^fn>` for each annotated function, triggering HPX's
  existing static registration mechanism
- `HPX_REGISTER_ANNOTATED_ACTIONS` — calls the above via an
  `inline bool` static initializer at namespace scope

GCC trunk constraint: `template for` only works in function bodies on
current GCC trunk — hence registration is triggered via a function call
rather than at namespace scope directly.

## Files

- `reflect_annotated_actions.hpp` — detection helpers and macro
- `reflect_annotated_actions_test.cpp` — distributed unit test
- `CMakeLists.txt` — registered in module and test suite

## Related

Builds on #7298, #7376, #7385.