### PR TITLE
Add contract preconditions to sorting/heap algorithms

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/algorithms/is_heap.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/is_heap.hpp
@@ -209,6 +209,7 @@ namespace hpx {
 #else    // DOXYGEN
 
 #include <hpx/config.hpp>
+#include <hpx/contracts.hpp>
 #include <hpx/modules/concepts.hpp>
 #include <hpx/modules/coroutines.hpp>
 #include <hpx/modules/execution.hpp>
@@ -611,7 +612,7 @@ namespace hpx {
             )
         // clang-format on
         static decltype(auto) invoke_default(ExPolicy&& policy, RandIter first,
-            RandIter last, Comp comp = Comp())
+            RandIter last, Comp comp = Comp()) HPX_PRE(first <= last)
         {
             static_assert(std::random_access_iterator<RandIter>,
                 "Requires a random access iterator.");
@@ -632,8 +633,8 @@ namespace hpx {
                 >
             )
         // clang-format on
-        static bool invoke_default(
-            RandIter first, RandIter last, Comp comp = Comp())
+        static bool invoke_default(RandIter first, RandIter last,
+            Comp comp = Comp()) HPX_PRE(first <= last)
         {
             static_assert(std::random_access_iterator<RandIter>,
                 "Requires a random access iterator.");
@@ -663,7 +664,7 @@ namespace hpx {
             )
         // clang-format on
         static decltype(auto) invoke_default(ExPolicy&& policy, RandIter first,
-            RandIter last, Comp comp = Comp())
+            RandIter last, Comp comp = Comp()) HPX_PRE(first <= last)
         {
             static_assert(std::random_access_iterator<RandIter>,
                 "Requires a random access iterator.");
@@ -684,8 +685,8 @@ namespace hpx {
                 >
             )
         // clang-format on
-        static RandIter invoke_default(
-            RandIter first, RandIter last, Comp comp = Comp())
+        static RandIter invoke_default(RandIter first, RandIter last,
+            Comp comp = Comp()) HPX_PRE(first <= last)
         {
             static_assert(std::random_access_iterator<RandIter>,
                 "Requires a random access iterator.");

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/make_heap.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/make_heap.hpp
@@ -192,6 +192,7 @@ namespace hpx {
 #else    // DOXYGEN
 
 #include <hpx/config.hpp>
+#include <hpx/contracts.hpp>
 #include <hpx/modules/concepts.hpp>
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/execution.hpp>
@@ -568,8 +569,8 @@ namespace hpx {
             )
         // clang-format on
         static hpx::parallel::util::detail::algorithm_result_t<ExPolicy>
-        invoke_default(
-            ExPolicy&& policy, RndIter first, RndIter last, Comp comp)
+        invoke_default(ExPolicy&& policy, RndIter first, RndIter last,
+            Comp comp) HPX_PRE(first <= last)
         {
             static_assert(std::random_access_iterator<RndIter>,
                 "Requires random access iterator.");
@@ -589,6 +590,7 @@ namespace hpx {
         // clang-format on
         static hpx::parallel::util::detail::algorithm_result_t<ExPolicy>
         invoke_default(ExPolicy&& policy, RndIter first, RndIter last)
+            HPX_PRE(first <= last)
         {
             static_assert(std::random_access_iterator<RndIter>,
                 "Requires random access iterator.");
@@ -613,6 +615,7 @@ namespace hpx {
         )
         // clang-format on
         static void invoke_default(RndIter first, RndIter last, Comp comp)
+            HPX_PRE(first <= last)
         {
             static_assert(std::random_access_iterator<RndIter>,
                 "Requires random access iterator.");
@@ -625,6 +628,7 @@ namespace hpx {
         template <typename RndIter>
             requires(hpx::traits::is_iterator_v<RndIter>)
         static void invoke_default(RndIter first, RndIter last)
+            HPX_PRE(first <= last)
         {
             static_assert(std::random_access_iterator<RndIter>,
                 "Requires random access iterator.");

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/nth_element.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/nth_element.hpp
@@ -134,6 +134,7 @@ namespace hpx {
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/contracts.hpp>
 #include <hpx/modules/concepts.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/execution_base.hpp>
@@ -434,8 +435,8 @@ namespace hpx {
                 >
             )
         // clang-format on
-        static void invoke_default(
-            RandomIt first, RandomIt nth, RandomIt last, Pred pred = Pred())
+        static void invoke_default(RandomIt first, RandomIt nth, RandomIt last,
+            Pred pred = Pred()) HPX_PRE(first <= nth && nth <= last)
         {
             static_assert(std::random_access_iterator<RandomIt>,
                 "Requires at least random iterator.");
@@ -459,6 +460,7 @@ namespace hpx {
         // clang-format on
         static decltype(auto) invoke_default(ExPolicy&& policy, RandomIt first,
             RandomIt nth, RandomIt last, Pred pred = Pred())
+            HPX_PRE(first <= nth && nth <= last)
         {
             static_assert(std::random_access_iterator<RandomIt>,
                 "Requires at least random iterator.");

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/partial_sort.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/partial_sort.hpp
@@ -108,6 +108,7 @@ namespace hpx {
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/contracts.hpp>
 #include <hpx/modules/async_local.hpp>
 #include <hpx/modules/concepts.hpp>
 #include <hpx/modules/execution.hpp>
@@ -579,6 +580,7 @@ namespace hpx {
         // clang-format on
         static RandIter invoke_default(
             RandIter first, RandIter middle, RandIter last, Comp comp = Comp())
+            HPX_PRE(first <= middle && middle <= last)
         {
             static_assert(std::random_access_iterator<RandIter>,
                 "Requires at least random access iterator.");
@@ -601,6 +603,7 @@ namespace hpx {
         // clang-format on
         static decltype(auto) invoke_default(ExPolicy&& policy, RandIter first,
             RandIter middle, RandIter last, Comp comp = Comp())
+            HPX_PRE(first <= middle && middle <= last)
         {
             static_assert(std::random_access_iterator<RandIter>,
                 "Requires at least random access iterator.");

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/partial_sort_copy.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/partial_sort_copy.hpp
@@ -150,6 +150,7 @@ namespace hpx {
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/contracts.hpp>
 #include <hpx/modules/concepts.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/executors.hpp>
@@ -372,6 +373,7 @@ namespace hpx {
         // clang-format on
         static RandIter invoke_default(InIter first, InIter last,
             RandIter d_first, RandIter d_last, Comp comp = Comp())
+            HPX_PRE(d_first <= d_last)
         {
             static_assert(std::input_iterator<InIter>,
                 "Requires at least input iterator.");
@@ -403,6 +405,7 @@ namespace hpx {
         static parallel::util::detail::algorithm_result_t<ExPolicy, RandIter>
         invoke_default(ExPolicy&& policy, FwdIter first, FwdIter last,
             RandIter d_first, RandIter d_last, Comp comp = Comp())
+            HPX_PRE(d_first <= d_last)
         {
             static_assert(std::forward_iterator<FwdIter>,
                 "Requires at least forward iterator.");

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/sort_by_key.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/sort_by_key.hpp
@@ -98,6 +98,7 @@ namespace hpx { namespace experimental {
 #else
 
 #include <hpx/config.hpp>
+#include <hpx/contracts.hpp>
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/type_support.hpp>
 #include <hpx/parallel/algorithms/sort.hpp>
@@ -141,6 +142,7 @@ namespace hpx::experimental {
         sort_by_key_result<KeyIter, ValueIter>>
     sort_by_key(ExPolicy&& policy, KeyIter key_first, KeyIter key_last,
         ValueIter value_first, Compare comp = Compare())
+        HPX_PRE(key_first <= key_last)
     {
 #if !defined(HPX_HAVE_TUPLE_RVALUE_SWAP)
         static_assert(hpx::util::detail::always_false<KeyIter>::value,

--- a/libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt
@@ -276,3 +276,43 @@ if(HPX_WITH_CXX_MODULES AND (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
     )
   endforeach()
 endif()
+
+# Contract precondition violation tests for the sorting/heap algorithm family
+# (nth_element, partial_sort, partial_sort_copy, is_heap, is_heap_until,
+# make_heap, sort_by_key). Each of these deliberately calls the algorithm with
+# an out-of-order iterator argument that violates its HPX_PRE precondition.
+# Under native C++26 contracts the precondition check aborts before the
+# (otherwise unsafe) algorithm body runs; without native contracts HPX_PRE is a
+# no-op and the call would fall through into undefined behavior unrelated to
+# contracts. These tests are therefore only built and run when native contracts
+# are available, mirroring the gating used by
+# libs/core/contracts/tests/unit/CMakeLists.txt.
+if(HPX_WITH_CXX26_CONTRACTS)
+  set(contract_violation_tests
+      nth_element_contract_violation
+      partial_sort_contract_violation
+      partial_sort_copy_contract_violation
+      is_heap_contract_violation
+      is_heap_until_contract_violation
+      make_heap_contract_violation
+      sort_by_key_contract_violation
+  )
+
+  foreach(test ${contract_violation_tests})
+    set(${test}_PARAMETERS FAILURE_EXPECTED)
+
+    source_group("Source Files" FILES ${test}.cpp)
+
+    add_hpx_executable(
+      ${test}_test INTERNAL_FLAGS
+      SOURCES ${test}.cpp
+      EXCLUDE_FROM_ALL
+      HPX_PREFIX ${HPX_BUILD_PREFIX}
+      FOLDER "Tests/Unit/Modules/Core/Algorithms"
+    )
+
+    add_hpx_unit_test(
+      "modules.algorithms.algorithms" ${test} ${${test}_PARAMETERS}
+    )
+  endforeach()
+endif()

--- a/libs/core/algorithms/tests/unit/algorithms/is_heap_contract_violation.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/is_heap_contract_violation.cpp
@@ -1,0 +1,37 @@
+//  Copyright (c) 2026 adhithyaragavan
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Test: HPX_PRE violation for hpx::is_heap
+//
+// hpx::is_heap requires first <= last. This test passes last that lies
+// before first, which violates the precondition. Both iterators are
+// individually valid and in-bounds (only their relative order is wrong), so
+// constructing and comparing them is well-defined regardless of whether
+// contracts are enabled -- only entering the algorithm body with this
+// ordering would be unsafe.
+//
+// This test is only built when native C++26 contracts (HPX_WITH_CXX26_CONTRACTS)
+// are enabled: the precondition check happens at the function boundary before
+// the (unsafe) algorithm body ever runs, so the violation is caught safely by
+// the contract machinery before any out-of-order iterator use occurs. Without
+// native contracts, HPX_PRE is a no-op and the call would fall through into
+// the algorithm body with this invalid ordering, which is undefined behavior
+// unrelated to contracts -- so this test is intentionally excluded from
+// non-contract builds rather than expected to "safely" no-op.
+
+#include <hpx/algorithm.hpp>
+
+#include <vector>
+
+int main()
+{
+    std::vector<int> v{5, 3, 1, 4, 2};
+
+    // last is before first -- violates first <= last
+    [[maybe_unused]] bool result = hpx::is_heap(v.begin() + 3, v.begin() + 1);
+
+    return 0;
+}

--- a/libs/core/algorithms/tests/unit/algorithms/is_heap_until_contract_violation.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/is_heap_until_contract_violation.cpp
@@ -1,0 +1,38 @@
+//  Copyright (c) 2026 adhithyaragavan
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Test: HPX_PRE violation for hpx::is_heap_until
+//
+// hpx::is_heap_until requires first <= last. This test passes last that
+// lies before first, which violates the precondition. Both iterators are
+// individually valid and in-bounds (only their relative order is wrong), so
+// constructing and comparing them is well-defined regardless of whether
+// contracts are enabled -- only entering the algorithm body with this
+// ordering would be unsafe.
+//
+// This test is only built when native C++26 contracts (HPX_WITH_CXX26_CONTRACTS)
+// are enabled: the precondition check happens at the function boundary before
+// the (unsafe) algorithm body ever runs, so the violation is caught safely by
+// the contract machinery before any out-of-order iterator use occurs. Without
+// native contracts, HPX_PRE is a no-op and the call would fall through into
+// the algorithm body with this invalid ordering, which is undefined behavior
+// unrelated to contracts -- so this test is intentionally excluded from
+// non-contract builds rather than expected to "safely" no-op.
+
+#include <hpx/algorithm.hpp>
+
+#include <vector>
+
+int main()
+{
+    std::vector<int> v{5, 3, 1, 4, 2};
+
+    // last is before first -- violates first <= last
+    [[maybe_unused]] auto result =
+        hpx::is_heap_until(v.begin() + 3, v.begin() + 1);
+
+    return 0;
+}

--- a/libs/core/algorithms/tests/unit/algorithms/make_heap_contract_violation.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/make_heap_contract_violation.cpp
@@ -1,0 +1,37 @@
+//  Copyright (c) 2026 adhithyaragavan
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Test: HPX_PRE violation for hpx::make_heap
+//
+// hpx::make_heap requires first <= last. This test passes last that lies
+// before first, which violates the precondition. Both iterators are
+// individually valid and in-bounds (only their relative order is wrong), so
+// constructing and comparing them is well-defined regardless of whether
+// contracts are enabled -- only entering the algorithm body with this
+// ordering would be unsafe.
+//
+// This test is only built when native C++26 contracts (HPX_WITH_CXX26_CONTRACTS)
+// are enabled: the precondition check happens at the function boundary before
+// the (unsafe) algorithm body ever runs, so the violation is caught safely by
+// the contract machinery before any out-of-order iterator use occurs. Without
+// native contracts, HPX_PRE is a no-op and the call would fall through into
+// the algorithm body with this invalid ordering, which is undefined behavior
+// unrelated to contracts -- so this test is intentionally excluded from
+// non-contract builds rather than expected to "safely" no-op.
+
+#include <hpx/algorithm.hpp>
+
+#include <vector>
+
+int main()
+{
+    std::vector<int> v{5, 3, 1, 4, 2};
+
+    // last is before first -- violates first <= last
+    hpx::make_heap(v.begin() + 3, v.begin() + 1);
+
+    return 0;
+}

--- a/libs/core/algorithms/tests/unit/algorithms/nth_element_contract_violation.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/nth_element_contract_violation.cpp
@@ -1,0 +1,37 @@
+//  Copyright (c) 2026 adhithyaragavan
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Test: HPX_PRE violation for hpx::nth_element
+//
+// hpx::nth_element requires first <= nth && nth <= last. This test passes
+// nth that lies before first, which violates the precondition. All three
+// iterators are individually valid and in-bounds (only their relative order
+// is wrong), so constructing and comparing them is well-defined regardless
+// of whether contracts are enabled -- only entering the algorithm body with
+// this ordering would be unsafe.
+//
+// This test is only built when native C++26 contracts (HPX_WITH_CXX26_CONTRACTS)
+// are enabled: the precondition check happens at the function boundary before
+// the (unsafe) algorithm body ever runs, so the violation is caught safely by
+// the contract machinery before any out-of-order iterator use occurs. Without
+// native contracts, HPX_PRE is a no-op and the call would fall through into
+// the algorithm body with this invalid ordering, which is undefined behavior
+// unrelated to contracts -- so this test is intentionally excluded from
+// non-contract builds rather than expected to "safely" no-op.
+
+#include <hpx/algorithm.hpp>
+
+#include <vector>
+
+int main()
+{
+    std::vector<int> v{5, 3, 1, 4, 2};
+
+    // nth is before first -- violates first <= nth
+    hpx::nth_element(v.begin() + 3, v.begin() + 1, v.end());
+
+    return 0;
+}

--- a/libs/core/algorithms/tests/unit/algorithms/partial_sort_contract_violation.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/partial_sort_contract_violation.cpp
@@ -1,0 +1,37 @@
+//  Copyright (c) 2026 adhithyaragavan
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Test: HPX_PRE violation for hpx::partial_sort
+//
+// hpx::partial_sort requires first <= middle && middle <= last. This test
+// passes middle that lies before first, which violates the precondition.
+// All three iterators are individually valid and in-bounds (only their
+// relative order is wrong), so constructing and comparing them is
+// well-defined regardless of whether contracts are enabled -- only entering
+// the algorithm body with this ordering would be unsafe.
+//
+// This test is only built when native C++26 contracts (HPX_WITH_CXX26_CONTRACTS)
+// are enabled: the precondition check happens at the function boundary before
+// the (unsafe) algorithm body ever runs, so the violation is caught safely by
+// the contract machinery before any out-of-order iterator use occurs. Without
+// native contracts, HPX_PRE is a no-op and the call would fall through into
+// the algorithm body with this invalid ordering, which is undefined behavior
+// unrelated to contracts -- so this test is intentionally excluded from
+// non-contract builds rather than expected to "safely" no-op.
+
+#include <hpx/algorithm.hpp>
+
+#include <vector>
+
+int main()
+{
+    std::vector<int> v{5, 3, 1, 4, 2};
+
+    // middle is before first -- violates first <= middle
+    hpx::partial_sort(v.begin() + 3, v.begin() + 1, v.end());
+
+    return 0;
+}

--- a/libs/core/algorithms/tests/unit/algorithms/partial_sort_copy_contract_violation.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/partial_sort_copy_contract_violation.cpp
@@ -1,0 +1,42 @@
+//  Copyright (c) 2026 adhithyaragavan
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Test: HPX_PRE violation for hpx::partial_sort_copy
+//
+// hpx::partial_sort_copy requires d_first <= d_last on the destination
+// range (the source range only needs to be an input/forward iterator range,
+// which is not comparable with <=, so no precondition is placed on it).
+// This test passes a destination range where d_last lies before d_first,
+// which violates the precondition. Both destination iterators are
+// individually valid and in-bounds (only their relative order is wrong), so
+// constructing and comparing them is well-defined regardless of whether
+// contracts are enabled -- only entering the algorithm body with this
+// ordering would be unsafe.
+//
+// This test is only built when native C++26 contracts (HPX_WITH_CXX26_CONTRACTS)
+// are enabled: the precondition check happens at the function boundary before
+// the (unsafe) algorithm body ever runs, so the violation is caught safely by
+// the contract machinery before any out-of-order iterator use occurs. Without
+// native contracts, HPX_PRE is a no-op and the call would fall through into
+// the algorithm body with this invalid ordering, which is undefined behavior
+// unrelated to contracts -- so this test is intentionally excluded from
+// non-contract builds rather than expected to "safely" no-op.
+
+#include <hpx/algorithm.hpp>
+
+#include <vector>
+
+int main()
+{
+    std::vector<int> v{5, 3, 1, 4, 2};
+    std::vector<int> d(v.size());
+
+    // d_last is before d_first -- violates d_first <= d_last
+    [[maybe_unused]] auto result = hpx::partial_sort_copy(
+        v.begin(), v.end(), d.begin() + 3, d.begin() + 1);
+
+    return 0;
+}

--- a/libs/core/algorithms/tests/unit/algorithms/sort_by_key_contract_violation.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/sort_by_key_contract_violation.cpp
@@ -1,0 +1,41 @@
+//  Copyright (c) 2026 adhithyaragavan
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Test: HPX_PRE violation for hpx::experimental::sort_by_key
+//
+// hpx::experimental::sort_by_key requires key_first <= key_last. This test
+// passes key_last that lies before key_first, which violates the
+// precondition. Both key iterators are individually valid and in-bounds
+// (only their relative order is wrong), so constructing and comparing them
+// is well-defined regardless of whether contracts are enabled -- only
+// entering the algorithm body with this ordering would be unsafe.
+//
+// This test is only built when native C++26 contracts (HPX_WITH_CXX26_CONTRACTS)
+// are enabled: the precondition check happens at the function boundary before
+// the (unsafe) algorithm body ever runs, so the violation is caught safely by
+// the contract machinery before any out-of-order iterator use occurs. Without
+// native contracts, HPX_PRE is a no-op and the call would fall through into
+// the algorithm body with this invalid ordering, which is undefined behavior
+// unrelated to contracts -- so this test is intentionally excluded from
+// non-contract builds rather than expected to "safely" no-op.
+
+#include <hpx/algorithm.hpp>
+#include <hpx/execution.hpp>
+
+#include <vector>
+
+int main()
+{
+    std::vector<int> keys{5, 3, 1, 4, 2};
+    std::vector<int> values{0, 1, 2, 3, 4};
+
+    // key_last is before key_first -- violates key_first <= key_last
+    [[maybe_unused]] auto result =
+        hpx::experimental::sort_by_key(hpx::execution::seq, keys.begin() + 3,
+            keys.begin() + 1, values.begin());
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

Extends the existing C++26 contract annotations (currently only on `sort`/`stable_sort`) to the rest of the random-access sorting/heap algorithm family:

- `nth_element`: `first <= nth && nth <= last`
- `partial_sort`: `first <= middle && middle <= last`
- `partial_sort_copy`: `d_first <= d_last` (only the destination range — the source is an input/forward iterator range, not comparable with `<=`)
- `is_heap` / `is_heap_until`: `first <= last`
- `make_heap`: `first <= last`
- `sort_by_key`: `key_first <= key_last`

Each `invoke_default` overload (serial and execution-policy) gets the annotation, following the exact placement used in `sort.hpp`/`stable_sort.hpp`.

## Tests

Added one precondition-violation test per algorithm under `libs/core/algorithms/tests/unit/algorithms/`. These are gated entirely on `HPX_WITH_CXX26_CONTRACTS` (excluded from the build otherwise), because violating an algorithm's precondition is genuine undefined behavior once the algorithm body runs — not just something contracts happen to catch. Under native contracts the precondition check aborts at the function boundary before the body executes, so the violating call is safe to make; without native contracts there's no safety guarantee, so these tests simply aren't built. Each test uses individually valid, in-bounds iterators in the wrong relative order (not out-of-range iterators), so constructing/comparing them is well-defined on its own.

## Test plan

- [x] Verified locally in fallback mode (g++ 15, C++20): annotations compile to no-ops, all six affected existing unit tests (`nth_element_test`, `partial_sort_test`, `partial_sort_copy_test`, `is_heap_test`, `make_heap_test`, `sort_by_key_test`) still build and pass.
- [ ] Native contract enforcement (gcc-trunk, `-fcontracts -fcontract-evaluation-semantic=enforce`) not yet exercised locally — should be covered by CI's `linux_release_gcc_trunk_reflection` workflow, though note that workflow currently only builds `tests.unit.modules.{serialization,contracts,actions_base}`, not `tests.unit.modules.algorithms`, so the new violation tests won't actually run there yet. Happy to extend that workflow if maintainers want these exercised in CI rather than left as local-only verification.