### PR TITLE
Fix EVE/simd unaligned load and store broadcast

### DIFF
--- a/libs/core/execution/include/hpx/execution/traits/detail/eve/vector_pack_load_store.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/detail/eve/vector_pack_load_store.hpp
@@ -36,7 +36,18 @@ namespace hpx::parallel::traits {
         template <typename Iter>
         HPX_HOST_DEVICE HPX_FORCEINLINE static V unaligned(Iter& iter)
         {
-            return *iter;
+            // V can be a genuine SIMD pack or a scalar value_type (width-1
+            // pack, see vector_pack_type<T, 1, Abi>). eve::wide's pointer
+            // constructor only accepts actual SIMD types, so scalars take
+            // the plain-load path instead.
+            if constexpr (eve::is_simd_value<V>{})
+            {
+                return V(std::addressof(*iter));
+            }
+            else
+            {
+                return *iter;
+            }
         }
     };
 
@@ -57,7 +68,17 @@ namespace hpx::parallel::traits {
         HPX_HOST_DEVICE HPX_FORCEINLINE static void unaligned(
             V& value, Iter& iter)
         {
-            *iter = value;
+            // See vector_pack_load::unaligned above: eve::store only
+            // accepts genuine SIMD packs, so scalars take the plain-store
+            // path instead.
+            if constexpr (eve::is_simd_value<V>{})
+            {
+                eve::store(value, std::addressof(*iter));
+            }
+            else
+            {
+                *iter = value;
+            }
         }
     };
 }    // namespace hpx::parallel::traits

--- a/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_load_store.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_load_store.hpp
@@ -35,7 +35,19 @@ namespace hpx::parallel::traits {
         template <typename Iter>
         HPX_HOST_DEVICE HPX_FORCEINLINE static V unaligned(Iter& iter)
         {
-            return *iter;
+            // V can be a genuine SIMD pack or a scalar value_type (width-1
+            // pack, see vector_pack_type<T, 1, Abi>). std::experimental::simd's
+            // pointer constructor only accepts actual SIMD types, so scalars
+            // take the plain-load path instead.
+            if constexpr (datapar::experimental::is_simd_v<V>)
+            {
+                return V(std::addressof(*iter),
+                    datapar::experimental::element_aligned);
+            }
+            else
+            {
+                return *iter;
+            }
         }
     };
 
@@ -56,7 +68,18 @@ namespace hpx::parallel::traits {
         HPX_HOST_DEVICE HPX_FORCEINLINE static void unaligned(
             V& value, Iter& iter)
         {
-            *iter = value;
+            // See vector_pack_load::unaligned above: copy_to() is only
+            // available on genuine SIMD packs, so scalars take the
+            // plain-store path instead.
+            if constexpr (datapar::experimental::is_simd_v<V>)
+            {
+                value.copy_to(std::addressof(*iter),
+                    datapar::experimental::element_aligned);
+            }
+            else
+            {
+                *iter = value;
+            }
         }
     };
 }    // namespace hpx::parallel::traits

