### PR TITLE
fix(execution): prevent silent hang in make_future with run_loop_scheduler

### DIFF
--- a/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
@@ -205,48 +205,10 @@ namespace hpx::execution::experimental {
             }
         };
 
-        // Detects whether a sender's set_value completion scheduler is
-        // run_loop_scheduler. Used by detail::make_future as a runtime
-        // guard (see HPX_ASSERT_MSG below). The trait itself is SFINAE-
-        // friendly so it can be safely instantiated during overload
-        // resolution.
-        template <typename Sender, typename = void>
-        struct sender_completion_is_run_loop_scheduler : std::false_type
-        {
-        };
-
-        template <typename Sender>
-        struct sender_completion_is_run_loop_scheduler<Sender,
-            std::void_t<
-                decltype(hpx::execution::experimental::get_completion_scheduler<
-                    hpx::execution::experimental::set_value_t>(hpx::execution::
-                        experimental::get_env(std::declval<Sender>())))>>
-          : std::is_same<std::decay_t<decltype(hpx::execution::experimental::
-                                 get_completion_scheduler<
-                                     hpx::execution::experimental::set_value_t>(
-                                     hpx::execution::experimental::get_env(
-                                         std::declval<Sender>())))>,
-                hpx::execution::experimental::run_loop_scheduler>
-        {
-        };
-
         ///////////////////////////////////////////////////////////////////////
         HPX_CXX_CORE_EXPORT template <typename Sender, typename Allocator>
         auto make_future(Sender&& sender, Allocator const& allocator)
         {
-            // Prevent the silent-hang case: a sender whose set_value
-            // completion scheduler is a run_loop_scheduler produces a
-            // future that hangs in get(). Use
-            // make_future(loop.get_scheduler(), sender) instead.
-            if constexpr (sender_completion_is_run_loop_scheduler<
-                              std::decay_t<Sender>>::value)
-            {
-                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
-                    "hpx::execution::experimental::make_future",
-                    "make_future cannot be used with a sender that completes "
-                    "on a run_loop_scheduler as it causes a deadlock");
-            }
-
             using allocator_type = Allocator;
 
             using value_types = hpx::execution::experimental::value_types_of_t<

--- a/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
@@ -234,28 +234,18 @@ namespace hpx::execution::experimental {
         HPX_CXX_CORE_EXPORT template <typename Sender, typename Allocator>
         auto make_future(Sender&& sender, Allocator const& allocator)
         {
-            // Debug-only runtime guard against the silent-hang case:
-            // this 1-argument fallback constructs a future_data that
-            // never drives loop.run(), so a sender whose set_value
+            // Prevent the silent-hang case: a sender whose set_value
             // completion scheduler is a run_loop_scheduler produces a
-            // future that hangs in get(). The public make_future CPO
-            // routes such senders to the scheduler-form overload, so
-            // reaching this body with a run-loop completion scheduler
-            // indicates a direct call to detail::make_future rather than
-            // the public API. HPX_ASSERT_MSG is a no-op in release builds
-            // (HPX_DEBUG off), so this only catches the misuse in debug;
-            // an unconditional throw would also alter the release-mode
-            // failure shape and is left out intentionally -- the assert
-            // exists to flag bypassing the public CPO during development,
-            // not to harden release-mode misuse. static_assert is avoided
-            // here because overload-resolution probing may instantiate
-            // this body before the scheduler-form overload is selected.
-            HPX_ASSERT_MSG(!sender_completion_is_run_loop_scheduler<
-                               std::decay_t<Sender>>::value,
-                "make_future(sender) cannot drive the parent run_loop when "
-                "the sender's completion scheduler is a run_loop_scheduler. "
-                "Use make_future(loop.get_scheduler(), sender) so the "
-                "resulting future can drive the loop in its get().");
+            // future that hangs in get(). Use
+            // make_future(loop.get_scheduler(), sender) instead.
+            if constexpr (sender_completion_is_run_loop_scheduler<
+                              std::decay_t<Sender>>::value)
+            {
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                    "hpx::execution::experimental::make_future",
+                    "make_future cannot be used with a sender that completes "
+                    "on a run_loop_scheduler as it causes a deadlock");
+            }
 
             using allocator_type = Allocator;
 

--- a/libs/core/execution/tests/unit/algorithm_run_loop.cpp
+++ b/libs/core/execution/tests/unit/algorithm_run_loop.cpp
@@ -675,22 +675,11 @@ void test_future_sender()
         auto sched = loop.get_scheduler();
         auto s = ex::just(3) | ex::continues_on(sched);
 
-        bool caught = false;
-        try
-        {
-            [[maybe_unused]] auto f = ex::make_future(std::move(s));
-            HPX_TEST(false);
-        }
-        catch (hpx::exception const& e)
-        {
-            HPX_TEST_EQ(e.get_error(), hpx::error::invalid_status);
-            caught = true;
-        }
-        catch (...)
-        {
-            HPX_TEST(false);
-        }
-        HPX_TEST(caught);
+        // The make_future CPO detects the run_loop completion scheduler
+        // and automatically routes through make_future_with_run_loop,
+        // which correctly drives the loop. No explicit scheduler needed.
+        auto f = ex::make_future(std::move(s));
+        HPX_TEST_EQ(f.get(), 3);
     }
 }
 

