### PR TITLE
algorithms: add copy_if sender support

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/algorithms/copy.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/copy.hpp
@@ -792,9 +792,8 @@ namespace hpx {
                 >
             )
         // clang-format on
-        static parallel::util::detail::algorithm_result_t<ExPolicy, FwdIter2>
-        invoke_default(ExPolicy&& policy, FwdIter1 first, FwdIter1 last,
-            FwdIter2 dest, Pred pred)
+        static decltype(auto) invoke_default(ExPolicy&& policy, FwdIter1 first,
+            FwdIter1 last, FwdIter2 dest, Pred pred)
         {
             static_assert(std::forward_iterator<FwdIter1>,
                 "Required at least forward iterator.");
@@ -804,11 +803,27 @@ namespace hpx {
                             hpx::traits::iter_value_t<FwdIter1>>),
                 "Requires at least forward iterator or sequential execution.");
 
-            return hpx::parallel::util::get_second_element(
-                hpx::parallel::detail::copy_if<
-                    hpx::parallel::util::in_out_result<FwdIter1, FwdIter2>>()
-                    .call(HPX_FORWARD(ExPolicy, policy), first, last, dest,
-                        HPX_MOVE(pred), hpx::identity_v));
+            constexpr bool has_scheduler_executor =
+                hpx::execution_policy_has_scheduler_executor_v<ExPolicy>;
+
+            if constexpr (has_scheduler_executor)
+            {
+                return hpx::parallel::util::get_second_element(
+                    hpx::parallel::execution::async_execute(policy.executor(),
+                        [first, last, dest, pred = HPX_MOVE(pred)]() mutable {
+                            return hpx::parallel::detail::sequential_copy_if(
+                                first, last, dest, HPX_MOVE(pred),
+                                hpx::identity_v);
+                        }));
+            }
+            else
+            {
+                return hpx::parallel::util::get_second_element(
+                    hpx::parallel::detail::copy_if<hpx::parallel::util::
+                            in_out_result<FwdIter1, FwdIter2>>()
+                        .call(HPX_FORWARD(ExPolicy, policy), first, last, dest,
+                            HPX_MOVE(pred), hpx::identity_v));
+            }
         }
 
         template <typename FwdIter1, typename FwdIter2, typename Pred>

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/copy.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/copy.hpp
@@ -810,8 +810,13 @@ namespace hpx {
 
             if constexpr (has_scheduler_executor)
             {
+                using result_handler =
+                    hpx::parallel::util::detail::algorithm_result<ExPolicy,
+                        hpx::parallel::util::in_out_result<FwdIter1, FwdIter2>>;
+
                 return hpx::parallel::util::get_second_element(
-                    hpx::parallel::execution::async_execute(policy.executor(),
+                    result_handler::get(hpx::parallel::execution::async_execute(
+                        policy.executor(),
                         [first, last, dest, pred = HPX_MOVE(pred)]() mutable {
                             try
                             {
@@ -825,7 +830,7 @@ namespace hpx {
                                     handle_local_exceptions<ExPolicy>::call(
                                         std::current_exception());
                             }
-                        }));
+                        })));
             }
             else
             {

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/copy.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/copy.hpp
@@ -324,6 +324,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/transfer.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
 #include <hpx/parallel/util/detail/clear_container.hpp>
+#include <hpx/parallel/util/detail/handle_local_exceptions.hpp>
 #include <hpx/parallel/util/foreach_partitioner.hpp>
 #include <hpx/parallel/util/loop.hpp>
 #include <hpx/parallel/util/result_types.hpp>
@@ -334,6 +335,7 @@ namespace hpx {
 #include <algorithm>
 #include <cstddef>
 #include <cstring>
+#include <exception>
 #include <iterator>
 #include <memory>
 #include <type_traits>
@@ -811,9 +813,18 @@ namespace hpx {
                 return hpx::parallel::util::get_second_element(
                     hpx::parallel::execution::async_execute(policy.executor(),
                         [first, last, dest, pred = HPX_MOVE(pred)]() mutable {
-                            return hpx::parallel::detail::sequential_copy_if(
-                                first, last, dest, HPX_MOVE(pred),
-                                hpx::identity_v);
+                            try
+                            {
+                                return hpx::parallel::detail::
+                                    sequential_copy_if(first, last, dest,
+                                        HPX_MOVE(pred), hpx::identity_v);
+                            }
+                            catch (...)
+                            {
+                                hpx::parallel::util::detail::
+                                    handle_local_exceptions<ExPolicy>::call(
+                                        std::current_exception());
+                            }
                         }));
             }
             else

--- a/libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt
@@ -166,6 +166,7 @@ set(sender_tests
     adjacentfind_sender
     all_of_sender
     any_of_sender
+    copy_if_sender
     copy_sender
     copyn_sender
     count_sender

--- a/libs/core/algorithms/tests/unit/algorithms/copy_if_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/copy_if_sender.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <exception>
 #include <iterator>
 #include <new>
 #include <stdexcept>
@@ -71,6 +72,10 @@ void test_copy_if_sender_case(LnPolicy ln_policy, ExPolicy&& ex_policy,
 
     auto result = tt::sync_wait(std::move(sender));
     HPX_TEST(result.has_value());
+    if (!result.has_value())
+    {
+        return;
+    }
 
     auto const output_end = hpx::get<0>(*result);
     HPX_TEST(output_end ==
@@ -130,9 +135,26 @@ void test_copy_if_sender_exception(
     {
         if constexpr (std::is_same_v<Exception, std::runtime_error>)
         {
-            caught_expected_exception = true;
             test::test_num_exceptions<ExPolicy, IteratorTag>::call(
                 ex_policy, errors);
+
+            bool all_exceptions_expected = errors.begin() != errors.end();
+            for (std::exception_ptr const& error : errors)
+            {
+                try
+                {
+                    std::rethrow_exception(error);
+                }
+                catch (std::runtime_error const&)
+                {
+                }
+                catch (...)
+                {
+                    all_exceptions_expected = false;
+                }
+            }
+            HPX_TEST(all_exceptions_expected);
+            caught_expected_exception = all_exceptions_expected;
         }
         else
         {

--- a/libs/core/algorithms/tests/unit/algorithms/copy_if_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/copy_if_sender.cpp
@@ -141,17 +141,21 @@ void test_copy_if_sender_exception(
             bool all_exceptions_expected = errors.begin() != errors.end();
             for (std::exception_ptr const& error : errors)
             {
+                bool is_expected_exception = false;
                 try
                 {
                     std::rethrow_exception(error);
                 }
                 catch (std::runtime_error const&)
                 {
+                    is_expected_exception = true;
                 }
                 catch (...)
                 {
-                    all_exceptions_expected = false;
+                    is_expected_exception = false;
                 }
+                all_exceptions_expected =
+                    all_exceptions_expected && is_expected_exception;
             }
             HPX_TEST(all_exceptions_expected);
             caught_expected_exception = all_exceptions_expected;

--- a/libs/core/algorithms/tests/unit/algorithms/copy_if_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/copy_if_sender.cpp
@@ -25,6 +25,32 @@ namespace ex = hpx::execution::experimental;
 namespace tt = hpx::this_thread::experimental;
 
 template <typename LnPolicy, typename ExPolicy, typename IteratorTag>
+void test_copy_if_scheduler(
+    LnPolicy ln_policy, ExPolicy&& ex_policy, IteratorTag)
+{
+    static_assert(!hpx::is_async_execution_policy_v<ExPolicy>);
+
+    using base_iterator = std::vector<int>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+    using scheduler_type = ex::thread_pool_policy_scheduler<LnPolicy>;
+
+    std::vector<int> input{1, 2, 3, 4, 5, 6};
+    std::vector<int> output(input.size(), -1);
+    auto exec = ex::explicit_scheduler_executor(scheduler_type(ln_policy));
+
+    auto result = hpx::copy_if(ex_policy.on(exec), iterator(input.begin()),
+        iterator(input.end()), output.begin(),
+        [](int value) { return value % 2 == 0; });
+    static_assert(std::is_same_v<decltype(result), base_iterator>);
+
+    HPX_TEST(result == output.begin() + 3);
+    std::vector<int> const expected{2, 4, 6};
+    HPX_TEST(std::equal(expected.begin(), expected.end(), output.begin()));
+    HPX_TEST(std::all_of(
+        result, output.end(), [](int value) { return value == -1; }));
+}
+
+template <typename LnPolicy, typename ExPolicy, typename IteratorTag>
 void test_copy_if_sender_case(LnPolicy ln_policy, ExPolicy&& ex_policy,
     IteratorTag, std::vector<int> input, std::vector<int> const& expected)
 {
@@ -136,6 +162,11 @@ template <typename IteratorTag>
 void copy_if_sender_test()
 {
     using namespace hpx::execution;
+
+    test_copy_if_scheduler(hpx::launch::sync, seq, IteratorTag{});
+    test_copy_if_scheduler(hpx::launch::sync, unseq, IteratorTag{});
+    test_copy_if_scheduler(hpx::launch::async, par, IteratorTag{});
+    test_copy_if_scheduler(hpx::launch::async, par_unseq, IteratorTag{});
 
     test_copy_if_sender(hpx::launch::sync, seq(task), IteratorTag{});
     test_copy_if_sender(hpx::launch::sync, unseq(task), IteratorTag{});

--- a/libs/core/algorithms/tests/unit/algorithms/copy_if_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/copy_if_sender.cpp
@@ -115,7 +115,14 @@ void test_copy_if_sender_exception(
     }
     catch (Exception const&)
     {
-        caught_expected_exception = true;
+        if constexpr (std::is_same_v<Exception, std::runtime_error>)
+        {
+            HPX_TEST(false);
+        }
+        else
+        {
+            caught_expected_exception = true;
+        }
     }
     catch (...)
     {

--- a/libs/core/algorithms/tests/unit/algorithms/copy_if_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/copy_if_sender.cpp
@@ -1,0 +1,166 @@
+//  Copyright (c) 2026 Pratyksh Gupta
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/algorithm.hpp>
+#include <hpx/execution.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+#include <new>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "test_utils.hpp"
+
+namespace ex = hpx::execution::experimental;
+namespace tt = hpx::this_thread::experimental;
+
+template <typename LnPolicy, typename ExPolicy, typename IteratorTag>
+void test_copy_if_sender_case(LnPolicy ln_policy, ExPolicy&& ex_policy,
+    IteratorTag, std::vector<int> input, std::vector<int> const& expected)
+{
+    static_assert(hpx::is_async_execution_policy_v<ExPolicy>);
+
+    using base_iterator = std::vector<int>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+    using scheduler_type = ex::thread_pool_policy_scheduler<LnPolicy>;
+
+    std::vector<int> output(input.size(), -1);
+    auto exec = ex::explicit_scheduler_executor(scheduler_type(ln_policy));
+
+    auto sender =
+        ex::just(iterator(input.begin()), iterator(input.end()), output.begin(),
+            [](int value) { return value % 2 == 0; }) |
+        hpx::copy_if(ex_policy.on(exec));
+    static_assert(ex::is_sender_v<decltype(sender)>);
+
+    auto result = tt::sync_wait(std::move(sender));
+    HPX_TEST(result.has_value());
+
+    auto const output_end = hpx::get<0>(*result);
+    HPX_TEST(output_end ==
+        output.begin() + static_cast<std::ptrdiff_t>(expected.size()));
+    HPX_TEST(std::equal(expected.begin(), expected.end(), output.begin()));
+    HPX_TEST(std::all_of(
+        output_end, output.end(), [](int value) { return value == -1; }));
+}
+
+template <typename LnPolicy, typename ExPolicy, typename IteratorTag>
+void test_copy_if_sender(LnPolicy ln_policy, ExPolicy&& ex_policy, IteratorTag)
+{
+    test_copy_if_sender_case(
+        ln_policy, ex_policy, IteratorTag{}, {1, 2, 3, 4, 5, 6}, {2, 4, 6});
+    test_copy_if_sender_case(ln_policy, ex_policy, IteratorTag{}, {}, {});
+    test_copy_if_sender_case(
+        ln_policy, ex_policy, IteratorTag{}, {2, 4, 6}, {2, 4, 6});
+    test_copy_if_sender_case(
+        ln_policy, ex_policy, IteratorTag{}, {1, 3, 5}, {});
+}
+
+template <typename Exception, typename LnPolicy, typename ExPolicy,
+    typename IteratorTag>
+void test_copy_if_sender_exception(
+    LnPolicy ln_policy, ExPolicy&& ex_policy, IteratorTag)
+{
+    static_assert(hpx::is_async_execution_policy_v<ExPolicy>);
+
+    using base_iterator = std::vector<int>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+    using scheduler_type = ex::thread_pool_policy_scheduler<LnPolicy>;
+
+    std::vector<int> input{1, 2, 3, 4};
+    std::vector<int> output(input.size());
+    auto exec = ex::explicit_scheduler_executor(scheduler_type(ln_policy));
+
+    bool caught_expected_exception = false;
+    try
+    {
+        tt::sync_wait(
+            ex::just(iterator(input.begin()), iterator(input.end()),
+                output.begin(),
+                [](int) -> bool {
+                    if constexpr (std::is_same_v<Exception, std::runtime_error>)
+                    {
+                        throw std::runtime_error("test");
+                    }
+                    else
+                    {
+                        throw std::bad_alloc();
+                    }
+                }) |
+            hpx::copy_if(ex_policy.on(exec)));
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& errors)
+    {
+        if constexpr (std::is_same_v<Exception, std::runtime_error>)
+        {
+            caught_expected_exception = true;
+            test::test_num_exceptions<ExPolicy, IteratorTag>::call(
+                ex_policy, errors);
+        }
+        else
+        {
+            HPX_TEST(false);
+        }
+    }
+    catch (Exception const&)
+    {
+        caught_expected_exception = true;
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_expected_exception);
+}
+
+template <typename IteratorTag>
+void copy_if_sender_test()
+{
+    using namespace hpx::execution;
+
+    test_copy_if_sender(hpx::launch::sync, seq(task), IteratorTag{});
+    test_copy_if_sender(hpx::launch::sync, unseq(task), IteratorTag{});
+    test_copy_if_sender(hpx::launch::async, par(task), IteratorTag{});
+    test_copy_if_sender(hpx::launch::async, par_unseq(task), IteratorTag{});
+
+    test_copy_if_sender_exception<std::runtime_error>(
+        hpx::launch::sync, seq(task), IteratorTag{});
+    test_copy_if_sender_exception<std::runtime_error>(
+        hpx::launch::async, par(task), IteratorTag{});
+    test_copy_if_sender_exception<std::bad_alloc>(
+        hpx::launch::sync, seq(task), IteratorTag{});
+    test_copy_if_sender_exception<std::bad_alloc>(
+        hpx::launch::async, par(task), IteratorTag{});
+}
+
+int hpx_main()
+{
+    copy_if_sender_test<std::forward_iterator_tag>();
+    copy_if_sender_test<std::random_access_iterator_tag>();
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    hpx::local::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
## Proposed Changes

- Add sender support for `hpx::copy_if` when used with scheduler-backed task policies
- Preserve the existing non-scheduler execution path and return the correct output iterator from sender completion
- Add tests covering iterator categories, empty/all/none/mixed inputs, returned iterators, and exception propagation