--- a/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_simd.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/detail/simd/vector_pack_simd.hpp
@@ -43,6 +43,7 @@ namespace hpx::datapar::experimental {
     HPX_CXX_CORE_EXPORT using std::experimental::simd_abi::native;
 
     HPX_CXX_CORE_EXPORT using std::experimental::memory_alignment_v;
+    HPX_CXX_CORE_EXPORT using std::experimental::element_aligned;
     HPX_CXX_CORE_EXPORT using std::experimental::vector_aligned;
 
     HPX_CXX_CORE_EXPORT using std::experimental::all_of;

--- a/libs/core/execution/tests/regressions/CMakeLists.txt
+++ b/libs/core/execution/tests/regressions/CMakeLists.txt
@@ -10,7 +10,7 @@ set(tests annotated_minmax_2593 chunk_size_4118 executor_parameters_num_chunks
 
 if(HPX_WITH_DATAPAR)
   set(tests ${tests} lambda_arguments_2403 lambda_return_type_2402
-            rebind_par_simd
+            rebind_par_simd vector_pack_unaligned_load_store_7287
   )
 endif()
 

--- a/libs/core/execution/tests/regressions/vector_pack_unaligned_load_store_7287.cpp
+++ b/libs/core/execution/tests/regressions/vector_pack_unaligned_load_store_7287.cpp
@@ -1,0 +1,90 @@
+//  Copyright (c) 2026 adhithyaragavan
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Regression test for #7287: vector_pack_load<V, T>::unaligned used to
+// broadcast a single scalar (*iter) across all lanes of the pack instead of
+// loading the N consecutive elements starting at that address. The
+// symmetric bug existed in vector_pack_store<V, T>::unaligned, which wrote
+// the same broadcast pattern instead of storing each lane back to its own
+// position. Both are fixed for the EVE and std-experimental-simd backends.
+//
+// This test loads a full-width, non-uniform pack via ::unaligned, checks
+// every lane against the source data (a broadcast bug would make every
+// lane equal to data[0]), flips the sign of each lane, stores the pack back
+// via ::unaligned, and checks every element in memory was updated
+// independently (a broadcast bug would write the same value everywhere).
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_DATAPAR)
+
+#include <hpx/execution.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstddef>
+#include <vector>
+
+int hpx_main()
+{
+    using value_type = int;
+    using V = hpx::parallel::traits::vector_pack_type_t<value_type>;
+
+    std::size_t const width = hpx::parallel::traits::vector_pack_size_v<V>;
+
+    // Non-uniform, strictly increasing data -- a broadcast bug would
+    // collapse every lane to data[0].
+    std::vector<value_type> data(width);
+    for (std::size_t i = 0; i != width; ++i)
+    {
+        data[i] = static_cast<value_type>(i + 1);
+    }
+
+    auto it = data.begin();
+    V pack =
+        hpx::parallel::traits::vector_pack_load<V, value_type>::unaligned(it);
+
+    for (std::size_t i = 0; i != width; ++i)
+    {
+        HPX_TEST_EQ(hpx::parallel::traits::get(pack, i), data[i]);
+    }
+
+    // Negate each lane and store back; a broadcast bug would overwrite the
+    // whole range with a single (repeated) value instead of updating each
+    // element independently.
+    for (std::size_t i = 0; i != width; ++i)
+    {
+        hpx::parallel::traits::set(
+            pack, i, -hpx::parallel::traits::get(pack, i));
+    }
+
+    hpx::parallel::traits::vector_pack_store<V, value_type>::unaligned(
+        pack, it);
+
+    for (std::size_t i = 0; i != width; ++i)
+    {
+        HPX_TEST_EQ(data[i], -static_cast<value_type>(i + 1));
+    }
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}
+
+#else
+
+int main()
+{
+    return 0;
+}
+
+#endif


### PR DESCRIPTION
## Summary

Fixes #7287.

`vector_pack_load<V, T>::unaligned` returned a broadcast of a single scalar (`*iter`) across every lane of the pack instead of loading the N consecutive elements starting at that address, for both the EVE and std-experimental-simd backends. The symmetric bug existed in `vector_pack_store<V, T>::unaligned`, writing the same broadcast value everywhere instead of storing each lane back to its own position.

- EVE backend: `unaligned()` now constructs directly from the pointer (`V(std::addressof(*iter))`), which resolves to `eve::wide`'s genuine unaligned-load constructor rather than the scalar-broadcast constructor; store uses `eve::store(value, ptr)` with a plain (non-`as_aligned`) pointer.
- std-experimental-simd backend: exposed `std::experimental::element_aligned` (previously only `vector_aligned` was re-exported) and used it for both load and store.

`V` can also be instantiated as a scalar `value_type` — the width-1 "pack" used by the remainder/tail-element path (see `vector_pack_type<T, 1, Abi>`) — for which neither `eve::wide`'s pointer constructor / `eve::store`, nor `std::experimental::simd`'s pointer constructor / `copy_to`, are valid. Both fixes are gated on `eve::is_simd_value<V>{}` / `datapar::experimental::is_simd_v<V>` respectively, falling back to the original plain-assignment behavior for the scalar case.

Scope: this only touches the `unaligned` load/store fix itself, split out from the larger change in #7288 (which also rewrites `search`/`search_n`) per discussion there.

## Tests

Added `libs/core/execution/tests/regressions/vector_pack_unaligned_load_store_7287.cpp` (gated on `HPX_WITH_DATAPAR`), following the naming/registration pattern of the other numbered regression tests in that directory (`annotated_minmax_2593`, `chunk_size_4118`, etc.). It:
1. Loads a non-uniform, strictly-increasing full-width pack via `unaligned()` and checks every lane against the source data (a broadcast bug collapses every lane to the first element).
2. Negates each lane and stores the pack back via `unaligned()`, then checks every destination element was updated independently (a broadcast bug overwrites the whole range with one repeated value).

## Test plan

- [x] Built and ran locally with `HPX_WITH_DATAPAR_BACKEND=EVE`: new regression test passes.
- [x] Confirmed the test is meaningful — reverting just the EVE load fix reproduces a **compile error** against the pre-fix code (not merely a wrong-value bug): `eve::wide`'s scalar-broadcast constructor is `explicit`, so `return *iter;` fails to convert to a full-width `V` when the function is actually instantiated with a genuine pack (as happens via `invoke_vectorized_in2`/`invoke_vectorized_in2_ind` in `iterator_helpers.hpp`, used by two-iterator algorithms like `mismatch`/`equal_binary`/`transform_binary`). None of the current datapar test suite happens to instantiate `unaligned()` with a full pack today, so this was previously silent; the new regression test is (as far as I can tell) the first thing in-tree to exercise that path directly.
- [x] Re-ran the full existing datapar test set potentially affected (`foreach_datapar_test`, `transform_datapar_test`, `find_datapar_test`, `datapar_zip_iterator_guard_test`, `mismatch_datapar_test`, `equal_binary_datapar_test`, `transform_binary_datapar_test`, `search_datapar_test`, `search_n_datapar_test`, `foreach_datapar_zipiter_test`) — all still pass with the fix applied.
- [ ] Not tested against the SVE or Vc backends (no access to that hardware/library locally); the `std::experimental::simd` fix was verified by inspection/compile reasoning only (this machine's compilers don't expose the same EVE test harness for that backend) — would appreciate a check on CI.