### PR TITLE
Add sender/receiver support for set_symmetric_difference

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/set_operation.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/set_operation.hpp
@@ -114,7 +114,14 @@ namespace hpx::parallel::detail {
                 policy.parameters(), policy.executor(),
                 hpx::chrono::null_duration, (std::min) (len1, len2));
 
-        std::size_t const step = (len1 + cores - 1) / cores;
+        // an entirely empty first range still needs exactly one chunk to
+        // route the degenerate case through below -- without this, a hint
+        // of 0 (from (std::min)(len1, len2) == 0) can make the partitioner
+        // allocate zero chunks and the special case below would never run
+        cores = (std::max) (cores, static_cast<std::size_t>(1));
+
+        std::size_t const step =
+            len1 == 0 ? 0 : (len1 + cores - 1) / cores;
 
         std::shared_ptr<buffer_type[]> buffer(
             new buffer_type[combiner(len1, len2)]);
@@ -125,6 +132,30 @@ namespace hpx::parallel::detail {
                       std::size_t const part_size) mutable -> void {
             HPX_ASSERT(part_size == 1);
             HPX_UNUSED(part_size);
+
+            // An entirely empty first range cannot be chunked by
+            // partitioning first1 (step collapses to 0 above). Route the
+            // single synthetic chunk against the full second range instead
+            // of bailing out, so algorithms whose degenerate-case
+            // semantics differ from "empty" (e.g. set_symmetric_difference,
+            // set_union) still produce correct output through this shared
+            // partitioned code path.
+            if (len1 == 0)
+            {
+                if (curr_chunk != chunks.get())
+                {
+                    return;    // only the first chunk does the work
+                }
+
+                curr_chunk->start = combiner(0, 0);
+                auto buffer_dest = buffer.get() + curr_chunk->start;
+                auto op_result = setop(
+                    first1, first1, first2, first2 + len2, buffer_dest, f);
+                curr_chunk->first1 = op_result.in1 - first1;
+                curr_chunk->first2 = op_result.in2 - first2;
+                curr_chunk->len = op_result.out - buffer_dest;
+                return;
+            }
 
             // find start in sequence 1
             std::size_t start1 = (curr_chunk - chunks.get()) * step;
@@ -240,6 +271,15 @@ namespace hpx::parallel::detail {
                 {
                     first2_pos = (std::max) (first2_pos, curr_chunk->first2);
                 }
+            }
+
+            if (chunk->first1 != set_chunk_data::uninit_first1)
+            {
+                first1_pos = (std::max) (first1_pos, chunk->first1);
+            }
+            if (chunk->first2 != set_chunk_data::uninit_first2)
+            {
+                first2_pos = (std::max) (first2_pos, chunk->first2);
             }
 
             // finally, copy data to destination

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/set_operation.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/set_operation.hpp
@@ -112,13 +112,13 @@ namespace hpx::parallel::detail {
         std::size_t cores =
             hpx::execution::experimental::processing_units_count(
                 policy.parameters(), policy.executor(),
-                hpx::chrono::null_duration, (std::min)(len1, len2));
+                hpx::chrono::null_duration, (std::min) (len1, len2));
 
         // an entirely empty first range still needs exactly one chunk to
         // route the degenerate case through below -- without this, a hint
         // of 0 (from (std::min)(len1, len2) == 0) can make the partitioner
         // allocate zero chunks and the special case below would never run
-        cores = (std::max)(cores, static_cast<std::size_t>(1));
+        cores = (std::max) (cores, static_cast<std::size_t>(1));
 
         std::size_t const step = len1 == 0 ? 0 : (len1 + cores - 1) / cores;
 
@@ -159,7 +159,7 @@ namespace hpx::parallel::detail {
             // find start in sequence 1
             std::size_t start1 = (curr_chunk - chunks.get()) * step;
             std::size_t end1 =
-                (std::min)(start1 + step, static_cast<std::size_t>(len1));
+                (std::min) (start1 + step, static_cast<std::size_t>(len1));
 
             if (start1 >= end1)
             {
@@ -264,21 +264,21 @@ namespace hpx::parallel::detail {
                 chunk->start_index = curr_chunk->start_index + curr_chunk->len;
                 if (curr_chunk->first1 != static_cast<std::size_t>(-1))
                 {
-                    first1_pos = (std::max)(first1_pos, curr_chunk->first1);
+                    first1_pos = (std::max) (first1_pos, curr_chunk->first1);
                 }
                 if (curr_chunk->first2 != static_cast<std::size_t>(-1))
                 {
-                    first2_pos = (std::max)(first2_pos, curr_chunk->first2);
+                    first2_pos = (std::max) (first2_pos, curr_chunk->first2);
                 }
             }
 
             if (chunk->first1 != set_chunk_data::uninit_first1)
             {
-                first1_pos = (std::max)(first1_pos, chunk->first1);
+                first1_pos = (std::max) (first1_pos, chunk->first1);
             }
             if (chunk->first2 != set_chunk_data::uninit_first2)
             {
-                first2_pos = (std::max)(first2_pos, chunk->first2);
+                first2_pos = (std::max) (first2_pos, chunk->first2);
             }
 
             // finally, copy data to destination

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/set_operation.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/set_operation.hpp
@@ -112,16 +112,15 @@ namespace hpx::parallel::detail {
         std::size_t cores =
             hpx::execution::experimental::processing_units_count(
                 policy.parameters(), policy.executor(),
-                hpx::chrono::null_duration, (std::min) (len1, len2));
+                hpx::chrono::null_duration, (std::min)(len1, len2));
 
         // an entirely empty first range still needs exactly one chunk to
         // route the degenerate case through below -- without this, a hint
         // of 0 (from (std::min)(len1, len2) == 0) can make the partitioner
         // allocate zero chunks and the special case below would never run
-        cores = (std::max) (cores, static_cast<std::size_t>(1));
+        cores = (std::max)(cores, static_cast<std::size_t>(1));
 
-        std::size_t const step =
-            len1 == 0 ? 0 : (len1 + cores - 1) / cores;
+        std::size_t const step = len1 == 0 ? 0 : (len1 + cores - 1) / cores;
 
         std::shared_ptr<buffer_type[]> buffer(
             new buffer_type[combiner(len1, len2)]);
@@ -160,7 +159,7 @@ namespace hpx::parallel::detail {
             // find start in sequence 1
             std::size_t start1 = (curr_chunk - chunks.get()) * step;
             std::size_t end1 =
-                (std::min) (start1 + step, static_cast<std::size_t>(len1));
+                (std::min)(start1 + step, static_cast<std::size_t>(len1));
 
             if (start1 >= end1)
             {
@@ -265,21 +264,21 @@ namespace hpx::parallel::detail {
                 chunk->start_index = curr_chunk->start_index + curr_chunk->len;
                 if (curr_chunk->first1 != static_cast<std::size_t>(-1))
                 {
-                    first1_pos = (std::max) (first1_pos, curr_chunk->first1);
+                    first1_pos = (std::max)(first1_pos, curr_chunk->first1);
                 }
                 if (curr_chunk->first2 != static_cast<std::size_t>(-1))
                 {
-                    first2_pos = (std::max) (first2_pos, curr_chunk->first2);
+                    first2_pos = (std::max)(first2_pos, curr_chunk->first2);
                 }
             }
 
             if (chunk->first1 != set_chunk_data::uninit_first1)
             {
-                first1_pos = (std::max) (first1_pos, chunk->first1);
+                first1_pos = (std::max)(first1_pos, chunk->first1);
             }
             if (chunk->first2 != set_chunk_data::uninit_first2)
             {
-                first2_pos = (std::max) (first2_pos, chunk->first2);
+                first2_pos = (std::max)(first2_pos, chunk->first2);
             }
 
             // finally, copy data to destination

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/set_symmetric_difference.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/set_symmetric_difference.hpp
@@ -283,8 +283,7 @@ namespace hpx::parallel {
             template <typename ExPolicy, typename Iter1, typename Sent1,
                 typename Iter2, typename Sent2, typename Iter3, typename F,
                 typename Proj1, typename Proj2>
-            static util::detail::algorithm_result_t<ExPolicy,
-                util::in_in_out_result<Iter1, Iter2, Iter3>>
+            static decltype(auto)
             parallel(ExPolicy&& policy, Iter1 first1, Sent1 last1, Iter2 first2,
                 Sent2 last2, Iter3 dest, F&& f, Proj1&& proj1, Proj2&& proj2)
             {
@@ -293,26 +292,14 @@ namespace hpx::parallel {
                 using difference_type2 =
                     typename std::iterator_traits<Iter2>::difference_type;
 
-                using result_type = util::in_in_out_result<Iter1, Iter2, Iter3>;
-
-                if (first1 == last1)
-                {
-                    return util::detail::convert_to_result(
-                        detail::copy<util::in_out_result<Iter2, Iter3>>().call(
-                            HPX_FORWARD(ExPolicy, policy), first2, last2, dest),
-                        [first1](util::in_out_result<Iter2, Iter3> const& p)
-                            -> result_type { return {first1, p.in, p.out}; });
-                }
-
-                if (first2 == last2)
-                {
-                    return util::detail::convert_to_result(
-                        detail::copy<util::in_out_result<Iter1, Iter3>>().call(
-                            HPX_FORWARD(ExPolicy, policy), first1, last1, dest),
-                        [first2](util::in_out_result<Iter1, Iter3> const& p)
-                            -> result_type { return {p.in, first2, p.out}; });
-                }
-
+                // NOTE: no early-exit special-casing here for first1==last1
+                // or first2==last2. set_operation() itself now handles both
+                // degenerate cases correctly (including len1==0, which is
+                // NOT equivalent to an empty result for symmetric
+                // difference -- see the fix in detail/set_operation.hpp).
+                // Keeping a single return statement here also avoids
+                // decltype(auto) needing to unify divergent sender types
+                // across multiple branches for the S/R case.
                 using buffer_type = typename set_operations_buffer<Iter3>::type;
                 using func_type = std::decay_t<F>;
 
@@ -362,8 +349,7 @@ namespace hpx {
                 >
             )
         // clang-format on
-        static hpx::parallel::util::detail::algorithm_result_t<ExPolicy,
-            FwdIter3>
+        static decltype(auto)
         invoke_default(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
             FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, Pred op = Pred())
         {

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/set_symmetric_difference.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/set_symmetric_difference.hpp
@@ -283,9 +283,9 @@ namespace hpx::parallel {
             template <typename ExPolicy, typename Iter1, typename Sent1,
                 typename Iter2, typename Sent2, typename Iter3, typename F,
                 typename Proj1, typename Proj2>
-            static decltype(auto)
-            parallel(ExPolicy&& policy, Iter1 first1, Sent1 last1, Iter2 first2,
-                Sent2 last2, Iter3 dest, F&& f, Proj1&& proj1, Proj2&& proj2)
+            static decltype(auto) parallel(ExPolicy&& policy, Iter1 first1,
+                Sent1 last1, Iter2 first2, Sent2 last2, Iter3 dest, F&& f,
+                Proj1&& proj1, Proj2&& proj2)
             {
                 using difference_type1 =
                     typename std::iterator_traits<Iter1>::difference_type;
@@ -349,9 +349,9 @@ namespace hpx {
                 >
             )
         // clang-format on
-        static decltype(auto)
-        invoke_default(ExPolicy&& policy, FwdIter1 first1, FwdIter1 last1,
-            FwdIter2 first2, FwdIter2 last2, FwdIter3 dest, Pred op = Pred())
+        static decltype(auto) invoke_default(ExPolicy&& policy, FwdIter1 first1,
+            FwdIter1 last1, FwdIter2 first2, FwdIter2 last2, FwdIter3 dest,
+            Pred op = Pred())
         {
             static_assert(std::forward_iterator<FwdIter1>,
                 "Requires at least forward iterator.");

--- a/libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt
@@ -215,6 +215,7 @@ set(sender_tests
     search_sender
     set_difference_sender
     set_intersection_sender
+    set_symmetric_difference_sender
     shift_left_sender
     shift_right_sender
     starts_with_sender

--- a/libs/core/algorithms/tests/unit/algorithms/set_symmetric_difference_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/set_symmetric_difference_sender.cpp
@@ -1,0 +1,249 @@
+//  Copyright (c) 2015-2020 Hartmut Kaiser
+//  Copyright (c) 2026 udaykiriti
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/algorithm.hpp>
+#include <hpx/execution.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdlib>
+#include <ctime>
+#include <iostream>
+#include <iterator>
+#include <string>
+#include <vector>
+
+#include "test_utils.hpp"
+
+// default comparison (operator<)
+template <typename LnPolicy, typename ExPolicy, typename IteratorTag>
+void test_set_symmetric_difference_sender(
+    LnPolicy ln_policy, ExPolicy&& ex_policy, IteratorTag)
+{
+    static_assert(hpx::is_async_execution_policy_v<ExPolicy>,
+        "hpx::is_async_execution_policy_v<ExPolicy>");
+
+    using base_iterator = std::vector<std::size_t>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+    using scheduler_t = ex::thread_pool_policy_scheduler<LnPolicy>;
+
+    std::vector<std::size_t> c1 = test::random_fill(10007);
+    std::vector<std::size_t> c2 = test::random_fill(c1.size());
+    std::sort(std::begin(c1), std::end(c1));
+    std::sort(std::begin(c2), std::end(c2));
+
+    std::vector<std::size_t> c3(c1.size() + c2.size());
+    std::vector<std::size_t> c4(c1.size() + c2.size());
+
+    auto exec = ex::explicit_scheduler_executor(scheduler_t(ln_policy));
+
+    auto result =
+        tt::sync_wait(ex::just(iterator(std::begin(c1)), iterator(std::end(c1)),
+                          std::begin(c2), std::end(c2), std::begin(c3)) |
+            hpx::set_symmetric_difference(ex_policy.on(exec)));
+
+    auto const expected_last = std::set_symmetric_difference(std::begin(c1),
+        std::end(c1), std::begin(c2), std::end(c2), std::begin(c4));
+
+    // the returned destination iterator marks the end of the produced range
+    auto const count = std::distance(std::begin(c4), expected_last);
+    auto const result_last = hpx::get<0>(result.value());
+    HPX_TEST(result_last == std::begin(c3) + count);
+
+    // verify values
+    HPX_TEST(std::equal(std::begin(c3), result_last, std::begin(c4)));
+}
+
+// custom comparator (operator>) -- exercises the F predicate through the
+// sender pipeline
+template <typename LnPolicy, typename ExPolicy, typename IteratorTag>
+void test_set_symmetric_difference_sender_comp(
+    LnPolicy ln_policy, ExPolicy&& ex_policy, IteratorTag)
+{
+    static_assert(hpx::is_async_execution_policy_v<ExPolicy>,
+        "hpx::is_async_execution_policy_v<ExPolicy>");
+
+    using base_iterator = std::vector<std::size_t>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+    using scheduler_t = ex::thread_pool_policy_scheduler<LnPolicy>;
+
+    auto const comp = [](std::size_t lhs, std::size_t rhs) {
+        return lhs > rhs;
+    };
+
+    std::vector<std::size_t> c1 = test::random_fill(10007);
+    std::vector<std::size_t> c2 = test::random_fill(c1.size());
+    std::sort(std::begin(c1), std::end(c1), comp);
+    std::sort(std::begin(c2), std::end(c2), comp);
+
+    std::vector<std::size_t> c3(c1.size() + c2.size());
+    std::vector<std::size_t> c4(c1.size() + c2.size());
+
+    auto exec = ex::explicit_scheduler_executor(scheduler_t(ln_policy));
+
+    auto result =
+        tt::sync_wait(ex::just(iterator(std::begin(c1)), iterator(std::end(c1)),
+                          std::begin(c2), std::end(c2), std::begin(c3), comp) |
+            hpx::set_symmetric_difference(ex_policy.on(exec)));
+
+    auto const expected_last = std::set_symmetric_difference(std::begin(c1),
+        std::end(c1), std::begin(c2), std::end(c2), std::begin(c4), comp);
+
+    auto const count = std::distance(std::begin(c4), expected_last);
+    auto const result_last = hpx::get<0>(result.value());
+    HPX_TEST(result_last == std::begin(c3) + count);
+
+    HPX_TEST(std::equal(std::begin(c3), result_last, std::begin(c4)));
+}
+
+// degenerate ranges -- both empty inputs flow through set_operation's
+// sentinel-initialized set_chunk_data instead of an early return
+template <typename LnPolicy, typename ExPolicy, typename IteratorTag>
+void test_set_symmetric_difference_sender_empty(
+    LnPolicy ln_policy, ExPolicy&& ex_policy, IteratorTag)
+{
+    static_assert(hpx::is_async_execution_policy_v<ExPolicy>,
+        "hpx::is_async_execution_policy_v<ExPolicy>");
+
+    using base_iterator = std::vector<std::size_t>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+    using scheduler_t = ex::thread_pool_policy_scheduler<LnPolicy>;
+
+    auto exec = ex::explicit_scheduler_executor(scheduler_t(ln_policy));
+
+    // empty first range -> result equals second range
+    {
+        std::vector<std::size_t> c1;
+        std::vector<std::size_t> c2 = test::random_fill(10007);
+        std::sort(std::begin(c2), std::end(c2));
+        std::vector<std::size_t> c3(c2.size());
+
+        auto result = tt::sync_wait(
+            ex::just(iterator(std::begin(c1)), iterator(std::end(c1)),
+                std::begin(c2), std::end(c2), std::begin(c3)) |
+            hpx::set_symmetric_difference(ex_policy.on(exec)));
+
+        auto const result_last = hpx::get<0>(result.value());
+        HPX_TEST(result_last == std::begin(c3) + c2.size());
+        HPX_TEST(std::equal(std::begin(c3), result_last, std::begin(c2)));
+    }
+
+    // empty second range -> result equals first range
+    {
+        std::vector<std::size_t> c1 = test::random_fill(10007);
+        std::sort(std::begin(c1), std::end(c1));
+        std::vector<std::size_t> c2;
+        std::vector<std::size_t> c3(c1.size());
+
+        auto result = tt::sync_wait(
+            ex::just(iterator(std::begin(c1)), iterator(std::end(c1)),
+                std::begin(c2), std::end(c2), std::begin(c3)) |
+            hpx::set_symmetric_difference(ex_policy.on(exec)));
+
+        auto const result_last = hpx::get<0>(result.value());
+        HPX_TEST(result_last == std::begin(c3) + c1.size());
+        HPX_TEST(std::equal(std::begin(c3), result_last, std::begin(c1)));
+    }
+
+    // both ranges empty -> empty result, dest unchanged
+    {
+        std::vector<std::size_t> c1;
+        std::vector<std::size_t> c2;
+        std::vector<std::size_t> c3(1, static_cast<std::size_t>(-1));
+
+        auto result = tt::sync_wait(
+            ex::just(iterator(std::begin(c1)), iterator(std::end(c1)),
+                std::begin(c2), std::end(c2), std::begin(c3)) |
+            hpx::set_symmetric_difference(ex_policy.on(exec)));
+
+        auto const result_last = hpx::get<0>(result.value());
+        HPX_TEST(result_last == std::begin(c3));
+        HPX_TEST_EQ(c3[0], static_cast<std::size_t>(-1));
+    }
+}
+
+template <typename IteratorTag>
+void set_symmetric_difference_sender_test()
+{
+    using namespace hpx::execution;
+    test_set_symmetric_difference_sender(
+        hpx::launch::sync, seq(task), IteratorTag());
+    test_set_symmetric_difference_sender(
+        hpx::launch::sync, unseq(task), IteratorTag());
+    test_set_symmetric_difference_sender(
+        hpx::launch::async, par(task), IteratorTag());
+    test_set_symmetric_difference_sender(
+        hpx::launch::async, par_unseq(task), IteratorTag());
+
+    test_set_symmetric_difference_sender_comp(
+        hpx::launch::sync, seq(task), IteratorTag());
+    test_set_symmetric_difference_sender_comp(
+        hpx::launch::sync, unseq(task), IteratorTag());
+    test_set_symmetric_difference_sender_comp(
+        hpx::launch::async, par(task), IteratorTag());
+    test_set_symmetric_difference_sender_comp(
+        hpx::launch::async, par_unseq(task), IteratorTag());
+
+    test_set_symmetric_difference_sender_empty(
+        hpx::launch::sync, seq(task), IteratorTag());
+    test_set_symmetric_difference_sender_empty(
+        hpx::launch::sync, unseq(task), IteratorTag());
+    test_set_symmetric_difference_sender_empty(
+        hpx::launch::async, par(task), IteratorTag());
+    test_set_symmetric_difference_sender_empty(
+        hpx::launch::async, par_unseq(task), IteratorTag());
+}
+
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = static_cast<unsigned int>(std::time(nullptr));
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    set_symmetric_difference_sender_test<std::forward_iterator_tag>();
+    set_symmetric_difference_sender_test<std::random_access_iterator_tag>();
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
Adds S/R support for set_symmetric_difference (issue #6535).

* Fix set_operation(): an entirely empty first range collapsed the chunk step to 0, so every chunk bailed out before calling setop, silently producing an empty result. Invisible for set_difference/set_intersection (empty output is correct there), but wrong for set_symmetric_difference, whose correct result in that case is the full second range. Now routes len1 == 0 through a single synthetic chunk against the full second range instead.
* Widen set_symmetric_difference::parallel() and the CPO's invoke_default return types to decltype(auto) so the scheduler-executor sender passes through
* Drop empty-range early returns from parallel(); set_operation now handles them correctly on its own
* New sender tests + CMakeLists.txt