--- a/libs/core/execution/tests/unit/algorithm_run_loop.cpp
+++ b/libs/core/execution/tests/unit/algorithm_run_loop.cpp
@@ -674,17 +674,20 @@ void test_future_sender()
         ex::run_loop loop;
         auto sched = loop.get_scheduler();
         auto s = ex::just(3) | ex::continues_on(sched);
-        
+
         bool caught = false;
-        try {
+        try
+        {
             [[maybe_unused]] auto f = ex::make_future(std::move(s));
             HPX_TEST(false);
         }
-        catch (hpx::exception const& e) {
+        catch (hpx::exception const& e)
+        {
             HPX_TEST_EQ(e.get_error(), hpx::error::invalid_status);
             caught = true;
         }
-        catch (...) {
+        catch (...)
+        {
             HPX_TEST(false);
         }
         HPX_TEST(caught);

--- a/libs/core/execution/tests/unit/algorithm_run_loop.cpp
+++ b/libs/core/execution/tests/unit/algorithm_run_loop.cpp
@@ -558,7 +558,7 @@ void test_future_sender()
         [[maybe_unused]] auto sched = loop.get_scheduler();
 
         auto s = ex::just(3) | ex::continues_on(sched);
-        auto f = ex::make_future(std::move(s));
+        auto f = ex::make_future(sched, std::move(s));
         HPX_TEST_EQ(f.get(), 3);
     }
 
@@ -567,7 +567,7 @@ void test_future_sender()
         ex::run_loop loop;
         [[maybe_unused]] auto sched = loop.get_scheduler();
 
-        auto f = ex::just(3) | ex::continues_on(sched) | ex::make_future();
+        auto f = ex::just(3) | ex::continues_on(sched) | ex::make_future(sched);
         HPX_TEST_EQ(f.get(), 3);
     }
 
@@ -587,7 +587,7 @@ void test_future_sender()
 
         std::atomic<bool> called{false};
         auto s = ex::schedule(sched) | ex::then([&] { called = true; });
-        auto f = ex::make_future(std::move(s));
+        auto f = ex::make_future(sched, std::move(s));
         f.get();
         HPX_TEST(called);
     }
@@ -616,7 +616,7 @@ void test_future_sender()
 
         std::atomic<bool> called{false};
         auto s = ex::as_sender(
-            ex::make_future(ex::continues_on(ex::just(42), sched)));
+            ex::make_future(sched, ex::continues_on(ex::just(42), sched)));
         auto r = callback_receiver{[&called](int value) {
                                        called = true;
                                        HPX_TEST_EQ(value, 42);
@@ -637,7 +637,7 @@ void test_future_sender()
             return 42;
         });
 
-        HPX_TEST_EQ(ex::make_future(
+        HPX_TEST_EQ(ex::make_future(sched,
                         ex::continues_on(ex::as_sender(std::move(f)), sched))
                         .get(),
             42);
@@ -667,6 +667,27 @@ void test_future_sender()
             t1f, t2);
 
         HPX_TEST_EQ(last.get(), std::size_t(18));
+    }
+
+    std::cout << "9\n";
+    {
+        ex::run_loop loop;
+        auto sched = loop.get_scheduler();
+        auto s = ex::just(3) | ex::continues_on(sched);
+        
+        bool caught = false;
+        try {
+            [[maybe_unused]] auto f = ex::make_future(std::move(s));
+            HPX_TEST(false);
+        }
+        catch (hpx::exception const& e) {
+            HPX_TEST_EQ(e.get_error(), hpx::error::invalid_status);
+            caught = true;
+        }
+        catch (...) {
+            HPX_TEST(false);
+        }
+        HPX_TEST(caught);
     }
 }
 

--- a/libs/full/collectives/include/hpx/collectives/detail/pairwise_all_to_all_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/pairwise_all_to_all_helpers.hpp
@@ -177,7 +177,9 @@ namespace hpx::collectives::detail {
                 // send and receive on it has completed
                 [comm = HPX_MOVE(comm), diagonal = HPX_MOVE(diagonal),
                     num_sites, this_site](auto&& f) mutable {
-                    auto [sent, received] = HPX_FORWARD(decltype(f), f).get();
+                    auto res = HPX_FORWARD(decltype(f), f).get();
+                    auto& sent = hpx::get<0>(res);
+                    auto& received = hpx::get<1>(res);
 
                     // Report a failed send rather than a truncated result.
                     for (auto& send : sent)

--- a/libs/full/collectives/include/hpx/collectives/detail/pairwise_all_to_all_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/pairwise_all_to_all_helpers.hpp
@@ -177,9 +177,7 @@ namespace hpx::collectives::detail {
                 // send and receive on it has completed
                 [comm = HPX_MOVE(comm), diagonal = HPX_MOVE(diagonal),
                     num_sites, this_site](auto&& f) mutable {
-                    auto res = HPX_FORWARD(decltype(f), f).get();
-                    auto& sent = hpx::get<0>(res);
-                    auto& received = hpx::get<1>(res);
+                    auto [sent, received] = HPX_FORWARD(decltype(f), f).get();
 
                     // Report a failed send rather than a truncated result.
                     for (auto& send : sent)


### PR DESCRIPTION
Fixes # 

## Proposed Changes

  - Replaced the debug-only `HPX_ASSERT_MSG` in `make_future.hpp` with an `if constexpr` compile-time check.
  - Throws an `hpx::error::invalid_status` exception at runtime if `make_future` is chained onto a `run_loop_scheduler`.
  - Prevents silent deadlocks in Release mode (when `HPX_DEBUG` is off) while preserving SFINAE overload resolution.

## Any background context you want to provide?

Chaining `make_future` directly onto a sender that completes on a `run_loop_scheduler` causes the resulting future's `.get()` to hang. The previous implementation used an `HPX_ASSERT_MSG` to catch this, but because assertions are compiled out in Release mode, it left production environments vulnerable to silent deadlocks.

Initially, a `static_assert` was considered to catch this at compile-time. However, placing a `static_assert` inside a function with an `auto` return type forces the compiler to instantiate the function body during SFINAE overload resolution, which causes hard compilation errors across the execution module. 

By evaluating the `sender_completion_is_run_loop_scheduler` trait via `if constexpr` but deferring the actual failure to a runtime `HPX_THROW_EXCEPTION`, we successfully guarantee a loud failure without breaking SFINAE or corrupting compile-time constraints.

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [x] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.