### PR TITLE
Adding hpx::force_disconnect to support the use case described in #7441

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,15 @@ if(HPX_WITH_FAULT_TOLERANCE)
   hpx_add_config_define(HPX_HAVE_FAULT_TOLERANCE)
 endif()
 
+hpx_option(
+  HPX_WITH_FORCE_DISCONNECT BOOL
+  "Build HPX to support forceful disconnect of localities (default: OFF)" OFF
+  ADVANCED
+)
+if(HPX_WITH_FORCE_DISCONNECT)
+  hpx_add_config_define(HPX_HAVE_FORCE_DISCONNECT)
+endif()
+
 # Compiler related build options
 hpx_option(
   HPX_WITH_GCC_VERSION_CHECK BOOL

--- a/components/supervision_dispatch/src/dispatch_api.cpp
+++ b/components/supervision_dispatch/src/dispatch_api.cpp
@@ -165,35 +165,34 @@ namespace {
         hpx::id_type const& here = hpx::find_here();
         auto local_registry = hpx::supervision::registry(here);
 
-        try
-        {
-            // New, strictly increasing epoch for this cycle's event::start
-            // publication.
-            std::uint64_t const new_epoch = ++ds.epoch_;
-            hpx::supervision::publish_event(
-                here, hpx::supervision::event::started, new_epoch);
+        hpx::detail::try_catch_exception_ptr(
+            [&]() {
+                // New, strictly increasing epoch for this cycle's event::start
+                // publication.
+                std::uint64_t const new_epoch = ++ds.epoch_;
+                hpx::supervision::publish_event(
+                    here, hpx::supervision::event::started, new_epoch);
 
-            // Step 3: register symbol name.
-            local_registry.register_name(hpx::launch::sync);
+                // Step 3: register symbol name.
+                local_registry.register_name(hpx::launch::sync);
 
-            // Step 4: single reactive discover_and_join() pass.
-            discover_and_join(local_registry, discovery_timeout);
+                // Step 4: single reactive discover_and_join() pass.
+                discover_and_join(local_registry, discovery_timeout);
 
-            // Success: install the pair for finalize() and is_initialized()
-            // to observe.
-            {
-                std::scoped_lock<hpx::spinlock> l(ds.mtx_);
-                ds.registry_ = HPX_MOVE(local_registry);
-            }
-        }
-        catch (...)
-        {
-            // Step 5: unregister both names, best-effort.
-            hpx::error_code ec1(hpx::throwmode::lightweight);
-            local_registry.unregister_name(hpx::launch::sync, ec1);
+                // Success: install the pair for finalize() and is_initialized()
+                // to observe.
+                {
+                    std::scoped_lock<hpx::spinlock> l(ds.mtx_);
+                    ds.registry_ = HPX_MOVE(local_registry);
+                }
+            },
+            [&](std::exception_ptr const& e) {
+                // Step 5: unregister both names, best-effort.
+                hpx::error_code ec1(hpx::throwmode::lightweight);
+                local_registry.unregister_name(hpx::launch::sync, ec1);
 
-            std::rethrow_exception(std::current_exception());
-        }
+                std::rethrow_exception(e);
+            });
     }
 
     bool needs_stopping(std::atomic<bool> const& flag,
@@ -506,40 +505,42 @@ namespace {
                 auto cont = [peer, epoch = state.epoch,
                                 seq = state.event_sequence_number,
                                 poll_timeout](auto&& f) {
-                    try
-                    {
-                        f.get();    // success: real terminal event delivered
-                    }
-                    catch (hpx::exception const& e)
-                    {
-                        if (e.get_error() != hpx::error::future_cancelled)
-                            return;
+                    hpx::detail::try_catch_exception_ptr<hpx::exception>(
+                        [&]() {
+                            // success: real terminal event delivered
+                            f.get();
+                        },
+                        [&](hpx::exception const& e) {
+                            if (e.get_error() != hpx::error::future_cancelled)
+                                return;
 
-                        if (!stalled_after_grace(
-                                seq, peer, epoch, poll_timeout))
-                            return;    // not stalled (yet)
+                            if (!stalled_after_grace(
+                                    seq, peer, epoch, poll_timeout))
+                                return;    // not stalled (yet)
 
-                        // No progress since the wait started: genuine stall.
-                        // Before fencing, re-confirm the target still has
-                        // *this* epoch open - remove_target() on the peer may
-                        // have erased its states_ entry in the interim (e.g.
-                        // the peer left/rejoined), in which case a `failed`
-                        // fence would be rejected as an illegal new-epoch
-                        // opener. Treat that as a no-op, mirroring the state.ec
-                        // branch above.
-                        hpx::error_code ec_check(hpx::throwmode::lightweight);
-                        auto const recheck = hpx::supervision::query_state(
-                            peer.peer_locality, ec_check);
-                        if (ec_check || recheck.ec || recheck.epoch != epoch)
-                            return;
+                            // No progress since the wait started: genuine
+                            // stall. Before fencing, re-confirm the target
+                            // still has *this* epoch open - remove_target() on
+                            // the peer may have erased its states_ entry in the
+                            // interim (e.g. the peer left/rejoined), in which
+                            // case a `failed` fence would be rejected as an
+                            // illegal new-epoch opener. Treat that as a no-op,
+                            // mirroring the state.ec branch above.
+                            hpx::error_code ec_check(
+                                hpx::throwmode::lightweight);
+                            auto const recheck = hpx::supervision::query_state(
+                                peer.peer_locality, ec_check);
+                            if (ec_check || recheck.ec ||
+                                recheck.epoch != epoch)
+                                return;
 
-                        // No progress since the wait started: genuine stall.
-                        // Fence locally only, never touch the peer's own
-                        // registry.
-                        hpx::error_code ec3(hpx::throwmode::lightweight);
-                        hpx::supervision::publish_event(peer.peer_locality,
-                            hpx::supervision::event::failed, epoch, ec3);
-                    }
+                            // No progress since the wait started: genuine
+                            // stall. Fence locally only, never touch the peer's
+                            // own registry.
+                            hpx::error_code ec3(hpx::throwmode::lightweight);
+                            hpx::supervision::publish_event(peer.peer_locality,
+                                hpx::supervision::event::failed, epoch, ec3);
+                        });
                 };
 
                 checks.push_back(hpx::supervision::await_terminal(
@@ -929,25 +930,24 @@ namespace hpx::supervision {
         auto const epoch = ds.epoch_.load(std::memory_order_acquire);
 
         std::exception_ptr publish_failure;
-        try
-        {
-            auto const here = hpx::find_here();
-            if (auto const state = hpx::supervision::query_state(here);
-                state.last_event == hpx::supervision::event::started)
-            {
+        hpx::detail::try_catch_exception_ptr(
+            [&]() {
+                auto const here = hpx::find_here();
+                if (auto const state = hpx::supervision::query_state(here);
+                    state.last_event == hpx::supervision::event::started)
+                {
+                    hpx::supervision::publish_event(
+                        here, hpx::supervision::event::running, epoch);
+                }
                 hpx::supervision::publish_event(
-                    here, hpx::supervision::event::running, epoch);
-            }
-            hpx::supervision::publish_event(
-                here, hpx::supervision::event::completed, epoch);
-        }
-        catch (...)
-        {
-            // Best-effort: still unregister/re-arm below even if event
-            // publication failed, so a transient failure never permanently
-            // strands the lifecycle at `finalizing`.
-            publish_failure = std::current_exception();
-        }
+                    here, hpx::supervision::event::completed, epoch);
+            },
+            [&](std::exception_ptr const& e) {
+                // Best-effort: still unregister/re-arm below even if event
+                // publication failed, so a transient failure never permanently
+                // strands the lifecycle at `finalizing`.
+                publish_failure = e;
+            });
 
         // Unregister registry name before releasing ownership, so no new peer
         // can discover either component mid-teardown.

--- a/components/supervision_dispatch/src/server/registry_server.cpp
+++ b/components/supervision_dispatch/src/server/registry_server.cpp
@@ -112,148 +112,143 @@ namespace hpx::supervision::server {
     std::pair<hpx::id_type, hpx::id_type> registry::register_observers(
         hpx::id_type const& peer_locality, std::uint64_t join_epoch)
     {
+        // Register for lifecycle-event notifications published for the
+        // peer's locality. Terminal notifications are re-published onto
+        // peer_locality's local supervision state (see below).
+        auto observer =
+            [peer_locality, join_epoch, this, keep_alive = get_id()](
+                hpx::supervision::lifecycle_event_notification const&
+                    notification) mutable {
+                // Read peer_locality's current local epoch/state before
+                // mirroring. If it hasn't been seeded yet (epoch mismatch or
+                // still "unknown"), open its epoch with `started` at the
+                // *peer's* epoch instead of assuming epoch 0. This keeps
+                // apply_new_epoch_locked()'s "new epoch must begin with
+                // started" invariant satisfied even when the peer joins
+                // mid-epoch.
+                hpx::error_code ec(hpx::throwmode::lightweight);
+                auto const local_state =
+                    hpx::supervision::query_state(peer_locality, ec);
+
+                // Both mirroring publishes below go through
+                // publish_event_no_notify() rather than publish_event(): this
+                // callback is itself registered as an observer for
+                // peer_locality, so a notifying re-publish into that same local
+                // manager entry would synchronously re-invoke this very
+                // observer, regardless of whether peer_locality names a
+                // different locality than L or not (the register_observer()/
+                // publish_event() pair operate on a single local per-target
+                // observer list, not one scoped per remote manager instance).
+                // publish_event_no_notify() performs the same state mutation
+                // without delivering to observers_, so it cannot re-trigger
+                // this callback.
+                if (ec ||
+                    local_state.last_event ==
+                        hpx::supervision::event::unknown ||
+                    local_state.epoch < notification.epoch)
+                {
+                    hpx::error_code ec1(hpx::throwmode::lightweight);
+                    hpx::supervision::publish_event_no_notify(peer_locality,
+                        hpx::supervision::event::started, notification.epoch,
+                        ec1);
+                }
+
+                // join()'s floor against the peer's real epoch (see the comment
+                // on register_observers() above) only covers what could be
+                // observed synchronously at join time; if this notification's
+                // epoch has since moved strictly ahead of the captured
+                // `join_epoch`, correct both the local capture and the stored
+                // peers_ entry forward to match, so snapshot_peers()/ leave()/
+                // evict_peer() do not keep keying off a stale seed. Guarded to
+                // only ever move forward (never on a lower or equal
+                // notification epoch), and to only take effect if `peers_`
+                // still holds the very entry this callback was registered for
+                // (i.e. it has not since been re-joined at a fresh epoch of its
+                // own).
+                if (notification.epoch > join_epoch)
+                {
+                    std::scoped_lock<hpx::spinlock> l(mtx_);
+                    if (auto const it = peers_.find(peer_locality);
+                        it != peers_.end() &&
+                        it->second.join_epoch == join_epoch)
+                    {
+                        it->second.join_epoch = notification.epoch;
+                    }
+                    join_epoch = notification.epoch;
+                }
+
+                // Mirror the peer's event onto peer_locality's local state at
+                // the same epoch it actually occurred in. This callback itself
+                // always runs on L (the dispatching locality that owns this
+                // registry/agent, regardless of where the peer lives - see the
+                // comment on register_observers() above), and the
+                // publish_event_no_notify() call below is the local-only,
+                // non-notifying overload, i.e. it writes into L's own local
+                // supervision_manager keyed by peer_locality without delivering
+                // to that entry's registered observers (see the comment above
+                // explaining why a notifying publish would self-recurse into
+                // this very callback).
+                {
+                    hpx::error_code ec2(hpx::throwmode::lightweight);
+                    hpx::supervision::publish_event_no_notify(peer_locality,
+                        notification.event, notification.epoch, ec2);
+                }
+
+                // Evict the peer if it has reached a terminal event, so peers_
+                // does not grow without bound over the lifetime of a
+                // long-running registry. Deferred via hpx::post() rather than
+                // done inline here: this callback intentionally avoids taking
+                // mtx_ (see the comment on register_observers() above
+                // explaining why `peer_locality` is captured by value), so the
+                // eviction - which does need mtx_ to safely mutate peers_ -
+                // runs as a separate task once this terminal publish has
+                // completed.
+                if (hpx::supervision::is_terminal(notification.event))
+                {
+                    // Preserve the mirrored terminal state just published above
+                    // as a tombstone (see cleanup_peer()): an admission check
+                    // racing against this eviction must keep observing the
+                    // fence rather than have it vanish once eviction runs.
+                    hpx::post(&registry::evict_peer, this, peer_locality,
+                        join_epoch, keep_alive, true);
+                }
+                return true;
+            };
+
         hpx::id_type activity_observer;
         hpx::id_type lifecycle_observer;
-        try
-        {
-            // Register for lifecycle-event notifications published for the
-            // peer's locality. Terminal notifications are re-published onto
-            // peer_locality's local supervision state (see below).
-            auto observer =
-                [peer_locality, join_epoch, this, keep_alive = get_id()](
-                    hpx::supervision::lifecycle_event_notification const&
-                        notification) mutable {
-                    // Read peer_locality's current local epoch/state before
-                    // mirroring. If it hasn't been seeded yet (epoch mismatch
-                    // or still "unknown"), open its epoch with `started` at the
-                    // *peer's* epoch instead of assuming epoch 0. This keeps
-                    // apply_new_epoch_locked()'s "new epoch must begin with
-                    // started" invariant satisfied even when the peer joins
-                    // mid-epoch.
-                    auto const& here = hpx::find_here();
 
-                    hpx::error_code ec(hpx::throwmode::lightweight);
-                    auto const local_state =
-                        hpx::supervision::query_state(peer_locality, ec);
+        hpx::detail::try_catch_exception_ptr(
+            [&] {
+                // Register ourselves as an observer for the peer's locality the
+                // its locality. This enables mirroring the peer's lifecycle
+                // events to here.
+                lifecycle_observer =
+                    hpx::supervision::register_observer(hpx::launch::sync,
+                        peer_locality, peer_locality, HPX_MOVE(observer));
 
-                    // Both mirroring publishes below go through
-                    // publish_event_no_notify() rather than publish_event():
-                    // this callback is itself registered as an observer for
-                    // peer_locality, so a notifying re-publish into that same
-                    // local manager entry would synchronously re-invoke this
-                    // very observer, regardless of whether peer_locality names
-                    // a different locality than L or not (the
-                    // register_observer()/publish_event() pair operate on a
-                    // single local per-target observer list, not one scoped per
-                    // remote manager instance). publish_event_no_notify()
-                    // performs the same state mutation without delivering to
-                    // observers_, so it cannot re-trigger this callback.
-                    if (ec ||
-                        local_state.last_event ==
-                            hpx::supervision::event::unknown ||
-                        local_state.epoch < notification.epoch)
-                    {
-                        hpx::error_code ec1(hpx::throwmode::lightweight);
-                        hpx::supervision::publish_event_no_notify(peer_locality,
-                            hpx::supervision::event::started,
-                            notification.epoch, ec1);
-                    }
+                // Register for activity-state transitions of any target tracked
+                // on the peer's locality (this includes the peer locality
+                // itself). activity_notification carries an active/inactive
+                // transition, not a lifecycle event, so it has no natural
+                // mapping onto peer_locality's publish_event()-driven
+                // terminal-latch state; it intentionally remains a no-op for
+                // this task and is left for a later task to decide whether/how
+                // activity transitions should feed into dispatch decisions.
+                activity_observer =
+                    hpx::supervision::register_activity_observer(launch::sync,
+                        peer_locality,
+                        [](activity_notification const&) { return true; });
+            },
+            [&](std::exception_ptr const& original) {
+                // The activity-observer registration failed after the lifecycle
+                // observer was registered successfully; unregister both again
+                // so neither is leaked on the peer's locality.
+                unregister_observers(
+                    peer_locality, lifecycle_observer, activity_observer);
 
-                    // join()'s floor against the peer's real epoch (see the
-                    // comment on register_observers() above) only covers what
-                    // could be observed synchronously at join time; if this
-                    // notification's epoch has since moved strictly ahead of
-                    // the captured `join_epoch`, correct both the local capture
-                    // and the stored peers_ entry forward to match, so
-                    // snapshot_peers()/leave()/evict_peer() do not keep keying
-                    // off a stale seed. Guarded to only ever move forward
-                    // (never on a lower or equal notification epoch), and to
-                    // only take effect if `peers_` still holds the very entry
-                    // this callback was registered for (i.e. it has not since
-                    // been re-joined at a fresh epoch of its own).
-                    if (notification.epoch > join_epoch)
-                    {
-                        std::scoped_lock<hpx::spinlock> l(mtx_);
-                        if (auto const it = peers_.find(peer_locality);
-                            it != peers_.end() &&
-                            it->second.join_epoch == join_epoch)
-                        {
-                            it->second.join_epoch = notification.epoch;
-                        }
-                        join_epoch = notification.epoch;
-                    }
-
-                    // Mirror the peer's event onto peer_locality's local state
-                    // at the same epoch it actually occurred in. This callback
-                    // itself always runs on L (the dispatching locality that
-                    // owns this registry/agent, regardless of where the peer
-                    // lives - see the comment on register_observers() above),
-                    // and the publish_event_no_notify() call below is the
-                    // local-only, non-notifying overload, i.e. it writes into
-                    // L's own local supervision_manager keyed by
-                    // peer_locality without delivering to that entry's
-                    // registered observers (see the comment above explaining
-                    // why a notifying publish would self-recurse into this
-                    // very callback).
-                    {
-                        hpx::error_code ec2(hpx::throwmode::lightweight);
-                        hpx::supervision::publish_event_no_notify(peer_locality,
-                            notification.event, notification.epoch, ec2);
-                    }
-
-                    // Evict the peer if it has reached a terminal event, so
-                    // peers_ does not grow without bound over the lifetime of a
-                    // long-running registry. Deferred via hpx::post() rather
-                    // than done inline here: this callback intentionally avoids
-                    // taking mtx_ (see the comment on register_observers()
-                    // above explaining why `peer_locality` is captured by
-                    // value), so the eviction - which does need mtx_ to safely
-                    // mutate peers_ - runs as a separate task once this
-                    // terminal publish has completed.
-                    if (hpx::supervision::is_terminal(notification.event))
-                    {
-                        // Preserve the mirrored terminal state just published
-                        // above as a tombstone (see cleanup_peer()): an
-                        // admission check racing against this eviction must
-                        // keep observing the fence rather than have it vanish
-                        // once eviction runs.
-                        hpx::post(&registry::evict_peer, this, peer_locality,
-                            join_epoch, keep_alive, true);
-                    }
-                    return true;
-                };
-
-            // Register ourselves as an observer for the peer's locality  the
-            // its locality. This enables mirroring the peer's lifecycle events
-            // to here.
-            lifecycle_observer =
-                hpx::supervision::register_observer(hpx::launch::sync,
-                    peer_locality, peer_locality, HPX_MOVE(observer));
-
-            // Register for activity-state transitions of any target tracked on
-            // the peer's locality (this includes the peer locality itself).
-            // activity_notification carries an active/inactive transition, not
-            // a lifecycle event, so it has no natural mapping onto
-            // peer_locality's publish_event()-driven terminal-latch state; it
-            // intentionally remains a no-op for this task and is left for a
-            // later task to decide whether/how activity transitions should
-            // feed into dispatch decisions.
-            activity_observer = hpx::supervision::register_activity_observer(
-                launch::sync, peer_locality,
-                [](activity_notification const&) { return true; });
-        }
-        catch (...)
-        {
-            std::exception_ptr const original = std::current_exception();
-
-            // The activity-observer registration failed after the lifecycle
-            // observer was registered successfully; unregister both again so
-            // neither is leaked on the peer's locality.
-            unregister_observers(
-                peer_locality, lifecycle_observer, activity_observer);
-
-            std::rethrow_exception(original);
-        }
+                std::rethrow_exception(original);
+            });
 
         return std::make_pair(lifecycle_observer, activity_observer);
     }
@@ -322,128 +317,128 @@ namespace hpx::supervision::server {
 
         hpx::id_type lifecycle_observer;
         hpx::id_type activity_observer;
-        std::uint64_t reported_join_epoch;
+        std::uint64_t reported_join_epoch = 0;
         bool need_publish_started = true;
-        try
-        {
-            // join() itself must not rely solely on a future notification to
-            // establish peer_locality's initial started state (see the
-            // registered observer callback in register_observers() above).
-            //
-            // Query peer_locality's own current shadow state here - not
-            // peer_locality's unrelated per-target state - since that is
-            // what publish_event() below is about to mutate. A freshly
-            // joined peer_locality always reports "unknown"/epoch 0, which
-            // would otherwise make this always seed at epoch 0 regardless
-            // of what state peer_locality's shared shadow is actually in
-            // (e.g. still "failed" from a previous, not yet evicted, peer
-            // occupying the same shadow).
 
-            std::uint64_t seed_epoch;
-            {
-                hpx::error_code ec(hpx::throwmode::lightweight);
-                auto const local_state =
-                    hpx::supervision::query_state(peer_locality, ec);
-
-                seed_epoch = !ec ? local_state.epoch : 0;
-                if (!ec)
-                {
-                    if (hpx::supervision::is_terminal(local_state.last_event))
-                    {
-                        // Prior occupant of this shadow reached a terminal
-                        // state; start a fresh epoch for the newly joining
-                        // peer.
-                        seed_epoch = local_state.epoch + 1;
-                    }
-                    else if (local_state.last_event !=
-                        hpx::supervision::event::unknown)
-                    {
-                        // The shadow has already progressed past "unknown" in
-                        // the current epoch (e.g. "started", "running",
-                        // "suspending"); re-publishing "started" here would be
-                        // an illegal same-epoch transition. Treat this join as
-                        // idempotent and reuse the existing epoch without
-                        // republishing.
-                        need_publish_started = false;
-                    }
-                }
-
-                reported_join_epoch = seed_epoch;
-
-                // reported_join_epoch (returned to callers as
-                // joined_peer::join_epoch / peer_snapshot::join_epoch, and used
-                // by failure_detection_loop() to seed query_failures) tracks
-                // peer_locality's real dispatch-cycle epoch
-                // (hpx::supervision::current_epoch(), bumped once per
-                // successful init() on peer_locality itself) whenever that is
-                // ahead of the shadow's own epoch space - e.g. peer_locality
-                // completed init() well before this join() call ran, with no
-                // query_state()/publish_event() against it in between.
+        hpx::detail::try_catch_exception_ptr(
+            [&] {
+                // join() itself must not rely solely on a future notification to
+                // establish peer_locality's initial started state (see the
+                // registered observer callback in register_observers() above).
                 //
-                // seed_epoch itself must NOT be escalated here: it feeds
-                // publish_event(..., event::started, seed_epoch, ...) below and
-                // register_observers()'s join_epoch baseline, both of which
-                // must stay in the shadow's own epoch numbering so that
-                // peer_locality's own lifecycle events (which legitimately
-                // start at epoch 0 for a fresh locality) are not rejected as
-                // stale against an epoch borrowed from peer_locality's
-                // unrelated dispatch-cycle counter.
-                if (peer_locality)
+                // Query peer_locality's own current shadow state here - not
+                // peer_locality's unrelated per-target state - since that is
+                // what publish_event() below is about to mutate. A freshly
+                // joined peer_locality always reports "unknown"/epoch 0, which
+                // would otherwise make this always seed at epoch 0 regardless
+                // of what state peer_locality's shared shadow is actually in
+                // (e.g. still "failed" from a previous, not yet evicted, peer
+                // occupying the same shadow).
                 {
-                    hpx::error_code peer_ec(hpx::throwmode::lightweight);
-                    std::uint64_t const peer_epoch =
-                        hpx::supervision::current_epoch(
-                            hpx::launch::sync, peer_locality, peer_ec);
-                    if (!peer_ec && peer_epoch > reported_join_epoch)
+                    hpx::error_code ec(hpx::throwmode::lightweight);
+                    auto const local_state =
+                        hpx::supervision::query_state(peer_locality, ec);
+
+                    std::uint64_t seed_epoch = !ec ? local_state.epoch : 0;
+                    if (!ec)
                     {
-                        reported_join_epoch = peer_epoch;
+                        if (hpx::supervision::is_terminal(
+                                local_state.last_event))
+                        {
+                            // Prior occupant of this shadow reached a terminal
+                            // state; start a fresh epoch for the newly joining
+                            // peer.
+                            seed_epoch = local_state.epoch + 1;
+                        }
+                        else if (local_state.last_event !=
+                            hpx::supervision::event::unknown)
+                        {
+                            // The shadow has already progressed past "unknown"
+                            // in the current epoch (e.g. "started", "running",
+                            // "suspending"); re-publishing "started" here would
+                            // be an illegal same-epoch transition. Treat this
+                            // join as idempotent and reuse the existing epoch
+                            // without republishing.
+                            need_publish_started = false;
+                        }
+                    }
+
+                    reported_join_epoch = seed_epoch;
+
+                    // reported_join_epoch (returned to callers as
+                    // joined_peer::join_epoch / peer_snapshot::join_epoch, and
+                    // used by failure_detection_loop() to seed query_failures)
+                    // tracks peer_locality's real dispatch-cycle epoch
+                    // (hpx::supervision::current_epoch(), bumped once per
+                    // successful init() on peer_locality itself) whenever that
+                    // is ahead of the shadow's own epoch space - e.g.
+                    // peer_locality completed init() well before this join()
+                    // call ran, with no query_state()/publish_event() against
+                    // it in between.
+                    //
+                    // seed_epoch itself must NOT be escalated here: it feeds
+                    // publish_event(..., event::started, seed_epoch, ...) below
+                    // and register_observers()'s join_epoch baseline, both of
+                    // which must stay in the shadow's own epoch numbering so
+                    // that peer_locality's own lifecycle events (which
+                    // legitimately start at epoch 0 for a fresh locality) are
+                    // not rejected as stale against an epoch borrowed from
+                    // peer_locality's unrelated dispatch-cycle counter.
+                    if (peer_locality)
+                    {
+                        hpx::error_code peer_ec(hpx::throwmode::lightweight);
+                        std::uint64_t const peer_epoch =
+                            hpx::supervision::current_epoch(
+                                hpx::launch::sync, peer_locality, peer_ec);
+                        if (!peer_ec && peer_epoch > reported_join_epoch)
+                        {
+                            reported_join_epoch = peer_epoch;
+                        }
+                    }
+
+                    if (need_publish_started)
+                    {
+                        hpx::error_code ec1(hpx::throwmode::lightweight);
+                        hpx::supervision::publish_event(hpx::launch::sync,
+                            peer_locality, peer_locality,
+                            hpx::supervision::event::started, seed_epoch, ec1);
                     }
                 }
 
+                {
+                    std::scoped_lock<hpx::spinlock> l(mtx_);
+                    peers_.at(peer_locality).join_epoch = reported_join_epoch;
+                }
+
+                // Register for lifecycle-event notifications published for the
+                // peer's locality. The baseline must match the epoch recorded
+                // in `peers_` above, otherwise evict_peer()'s epoch guard and
+                // the callback's epoch-forward correction can never match.
+                std::tie(lifecycle_observer, activity_observer) =
+                    register_observers(peer_locality, reported_join_epoch);
+            },
+            [&](std::exception_ptr const& e) {
+                // Clean up any target state seeded by this failed join *before*
+                // releasing the reservation, so a concurrent join() for the
+                // same peer cannot have its freshly published state removed by
+                // this failed attempt.
                 if (need_publish_started)
                 {
-                    hpx::error_code ec1(hpx::throwmode::lightweight);
-                    hpx::supervision::publish_event(hpx::launch::sync,
-                        peer_locality, peer_locality,
-                        hpx::supervision::event::started, seed_epoch, ec1);
+                    hpx::error_code ec(hpx::throwmode::lightweight);
+                    hpx::supervision::remove_target(peer_locality, ec);
                 }
-            }
 
-            {
-                std::scoped_lock<hpx::spinlock> l(mtx_);
-                peers_.at(peer_locality).join_epoch = reported_join_epoch;
-            }
+                // Only now release the reservation made by reserve_ownership()
+                // above, so a concurrent join() for the same peer, waiting in
+                // cond_.wait(l), is not left hanging forever.
+                {
+                    std::unique_lock l(mtx_);
+                    peers_.erase(peer_locality);
+                    cond_.notify_all(HPX_MOVE(l));
+                }
 
-            // Register for lifecycle-event notifications published for the
-            // peer's locality. The baseline must match the epoch recorded in
-            // `peers_` above, otherwise evict_peer()'s epoch guard and the
-            // callback's epoch-forward correction can never match.
-            std::tie(lifecycle_observer, activity_observer) =
-                register_observers(peer_locality, reported_join_epoch);
-        }
-        catch (...)
-        {
-            // Clean up any target state seeded by this failed join *before*
-            // releasing the reservation, so a concurrent join() for the same
-            // peer cannot have its freshly published state removed by this
-            // failed attempt.
-            if (need_publish_started)
-            {
-                hpx::error_code ec(hpx::throwmode::lightweight);
-                hpx::supervision::remove_target(peer_locality, ec);
-            }
-
-            // Only now release the reservation made by reserve_ownership()
-            // above, so a concurrent join() for the same peer, waiting in
-            // cond_.wait(l), is not left hanging forever.
-            {
-                std::unique_lock l(mtx_);
-                peers_.erase(peer_locality);
-                cond_.notify_all(HPX_MOVE(l));
-            }
-
-            std::rethrow_exception(std::current_exception());
-        }
+                std::rethrow_exception(e);
+            });
 
         bool need_cleanup = false;
         bool preserve_terminal_state = false;

--- a/libs/core/errors/include/hpx/errors/try_catch_exception_ptr.hpp
+++ b/libs/core/errors/include/hpx/errors/try_catch_exception_ptr.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2021 ETH Zurich
+//  Copyright (c) 2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -9,6 +10,7 @@
 #include <hpx/config.hpp>
 
 #include <exception>
+#include <type_traits>
 #include <utility>
 
 namespace hpx::detail {
@@ -27,20 +29,85 @@ namespace hpx::detail {
     /// Note: Windows does not seem to have problems resuming a catch block on a
     /// different worker thread, but we use this nonetheless on Windows since it
     /// doesn't hurt.
-    HPX_CXX_CORE_EXPORT template <typename TryCallable, typename CatchCallable>
+    ///
+    /// \tparam ExceptionType The type of exception to catch. Defaults to
+    ///         \a void, in which case any exception is caught and captured as
+    ///         a \a std::exception_ptr via \a std::current_exception(). If a
+    ///         concrete type is given, only exceptions matching
+    ///         \a ExceptionType per C++ catch-clause matching rules (i.e. the
+    ///         thrown object's type is \a ExceptionType, or an unambiguous
+    ///         accessible public base thereof, modulo cv-qualification) are
+    ///         caught and forwarded by value. \a ExceptionType must be
+    ///         default-constructible and copy-assignable when a concrete type
+    ///         is used.
+    /// \tparam TryCallable A callable type with no parameters, invoked inside
+    ///         the try block.
+    /// \tparam CatchCallable A callable type taking a single parameter of type
+    ///         \a std::exception_ptr (when \a ExceptionType is \a void) or of
+    ///         type \a ExceptionType (otherwise), invoked with the captured
+    ///         exception after the try-catch block has completed.
+    ///
+    /// \param t The callable to invoke inside the try block. Its return value
+    ///          (if the try block does not throw) is returned directly from
+    ///          \a try_catch_exception_ptr.
+    /// \param c The callable to invoke with the captured exception if \a t
+    ///          throws a matching exception. Its return value is returned from
+    ///          \a try_catch_exception_ptr in that case.
+    ///
+    /// \return The result of invoking \a t() if no matching exception is
+    ///         thrown; otherwise, the result of invoking \a c() with the
+    ///         captured exception. Because the function returns
+    ///         \a decltype(auto), every return statement in both branches
+    ///         must deduce to the exact same type (after reference/cv folding);
+    ///         the two return types are not merely required to be convertible
+    ///         to one another, as a mismatch is ill-formed and fails to
+    ///         compile.
+    ///
+    /// \note When \a ExceptionType is not \a void, only exceptions matching
+    ///       that type (per catch-clause matching rules) are handled; any other
+    ///       exception propagates normally out of
+    ///       \a try_catch_exception_ptr instead of being forwarded to \a c.
+    ///
+    /// \note Because \a catch (ExceptionType const&) also matches exceptions
+    ///       whose dynamic type publicly derives from \a ExceptionType, the
+    ///       assignment \c e \c = \c caught in the typed branch may copy-assign
+    ///       a derived object into a base-typed \a e. Any state introduced only
+    ///       by the derived type -- for example diagnostic information mixed in
+    ///       via \a hpx::exception_info (stack traces, thrown file/line, etc.)
+    ///       -- is silently dropped in that case. If \a c needs access to such
+    ///       diagnostics, capture \a std::current_exception() separately (e.g.
+    ///       by using the default \a ExceptionType = void overload) instead of
+    ///       relying on the typed value alone.
+    HPX_CXX_CORE_EXPORT template <typename ExceptionType = void,
+        typename TryCallable, typename CatchCallable>
     HPX_FORCEINLINE decltype(auto) try_catch_exception_ptr(
         TryCallable&& t, CatchCallable&& c)
     {
-        std::exception_ptr ep;
-        try
+        if constexpr (std::is_void_v<ExceptionType>)
         {
-            return t();
+            std::exception_ptr ep;
+            try
+            {
+                return t();
+            }
+            catch (...)
+            {
+                ep = std::current_exception();
+            }
+            return c(HPX_MOVE(ep));
         }
-        catch (...)
+        else
         {
-            ep = std::current_exception();
+            ExceptionType e;
+            try
+            {
+                return t();
+            }
+            catch (ExceptionType const& caught)
+            {
+                e = caught;
+            }
+            return c(HPX_MOVE(e));
         }
-        return c(HPX_MOVE(ep));
     }
 }    // namespace hpx::detail
-// namespace hpx::detail

--- a/libs/core/futures/include/hpx/futures/future.hpp
+++ b/libs/core/futures/include/hpx/futures/future.hpp
@@ -33,9 +33,11 @@
 #include <hpx/modules/timing.hpp>
 #include <hpx/modules/type_support.hpp>
 
+#include <chrono>
 #include <exception>
 #include <iterator>
 #include <memory>
+#include <source_location>
 #include <type_traits>
 #include <utility>
 
@@ -882,6 +884,79 @@ namespace hpx {
                     return HPX_INVOKE(conv, f.get());
                 });
         }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Default bound for waiting on a future.
+    HPX_CXX_CORE_EXPORT inline constexpr std::chrono::milliseconds
+        default_future_timeout{30000};
+
+    /// \brief Returns the current process-wide timeout used when waiting on a
+    ///        future.
+    ///
+    /// \return The timeout duration. Defaults to \a default_future_timeout (30
+    ///         seconds) unless changed via \a set_future_timeout.
+    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT std::chrono::milliseconds
+    get_future_timeout() noexcept;
+
+    /// \brief Sets the process-wide timeout used when waiting on a future.
+    ///
+    /// \param timeout The new timeout value applied to all subsequent future
+    ///                waits (e.g. via \a wait_or_handle_timeout) unless a
+    ///                different timeout is passed explicitly.
+    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void set_future_timeout(
+        hpx::chrono::steady_duration const& timeout) noexcept;
+
+    /// \brief Waits on and consumes the given future, throwing (or reporting
+    ///        via \a ec) a timeout error if the wait exceeds \a timeout.
+    ///
+    /// \param f The future to wait on; consumed (moved-from) by this call.
+    /// \param function_name Name reported in the timeout error message.
+    /// \param timeout Maximum time to wait before timing out. Defaults to the
+    ///                current process-wide timeout returned by
+    ///                \a get_future_timeout.
+    /// \param ec Used to report the timeout error instead of throwing.
+    ///
+    /// \throws hpx::exception with \a hpx::error::future_wait_timed_out if the
+    ///         future is not ready before \a timeout elapses (unless \a ec is
+    ///         supplied, in which case the error is stored in \a ec).
+    ///
+    /// \return The value held by the future, as returned by \a f.get().
+    HPX_CXX_CORE_EXPORT template <typename T>
+    decltype(auto) wait_or_handle_timeout(hpx::future<T>&& f,
+        char const* function_name,
+        hpx::chrono::steady_duration const& timeout = hpx::get_future_timeout(),
+        hpx::error_code& ec = hpx::throws)
+    {
+        if (f.wait_for(timeout, ec) == hpx::future_status::timeout || ec)
+        {
+            HPX_THROWS_IF(ec, hpx::error::future_wait_timed_out, function_name,
+                "future.wait_for timed out");
+        }
+        return f.get(ec);
+    }
+
+    /// \brief Overload of \a wait_or_handle_timeout that derives the reported
+    ///        function name from \a location instead of an explicit string.
+    ///
+    /// \param f The future to wait on; consumed (moved-from) by this call.
+    /// \param location Call-site information identifying the caller in the
+    ///                 timeout error message. Defaults to the caller's
+    ///                 location.
+    /// \param timeout Maximum time to wait before timing out. Defaults to the
+    ///                current process-wide timeout returned by
+    ///                \a get_future_timeout.
+    /// \param ec Used to report the timeout error instead of throwing.
+    ///
+    /// \return The value held by the future, as returned by \a f.get().
+    HPX_CXX_CORE_EXPORT template <typename T>
+    decltype(auto) wait_or_handle_timeout(hpx::future<T>&& f,
+        std::source_location const& location = std::source_location::current(),
+        hpx::chrono::steady_duration const& timeout = hpx::get_future_timeout(),
+        hpx::error_code& ec = hpx::throws)
+    {
+        return wait_or_handle_timeout(
+            HPX_MOVE(f), location.function_name(), timeout, ec);
     }
 }    // namespace hpx
 

--- a/libs/core/futures/src/future_data.cpp
+++ b/libs/core/futures/src/future_data.cpp
@@ -18,7 +18,10 @@
 #include <hpx/modules/memory.hpp>
 #include <hpx/modules/tracing.hpp>
 
+#include <atomic>
+#include <chrono>
 #include <cstddef>
+#include <cstdint>
 #include <exception>
 #include <mutex>
 #include <utility>
@@ -425,3 +428,28 @@ namespace hpx::lcos::detail {
         return hpx::future_status::ready;    //-V110
     }
 }    // namespace hpx::lcos::detail
+
+namespace hpx {
+
+    namespace {
+
+        std::atomic<std::int64_t> future_timeout_ms{
+            default_future_timeout.count()};
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    std::chrono::milliseconds get_future_timeout() noexcept
+    {
+        return std::chrono::milliseconds(
+            future_timeout_ms.load(std::memory_order_relaxed));
+    }
+
+    void set_future_timeout(
+        hpx::chrono::steady_duration const& timeout) noexcept
+    {
+        auto const timeout_ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                timeout.value());
+        future_timeout_ms.store(timeout_ms.count(), std::memory_order_relaxed);
+    }
+}    // namespace hpx

--- a/libs/core/runtime_configuration/include/hpx/runtime_configuration/runtime_configuration.hpp
+++ b/libs/core/runtime_configuration/include/hpx/runtime_configuration/runtime_configuration.hpp
@@ -149,6 +149,30 @@ namespace hpx::util {
             return modules_;
         }
 
+        /// \brief Check whether fault tolerance for node/locality faults is
+        ///        enabled via the "enable_fault_tolerance" configuration
+        ///        entry in the "hpx" section.
+        ///
+        /// \return true if fault tolerance is enabled, false otherwise.
+        bool tolerate_node_faults();
+
+        /// \brief Set whether this runtime instance should tolerate node
+        ///        faults.
+        ///
+        /// This controls whether the runtime is configured to continue
+        /// operating in the presence of locality failures (e.g. forced or
+        /// unexpected disconnection of remote localities) rather than treating
+        /// such failures as fatal errors.
+        ///
+        /// \param value  Set to `true` to enable fault tolerance for node
+        ///               failures, or `false` to require all localities to
+        ///               remain connected for normal operation.
+        void tolerate_node_faults(bool const value) const
+        {
+            tolerate_node_faults_value = value;
+            need_to_initialize_tolerate_node_faults = false;
+        }
+
     private:
         std::ptrdiff_t init_stack_size(char const* entryname,
             char const* defaultvaluestr, std::ptrdiff_t defaultvalue) const;
@@ -194,6 +218,8 @@ namespace hpx::util {
         std::ptrdiff_t large_stacksize;
         std::ptrdiff_t huge_stacksize;
         bool need_to_call_pre_initialize;
+        mutable bool need_to_initialize_tolerate_node_faults;
+        mutable bool tolerate_node_faults_value;
 #if defined(__linux) || defined(linux) || defined(__linux__)
         char const* argv0;
 #endif

--- a/libs/core/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/core/runtime_configuration/src/runtime_configuration.cpp
@@ -190,7 +190,9 @@ namespace hpx::util {
                 HPX_PP_EXPAND(HPX_HAVE_THREAD_BACKTRACE_DEPTH)) "}",
             "handle_signals = ${HPX_HANDLE_SIGNALS:1}",
             "handle_failed_new = ${HPX_HANDLE_FAILED_NEW:1}",
-
+#if defined(HPX_HAVE_FAULT_TOLERANCE)
+            "enable_fault_tolerance = ${HPX_ENABLE_FAULT_TOLERANCE:0}",
+#endif
             // arity for collective operations implemented in a tree fashion
             "[hpx.lcos.collectives]",
             "arity = ${HPX_LCOS_COLLECTIVES_ARITY:32}",
@@ -717,6 +719,8 @@ namespace hpx::util {
       , large_stacksize(HPX_LARGE_STACK_SIZE)
       , huge_stacksize(HPX_HUGE_STACK_SIZE)
       , need_to_call_pre_initialize(true)
+      , need_to_initialize_tolerate_node_faults(true)
+      , tolerate_node_faults_value(false)
 #if defined(__linux) || defined(linux) || defined(__linux__)
       , argv0(argv0_)
 #endif
@@ -1187,6 +1191,29 @@ namespace hpx::util {
             }
         }
         return HPX_PARCEL_MAX_OUTBOUND_MESSAGE_SIZE;    // default is 1GByte
+    }
+
+    bool runtime_configuration::tolerate_node_faults()
+    {
+        // ignore the benign data races around loading/setting the values from
+        // the booleans
+        if (!need_to_initialize_tolerate_node_faults)
+        {
+            return tolerate_node_faults_value;
+        }
+
+        bool value = false;
+        if (util::section const* sec = get_section("hpx"); nullptr != sec)
+        {
+            std::string const entry =
+                sec->get_entry("enable_fault_tolerance", "0");
+            value = !entry.empty() && entry != "0";
+        }
+
+        tolerate_node_faults_value = value;
+        need_to_initialize_tolerate_node_faults = false;
+
+        return value;
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/core/runtime_local/src/runtime_local.cpp
+++ b/libs/core/runtime_local/src/runtime_local.cpp
@@ -1064,8 +1064,8 @@ namespace hpx {
 
     bool tolerate_node_faults()
     {
-#ifdef HPX_HAVE_FAULT_TOLERANCE
-        return true;
+#if defined(HPX_HAVE_FAULT_TOLERANCE)
+        return hpx::get_config_entry("hpx.enable_fault_tolerance", "0") != "0";
 #else
         return false;
 #endif

--- a/libs/full/actions_base/include/hpx/actions_base/macros.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/macros.hpp
@@ -138,6 +138,7 @@
 #define HPX_ACTION_HAS_NORMAL_PRIORITY(action)         /**/
 #define HPX_ACTION_HAS_HIGH_PRIORITY(action)           /**/
 #define HPX_ACTION_HAS_HIGH_RECURSIVE_PRIORITY(action) /**/
+#define HPX_ACTION_HAS_BOUND_PRIORITY(action)          /**/
 // obsolete, kept for compatibility
 #define HPX_ACTION_HAS_CRITICAL_PRIORITY(action) /**/
 #else
@@ -168,6 +169,9 @@
 /**/
 #define HPX_ACTION_HAS_HIGH_RECURSIVE_PRIORITY(action)                         \
     HPX_ACTION_HAS_PRIORITY(action, threads::thread_priority::high_recursive)  \
+/**/
+#define HPX_ACTION_HAS_BOUND_PRIORITY(action)                                  \
+    HPX_ACTION_HAS_PRIORITY(action, threads::thread_priority::bound)           \
 /**/
 
 // obsolete, kept for compatibility

--- a/libs/full/agas/include/hpx/agas/addressing_service.hpp
+++ b/libs/full/agas/include/hpx/agas/addressing_service.hpp
@@ -106,8 +106,8 @@ namespace hpx::agas {
         naming::gid_type locality_;
 
         mutable hpx::shared_mutex resolved_localities_mtx_;
-        using resolved_localities_type =
-            std::map<naming::gid_type, parcelset::endpoints_type>;
+        using resolved_localities_type = std::map<naming::gid_type,
+            std::pair<parcelset::endpoints_type, bool>>;
         resolved_localities_type resolved_localities_;
 
         explicit addressing_service(util::runtime_configuration const& ini_);
@@ -165,6 +165,15 @@ namespace hpx::agas {
         {
             return runtime_type == runtime_mode::connect;
         }
+
+        /// \brief Return whether a locality joined while connecting.
+        ///
+        /// \param locality The locality GID to inspect. If locality is invalid,
+        ///                 return the connecting status of the calling
+        ///                 locality.
+        ///
+        /// \returns `true` if the locality is marked as connecting.
+        bool is_connecting(hpx::naming::gid_type const& locality) const;
 
         bool resolve_locally_known_addresses(
             naming::gid_type const& id, naming::address& addr) const;
@@ -228,7 +237,7 @@ namespace hpx::agas {
             naming::gid_type const& id, gva const& g, future<bool> f);
 
         /// Maintain list of migrated objects
-        bool was_object_migrated_locked(naming::gid_type const& id);
+        bool was_object_migrated_locked(naming::gid_type const& id) const;
 
     private:
         /// Assumes that \a refcnt_requests_mtx_ is locked.
@@ -269,7 +278,7 @@ namespace hpx::agas {
         /// \brief Add a locality to the runtime.
         bool register_locality(parcelset::endpoints_type const& endpoints,
             naming::gid_type& prefix, std::uint32_t num_threads,
-            error_code& ec = throws);
+            bool is_connecting, error_code& ec = throws);
 
         /// \brief Resolve a locality to its prefix.
         ///
@@ -277,7 +286,7 @@ namespace hpx::agas {
         parcelset::endpoints_type const& resolve_locality(
             naming::gid_type const& gid, error_code& ec = throws);
 
-        bool has_resolved_locality(naming::gid_type const& gid);
+        bool has_resolved_locality(naming::gid_type const& gid) const;
 
         /// \brief Remove a locality from the runtime.
         bool unregister_locality(
@@ -930,7 +939,7 @@ namespace hpx::agas {
         }
 
         bool resolve_cached(naming::gid_type const& id, naming::address& addr,
-            error_code& ec = throws);
+            error_code& ec = throws) const;
 
         bool resolve_cached(hpx::id_type const& id, naming::address& addr,
             error_code& ec = throws)
@@ -964,7 +973,8 @@ namespace hpx::agas {
 
         bool resolve_cached(naming::gid_type const* gids,
             naming::address* addrs, std::size_t size,
-            hpx::detail::dynamic_bitset<>& locals, error_code& ec = throws);
+            hpx::detail::dynamic_bitset<>& locals,
+            error_code& ec = throws) const;
 
 #if defined(HPX_HAVE_NETWORKING)
         /// \brief Route the given parcel to the appropriate AGAS service instance
@@ -1225,7 +1235,7 @@ namespace hpx::agas {
         /// Maintain list of migrated objects
         std::pair<bool, components::pinned_ptr> was_object_migrated(
             naming::gid_type const& gid,
-            hpx::move_only_function<components::pinned_ptr()>&& f);
+            hpx::move_only_function<components::pinned_ptr()>&& f) const;
 
         /// Mark the given object as being migrated (if the object is unpinned).
         /// Delay migration until the object is unpinned otherwise.

--- a/libs/full/agas/src/addressing_service.cpp
+++ b/libs/full/agas/src/addressing_service.cpp
@@ -62,7 +62,7 @@ namespace hpx::agas {
         gva_cache_key() = default;
 
         explicit gva_cache_key(
-            naming::gid_type const& id, std::uint64_t count = 1)
+            naming::gid_type const& id, std::uint64_t const count = 1)
           : key_(naming::detail::get_stripped_gid(id),
                 naming::detail::get_stripped_gid(id) + (count - 1))
         {
@@ -144,7 +144,7 @@ namespace hpx::agas {
         launch_bootstrap(endpoints, rtcfg);
     }
 
-    void addressing_service::initialize(std::uint64_t rts_lva)
+    void addressing_service::initialize(std::uint64_t const rts_lva)
     {
         rts_lva_ = rts_lva;
         set_status(hpx::state::running);
@@ -163,7 +163,7 @@ namespace hpx::agas {
         locality_ns_.reset(new detail::bootstrap_locality_namespace(
             static_cast<server::primary_namespace*>(primary_ns_.ptr())));
 
-        naming::gid_type const here =
+        constexpr naming::gid_type here =
             naming::get_gid_from_locality_id(agas::booststrap_prefix);
         set_local_locality(here);
 
@@ -183,7 +183,7 @@ namespace hpx::agas {
     }
 
     void addressing_service::adjust_local_cache_size(
-        std::size_t cache_size) const
+        std::size_t const cache_size) const
     {
         // adjust the local AGAS cache size for the number of worker threads and
         // create the hierarchy based on the topology
@@ -207,7 +207,7 @@ namespace hpx::agas {
 
     bool addressing_service::register_locality(
         parcelset::endpoints_type const& endpoints, naming::gid_type& prefix,
-        std::uint32_t num_threads, error_code& ec)
+        std::uint32_t const num_threads, bool is_connecting, error_code& ec)
     {
         try
         {
@@ -216,10 +216,10 @@ namespace hpx::agas {
 
             {
                 std::unique_lock<hpx::shared_mutex> l(resolved_localities_mtx_);
-                std::pair<resolved_localities_type::iterator, bool> const res =
-                    resolved_localities_.emplace(prefix, endpoints);
+                auto const [it, inserted] = resolved_localities_.emplace(
+                    prefix, std::make_pair(endpoints, is_connecting));
 
-                if (!res.second)
+                if (!inserted)
                 {
                     l.unlock();
                     HPX_THROWS_IF(ec, hpx::error::bad_parameter,
@@ -238,21 +238,34 @@ namespace hpx::agas {
         }
     }
 
+    bool addressing_service::is_connecting(
+        hpx::naming::gid_type const& locality) const
+    {
+        if (!locality)
+        {
+            return is_connecting();
+        }
+
+        std::lock_guard<hpx::shared_mutex> l(resolved_localities_mtx_);
+        auto const it = resolved_localities_.find(locality);
+        return it != resolved_localities_.end() && it->second.second;
+    }
+
     void addressing_service::register_console(
         parcelset::endpoints_type const& eps)
     {
         std::lock_guard<hpx::shared_mutex> l(resolved_localities_mtx_);
-        [[maybe_unused]] std::pair<resolved_localities_type::iterator,
-            bool> const res =
-            resolved_localities_.emplace(
-                naming::get_gid_from_locality_id(0), eps);
-        HPX_ASSERT(res.second);
+        [[maybe_unused]] auto const [it, inserted] =
+            resolved_localities_.emplace(naming::get_gid_from_locality_id(0),
+                std::make_pair(eps, false));
+        HPX_ASSERT(inserted);
     }
 
-    bool addressing_service::has_resolved_locality(naming::gid_type const& gid)
+    bool addressing_service::has_resolved_locality(
+        naming::gid_type const& gid) const
     {
         std::shared_lock<hpx::shared_mutex> l(resolved_localities_mtx_);
-        return resolved_localities_.find(gid) != resolved_localities_.end();
+        return resolved_localities_.contains(gid);
     }
 
     void addressing_service::pre_cache_endpoints(
@@ -263,7 +276,8 @@ namespace hpx::agas {
         for (parcelset::endpoints_type const& endpoint : endpoints)
         {
             resolved_localities_.emplace(
-                naming::get_gid_from_locality_id(locality_id), endpoint);
+                naming::get_gid_from_locality_id(locality_id),
+                std::make_pair(endpoint, false));
             ++locality_id;
         }
     }
@@ -275,13 +289,14 @@ namespace hpx::agas {
         {
             std::shared_lock<hpx::shared_mutex> l(resolved_localities_mtx_);
             it = resolved_localities_.find(gid);
-            if (it != resolved_localities_.end() && !it->second.empty())
+            if (it != resolved_localities_.end() && !it->second.first.empty())
             {
-                return it->second;
+                return it->second.first;
             }
         }
-        std::unique_lock<hpx::shared_mutex> l(resolved_localities_mtx_);
+
         // The locality hasn't been requested to be resolved yet. Do it now.
+        std::unique_lock<hpx::shared_mutex> l(resolved_localities_mtx_);
         parcelset::endpoints_type endpoints;
         {
             hpx::unlock_guard<std::unique_lock<hpx::shared_mutex>> ul(l);
@@ -297,13 +312,14 @@ namespace hpx::agas {
             }
         }
 
-        // Search again ... might have been added by a different thread
-        // already
+        // Search again ... might have been added by a different thread already
         it = resolved_localities_.find(gid);
         if (it == resolved_localities_.end())
         {
-            if (HPX_UNLIKELY(!util::insert_checked(
-                    resolved_localities_.emplace(gid, endpoints), it)))
+            if (HPX_UNLIKELY(
+                    !util::insert_checked(resolved_localities_.emplace(gid,
+                                              std::make_pair(endpoints, false)),
+                        it)))
             {
                 l.unlock();
 
@@ -316,26 +332,27 @@ namespace hpx::agas {
                 return empty_endpoints;
             }
         }
-        else if (it->second.empty() && !endpoints.empty())
+        else if (it->second.first.empty() && !endpoints.empty())
         {
-            resolved_localities_[gid] = HPX_MOVE(endpoints);
+            resolved_localities_[gid] =
+                std::make_pair(HPX_MOVE(endpoints), false);
         }
-        return it->second;
+        return it->second.first;
     }
 
-    // TODO: We need to ensure that the locality isn't unbound while it still
-    // holds referenced objects.
     bool addressing_service::unregister_locality(
         naming::gid_type const& gid, error_code& ec)
     {
         try
         {
-            locality_ns_->free(gid);
-            component_ns_->unregister_server_instance(ec);
-            symbol_ns_.unregister_server_instance(ec);
-
+            bool const result = locality_ns_->free(gid);
+            if (gid == get_locality())
+            {
+                component_ns_->unregister_server_instance(ec);
+                symbol_ns_.unregister_server_instance(ec);
+            }
             remove_resolved_locality(gid);
-            return true;
+            return result;
         }
         catch (hpx::exception const& e)
         {
@@ -427,7 +444,7 @@ namespace hpx::agas {
 
     bool addressing_service::get_localities(
         std::vector<naming::gid_type>& locality_ids,
-        components::component_type type, error_code& ec) const
+        components::component_type const type, error_code& ec) const
     {
         try
         {
@@ -470,7 +487,7 @@ namespace hpx::agas {
 
     ///////////////////////////////////////////////////////////////////////////
     std::uint32_t addressing_service::get_num_localities(
-        components::component_type type, error_code& ec) const
+        components::component_type const type, error_code& ec) const
     {
         try
         {
@@ -489,7 +506,7 @@ namespace hpx::agas {
     }
 
     hpx::future<std::uint32_t> addressing_service::get_num_localities_async(
-        components::component_type type) const
+        components::component_type const type) const
     {
         if (type == to_int(hpx::components::component_enum_type::invalid))
         {
@@ -570,7 +587,7 @@ namespace hpx::agas {
     }
 
     std::string addressing_service::get_component_type_name(
-        components::component_type id, error_code& ec) const
+        components::component_type const id, error_code& ec) const
     {
         try
         {
@@ -584,7 +601,8 @@ namespace hpx::agas {
     }
 
     components::component_type addressing_service::register_factory(
-        std::uint32_t prefix, std::string const& name, error_code& ec) const
+        std::uint32_t const prefix, std::string const& name,
+        error_code& ec) const
     {
         try
         {
@@ -598,7 +616,7 @@ namespace hpx::agas {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    bool addressing_service::get_id_range(std::uint64_t count,
+    bool addressing_service::get_id_range(std::uint64_t const count,
         naming::gid_type& lower_bound, naming::gid_type& upper_bound,
         error_code& ec)
     {
@@ -628,8 +646,8 @@ namespace hpx::agas {
     }
 
     bool addressing_service::bind_range_local(naming::gid_type const& lower_id,
-        std::uint64_t count, naming::address const& baseaddr,
-        std::uint64_t offset, error_code& ec)
+        std::uint64_t const count, naming::address const& baseaddr,
+        std::uint64_t const offset, error_code& ec)
     {
         try
         {
@@ -688,8 +706,8 @@ namespace hpx::agas {
     }
 
     hpx::future<bool> addressing_service::bind_range_async(
-        naming::gid_type const& lower_id, std::uint64_t count,
-        naming::address const& baseaddr, std::uint64_t offset,
+        naming::gid_type const& lower_id, std::uint64_t const count,
+        naming::address const& baseaddr, std::uint64_t const offset,
         naming::gid_type const& locality)
     {
         // ask server
@@ -710,13 +728,13 @@ namespace hpx::agas {
     }
 
     hpx::future<naming::address> addressing_service::unbind_range_async(
-        naming::gid_type const& lower_id, std::uint64_t count)
+        naming::gid_type const& lower_id, std::uint64_t const count)
     {
         return primary_ns_.unbind_gid_async(count, lower_id);
     }
 
     bool addressing_service::unbind_range_local(
-        naming::gid_type const& lower_id, std::uint64_t count,
+        naming::gid_type const& lower_id, std::uint64_t const count,
         naming::address& addr, error_code& ec)
     {
         try
@@ -837,7 +855,7 @@ namespace hpx::agas {
 
     // Return true if at least one address is local.
     bool addressing_service::is_local_lva_encoded_address(
-        std::uint64_t msb) const
+        std::uint64_t const msb) const
     {
         // NOTE: This should still be migration safe.
         return naming::detail::strip_internal_bits_and_component_type_from_gid(
@@ -998,8 +1016,8 @@ namespace hpx::agas {
         }
     }
 
-    bool addressing_service::resolve_cached(
-        naming::gid_type const& gid, naming::address& addr, error_code& ec)
+    bool addressing_service::resolve_cached(naming::gid_type const& gid,
+        naming::address& addr, error_code& ec) const
     {
         naming::gid_type const id =
             naming::detail::get_stripped_gid_except_dont_cache(gid);
@@ -1080,8 +1098,15 @@ namespace hpx::agas {
         {
             HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "addressing_service::resolve_async", "invalid reference id");
+        }
+
+#if defined(HPX_HAVE_FORCE_DISCONNECT)
+        if (parcelset::locality_was_disconnected(
+                naming::get_locality_id_from_gid(gid)))
+        {
             return naming::address();
         }
+#endif
 
         // Try the cache.
         if (caching_)
@@ -1167,7 +1192,6 @@ namespace hpx::agas {
             HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "addressing_service::resolve_full_async",
                 "invalid reference id");
-            return naming::address();
         }
 
         // ask server
@@ -1194,7 +1218,7 @@ namespace hpx::agas {
 
     ///////////////////////////////////////////////////////////////////////////
     bool addressing_service::resolve_full_local(naming::gid_type const* gids,
-        naming::address* addrs, std::size_t count,
+        naming::address* addrs, std::size_t const count,
         hpx::detail::dynamic_bitset<>& locals, error_code& ec)
     {
         locals.resize(count);
@@ -1264,8 +1288,8 @@ namespace hpx::agas {
     }
 
     bool addressing_service::resolve_cached(naming::gid_type const* gids,
-        naming::address* addrs, std::size_t count,
-        hpx::detail::dynamic_bitset<>& locals, error_code& ec)
+        naming::address* addrs, std::size_t const count,
+        hpx::detail::dynamic_bitset<>& locals, error_code& ec) const
     {
         locals.resize(count);
 
@@ -1331,14 +1355,14 @@ namespace hpx::agas {
     // incref was sent. The pending decref was subtracted from the amount of
     // credits to incref.
     std::int64_t addressing_service::synchronize_with_async_incref(
-        std::int64_t old_credit, hpx::id_type const&,
-        std::int64_t compensated_credit)
+        std::int64_t const old_credit, hpx::id_type const&,
+        std::int64_t const compensated_credit)
     {
         return old_credit + compensated_credit;
     }
 
     std::int64_t addressing_service::incref_async_helper(
-        naming::gid_type const& id, std::int64_t credit,
+        naming::gid_type const& id, std::int64_t const credit,
         hpx::id_type const& keep_alive)
     {
         auto result = incref_async(id, credit, keep_alive);
@@ -1370,7 +1394,6 @@ namespace hpx::agas {
             HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "addressing_service::incref_async",
                 "invalid credit count of {1}", credit);
-            return std::int64_t(-1);
         }
 
         HPX_ASSERT(keep_alive != hpx::invalid_id);
@@ -1459,7 +1482,7 @@ namespace hpx::agas {
 
     ///////////////////////////////////////////////////////////////////////////
     void addressing_service::decref(
-        naming::gid_type const& gid, std::int64_t credit, error_code& ec)
+        naming::gid_type const& gid, std::int64_t const credit, error_code& ec)
     {
         naming::gid_type raw(naming::detail::get_stripped_gid(gid));
 
@@ -1526,7 +1549,8 @@ namespace hpx::agas {
 
     ///////////////////////////////////////////////////////////////////////////
     static bool correct_credit_on_failure(future<bool> f, hpx::id_type id,
-        std::int64_t mutable_gid_credit, std::int64_t new_gid_credit)
+        std::int64_t const mutable_gid_credit,
+        std::int64_t const new_gid_credit)
     {
         // Return the credit to the GID if the operation failed
         if ((f.has_exception() && mutable_gid_credit != 0) || !f.get())
@@ -1643,7 +1667,7 @@ namespace hpx::agas {
 
     namespace detail {
 
-        hpx::future<hpx::id_type> on_register_event(
+        static hpx::future<hpx::id_type> on_register_event(
             hpx::future<bool> f, hpx::future<hpx::id_type> result_f)
         {
             if (!f.get())
@@ -1657,7 +1681,7 @@ namespace hpx::agas {
     }    // namespace detail
 
     future<hpx::id_type> addressing_service::on_symbol_namespace_event(
-        std::string const& name, bool call_for_past_events) const
+        std::string const& name, bool const call_for_past_events) const
     {
         hpx::distributed::promise<hpx::id_type, naming::gid_type> p;
         auto result_f = p.get_future();
@@ -1677,14 +1701,18 @@ namespace hpx::agas {
         return symbol_ns_.iterate_async(pattern);
     }
 
-    // This function has to return false if the key is already in the cache (true
-    // means go ahead with the cache update).
-    bool check_for_collisions(addressing_service::gva_cache_key const& new_key,
-        addressing_service::gva_cache_key const& old_key)
-    {
-        return (new_key.get_gid() != old_key.get_gid()) ||
-            (new_key.get_count() != old_key.get_count());
-    }
+    namespace detail {
+
+        // This function has to return false if the key is already in the cache (true
+        // means go ahead with the cache update).
+        static bool check_for_collisions(
+            addressing_service::gva_cache_key const& new_key,
+            addressing_service::gva_cache_key const& old_key)
+        {
+            return (new_key.get_gid() != old_key.get_gid()) ||
+                (new_key.get_count() != old_key.get_count());
+        }
+    }    // namespace detail
 
     void addressing_service::update_cache_entry(
         naming::gid_type const& id, gva const& g, error_code& ec)
@@ -1750,7 +1778,8 @@ namespace hpx::agas {
 
             {
                 std::unique_lock<hpx::shared_mutex> lock(gva_cache_mtx_);
-                if (!gva_cache_->update_if(key, g, check_for_collisions))
+                if (!gva_cache_->update_if(
+                        key, g, detail::check_for_collisions))
                 {
                     if (LAGAS_ENABLED(warning))
                     {
@@ -1929,25 +1958,27 @@ namespace hpx::agas {
         return gva_cache_->size();
     }
 
-    std::uint64_t addressing_service::get_cache_hits(bool reset) const
+    std::uint64_t addressing_service::get_cache_hits(bool const reset) const
     {
         std::shared_lock<hpx::shared_mutex> lock(gva_cache_mtx_);
         return gva_cache_->get_statistics().hits(reset);
     }
 
-    std::uint64_t addressing_service::get_cache_misses(bool reset) const
+    std::uint64_t addressing_service::get_cache_misses(bool const reset) const
     {
         std::shared_lock<hpx::shared_mutex> lock(gva_cache_mtx_);
         return gva_cache_->get_statistics().misses(reset);
     }
 
-    std::uint64_t addressing_service::get_cache_evictions(bool reset) const
+    std::uint64_t addressing_service::get_cache_evictions(
+        bool const reset) const
     {
         std::shared_lock<hpx::shared_mutex> lock(gva_cache_mtx_);
         return gva_cache_->get_statistics().evictions(reset);
     }
 
-    std::uint64_t addressing_service::get_cache_insertions(bool reset) const
+    std::uint64_t addressing_service::get_cache_insertions(
+        bool const reset) const
     {
         std::shared_lock<hpx::shared_mutex> lock(gva_cache_mtx_);
         return gva_cache_->get_statistics().insertions(reset);
@@ -1955,55 +1986,56 @@ namespace hpx::agas {
 
     ///////////////////////////////////////////////////////////////////////////
     std::uint64_t addressing_service::get_cache_get_entry_count(
-        bool reset) const
+        bool const reset) const
     {
         std::shared_lock<hpx::shared_mutex> lock(gva_cache_mtx_);
         return gva_cache_->get_statistics().get_get_entry_count(reset);
     }
 
     std::uint64_t addressing_service::get_cache_insertion_entry_count(
-        bool reset) const
+        bool const reset) const
     {
         std::shared_lock<hpx::shared_mutex> lock(gva_cache_mtx_);
         return gva_cache_->get_statistics().get_insert_entry_count(reset);
     }
 
     std::uint64_t addressing_service::get_cache_update_entry_count(
-        bool reset) const
+        bool const reset) const
     {
         std::shared_lock<hpx::shared_mutex> lock(gva_cache_mtx_);
         return gva_cache_->get_statistics().get_update_entry_count(reset);
     }
 
     std::uint64_t addressing_service::get_cache_erase_entry_count(
-        bool reset) const
+        bool const reset) const
     {
         std::shared_lock<hpx::shared_mutex> lock(gva_cache_mtx_);
         return gva_cache_->get_statistics().get_erase_entry_count(reset);
     }
 
-    std::uint64_t addressing_service::get_cache_get_entry_time(bool reset) const
+    std::uint64_t addressing_service::get_cache_get_entry_time(
+        bool const reset) const
     {
         std::shared_lock<hpx::shared_mutex> lock(gva_cache_mtx_);
         return gva_cache_->get_statistics().get_get_entry_time(reset);
     }
 
     std::uint64_t addressing_service::get_cache_insertion_entry_time(
-        bool reset) const
+        bool const reset) const
     {
         std::shared_lock<hpx::shared_mutex> lock(gva_cache_mtx_);
         return gva_cache_->get_statistics().get_insert_entry_time(reset);
     }
 
     std::uint64_t addressing_service::get_cache_update_entry_time(
-        bool reset) const
+        bool const reset) const
     {
         std::shared_lock<hpx::shared_mutex> lock(gva_cache_mtx_);
         return gva_cache_->get_statistics().get_update_entry_time(reset);
     }
 
     std::uint64_t addressing_service::get_cache_erase_entry_time(
-        bool reset) const
+        bool const reset) const
     {
         std::shared_lock<hpx::shared_mutex> lock(gva_cache_mtx_);
         return gva_cache_->get_statistics().get_erase_entry_time(reset);
@@ -2286,7 +2318,7 @@ namespace hpx::agas {
     hpx::future<void> addressing_service::mark_as_migrated(
         naming::gid_type const& gid_,
         hpx::move_only_function<std::pair<bool, hpx::future<void>>()>&& f,
-        [[maybe_unused]] bool expect_to_be_marked_as_migrating)
+        [[maybe_unused]] bool const expect_to_be_marked_as_migrating)
     {
         if (!gid_)
         {
@@ -2420,18 +2452,17 @@ namespace hpx::agas {
     }
 
     bool addressing_service::was_object_migrated_locked(
-        naming::gid_type const& gid_)
+        naming::gid_type const& gid_) const
     {
         naming::gid_type const gid(naming::detail::get_stripped_gid(gid_));
 
-        return migrated_objects_table_.find(gid) !=
-            migrated_objects_table_.end();
+        return migrated_objects_table_.contains(gid);
     }
 
     std::pair<bool, components::pinned_ptr>
     addressing_service::was_object_migrated(naming::gid_type const& gid,
         hpx::move_only_function<components::pinned_ptr()>&& f    //-V669
-    )
+    ) const
     {
         if (!gid)
         {

--- a/libs/full/agas/src/detail/interface.cpp
+++ b/libs/full/agas/src/detail/interface.cpp
@@ -29,6 +29,11 @@ namespace hpx::agas::detail::impl {
         return naming::get_agas_client().is_console();
     }
 
+    bool is_connecting(naming::gid_type const& locality)
+    {
+        return naming::get_agas_client().is_connecting(locality);
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     bool register_name(
         std::string const& name, naming::gid_type const& gid, error_code&)
@@ -534,6 +539,7 @@ namespace hpx::agas {
         agas_interface_functions()
         {
             detail::is_console = &detail::impl::is_console;
+            detail::is_connecting = &detail::impl::is_connecting;
 
             detail::register_name = &detail::impl::register_name;
             detail::register_name_async = &detail::impl::register_name_async;

--- a/libs/full/agas/tests/regressions/departed_locality_7384.cpp
+++ b/libs/full/agas/tests/regressions/departed_locality_7384.cpp
@@ -10,6 +10,8 @@
 // error path (hpx::error::bad_parameter) instead of letting a
 // std::system_error raised by unique_lock::unlock escape (see #7384).
 
+#define HPX_HAVE_FORCE_NO_CXX_MODULES
+
 #include <hpx/config.hpp>
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx.hpp>
@@ -46,7 +48,7 @@ std::vector<std::string> get_environment()
 {
     std::vector<std::string> env;
 #if defined(HPX_WINDOWS)
-    int len = get_arraylen(_environ);
+    int const len = get_arraylen(_environ);
     std::copy(&_environ[0], &_environ[len], std::back_inserter(env));
 #elif defined(linux) || defined(__linux) || defined(__linux__) ||              \
     defined(__AIX__) || defined(__APPLE__) || defined(__FreeBSD__)
@@ -160,8 +162,8 @@ int hpx_main(hpx::program_options::variables_map& vm)
     hpx::id_type const here = hpx::find_here();
     hpx::id_type departed;
 
-    std::vector<hpx::id_type> localities = hpx::find_all_localities();
-    HPX_TEST_EQ(localities.size(), std::size_t(2));
+    std::vector<hpx::id_type> const localities = hpx::find_all_localities();
+    HPX_TEST_EQ(localities.size(), static_cast<std::size_t>(2));
     for (hpx::id_type const& id : localities)
     {
         if (id != here)
@@ -197,7 +199,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
             break;
         hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
-    HPX_TEST_EQ(hpx::find_all_localities().size(), std::size_t(1));
+    HPX_TEST_EQ(hpx::find_all_localities().size(), static_cast<std::size_t>(1));
 
     // Resolving the departed locality now has to fail through the intended
     // AGAS error path. Before the fix for #7384 a std::system_error raised by
@@ -241,7 +243,8 @@ int hpx_main(hpx::program_options::variables_map& vm)
     // Dispatching an action to the departed locality fails with the intended
     // hpx::error::bad_parameter as well. Note that hpx::exception is derived
     // from std::system_error, catch it first.
-    bool caught_bad_parameter = false;
+    bool caught_hpx_exception = false;
+    hpx::error err = hpx::error::success;
     bool no_error = false;
     caught_system_error = false;
     try
@@ -253,7 +256,8 @@ int hpx_main(hpx::program_options::variables_map& vm)
     }
     catch (hpx::exception const& e)
     {
-        caught_bad_parameter = e.get_error() == hpx::error::bad_parameter;
+        caught_hpx_exception = true;
+        err = e.get_error();
     }
     catch (std::system_error const&)
     {
@@ -262,7 +266,9 @@ int hpx_main(hpx::program_options::variables_map& vm)
 
     HPX_TEST(!no_error);
     HPX_TEST(!caught_system_error);
-    HPX_TEST(caught_bad_parameter);
+    HPX_TEST(caught_hpx_exception);
+    HPX_TEST(err == hpx::error::locality_was_disconnected ||
+        err == hpx::error::bad_parameter);
 
     return hpx::finalize();
 }

--- a/libs/full/agas/tests/regressions/departed_locality_7384_child.cpp
+++ b/libs/full/agas/tests/regressions/departed_locality_7384_child.cpp
@@ -9,7 +9,10 @@
 // connects to the running test as a new locality, waits until the test has
 // captured this locality's id, and disconnects gracefully.
 
+#define HPX_HAVE_FORCE_NO_CXX_MODULES
+
 #include <hpx/config.hpp>
+
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>

--- a/libs/full/agas_base/include/hpx/agas_base/agas_fwd.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/agas_fwd.hpp
@@ -22,7 +22,8 @@ namespace hpx::agas {
 
     ////////////////////////////////////////////////////////////////////////
     // Base name used to register AGAS service instances
-    HPX_CXX_EXPORT inline constexpr char const* const service_name = "/0/agas/";
+    HPX_CXX_EXPORT inline constexpr char const* const service_name =
+        "/{}/agas/";
 
     // Fixed addresses of AGAS components
     HPX_CXX_EXPORT inline constexpr std::uint64_t booststrap_prefix = 0ULL;

--- a/libs/full/agas_base/include/hpx/agas_base/detail/bootstrap_locality_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/detail/bootstrap_locality_namespace.hpp
@@ -39,7 +39,7 @@ namespace hpx::agas::detail {
             std::uint64_t count, std::uint32_t num_threads,
             naming::gid_type const& suggested_prefix) override;
 
-        void free(naming::gid_type const& locality) override;
+        bool free(naming::gid_type const& locality) override;
 
         std::vector<std::uint32_t> localities() override;
 

--- a/libs/full/agas_base/include/hpx/agas_base/detail/hosted_locality_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/detail/hosted_locality_namespace.hpp
@@ -47,7 +47,7 @@ namespace hpx::agas::detail {
             std::uint64_t count, std::uint32_t num_threads,
             naming::gid_type const& suggested_prefix) override;
 
-        void free(naming::gid_type const& locality) override;
+        bool free(naming::gid_type const& locality) override;
 
         std::vector<std::uint32_t> localities() override;
 

--- a/libs/full/agas_base/include/hpx/agas_base/locality_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/locality_namespace.hpp
@@ -34,7 +34,7 @@ namespace hpx::agas {
             std::uint32_t num_threads,
             naming::gid_type const& suggested_prefix) = 0;
 
-        virtual void free(naming::gid_type const& locality) = 0;
+        virtual bool free(naming::gid_type const& locality) = 0;
 
         virtual std::vector<std::uint32_t> localities() = 0;
 

--- a/libs/full/agas_base/include/hpx/agas_base/server/locality_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/server/locality_namespace.hpp
@@ -152,7 +152,7 @@ namespace hpx::agas::server {
         parcelset::endpoints_type resolve_locality(
             naming::gid_type const& locality);
 
-        void free(naming::gid_type const& locality);
+        bool free(naming::gid_type const& locality);
 
         std::vector<std::uint32_t> localities();
 

--- a/libs/full/agas_base/src/detail/bootstrap_locality_namespace.cpp
+++ b/libs/full/agas_base/src/detail/bootstrap_locality_namespace.cpp
@@ -50,9 +50,9 @@ namespace hpx::agas::detail {
             endpoints, count, num_threads, suggested_prefix);
     }
 
-    void bootstrap_locality_namespace::free(naming::gid_type const& locality)
+    bool bootstrap_locality_namespace::free(naming::gid_type const& locality)
     {
-        server_.free(locality);
+        return server_.free(locality);
     }
 
     std::vector<std::uint32_t> bootstrap_locality_namespace::localities()

--- a/libs/full/agas_base/src/detail/hosted_component_namespace.cpp
+++ b/libs/full/agas_base/src/detail/hosted_component_namespace.cpp
@@ -9,9 +9,11 @@
 
 #if defined(HPX_HAVE_NETWORKING)
 #include <hpx/assert.hpp>
-#include <hpx/modules/async_distributed.hpp>
+#include <hpx/modules/futures.hpp>
 #include <hpx/modules/serialization.hpp>
 #include <hpx/modules/type_support.hpp>
+
+#include <hpx/modules/async_distributed.hpp>
 
 #include <hpx/agas_base/detail/hosted_component_namespace.hpp>
 #include <hpx/agas_base/server/component_namespace.hpp>
@@ -31,90 +33,92 @@ namespace hpx::agas::detail {
     }
 
     components::component_type hosted_component_namespace::bind_prefix(
-        std::string const& key, std::uint32_t prefix)
+        [[maybe_unused]] std::string const& key,
+        [[maybe_unused]] std::uint32_t prefix)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-        server::component_namespace::bind_prefix_action action;
-        return action(gid_, key, prefix);
+        constexpr server::component_namespace::bind_prefix_action action;
+        return hpx::wait_or_handle_timeout(
+            hpx::async(action, gid_, key, prefix),
+            "hosted_component_namespace::bind_prefix");
 #else
-        HPX_UNUSED(key);
-        HPX_UNUSED(prefix);
         HPX_ASSERT(false);
         return components::component_type{};
 #endif
     }
 
     components::component_type hosted_component_namespace::bind_name(
-        std::string const& name)
+        [[maybe_unused]] std::string const& name)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-        server::component_namespace::bind_name_action action;
-        return action(gid_, name);
+        constexpr server::component_namespace::bind_name_action action;
+        return hpx::wait_or_handle_timeout(hpx::async(action, gid_, name),
+            "hosted_component_namespace::bind_name");
 #else
-        HPX_UNUSED(name);
         HPX_ASSERT(false);
         return components::component_type{};
 #endif
     }
 
     std::vector<std::uint32_t> hosted_component_namespace::resolve_id(
-        components::component_type key)
+        [[maybe_unused]] components::component_type key)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-        server::component_namespace::resolve_id_action action;
-        return action(gid_, key);
+        constexpr server::component_namespace::resolve_id_action action;
+        return hpx::wait_or_handle_timeout(hpx::async(action, gid_, key),
+            "hosted_component_namespace::resolve_id");
 #else
-        HPX_UNUSED(key);
         HPX_ASSERT(false);
         return std::vector<std::uint32_t>{1, std::uint32_t(0)};
 #endif
     }
 
-    bool hosted_component_namespace::unbind(std::string const& key)
+    bool hosted_component_namespace::unbind(
+        [[maybe_unused]] std::string const& key)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-        server::component_namespace::unbind_action action;
-        return action(gid_, key);
+        constexpr server::component_namespace::unbind_action action;
+        return hpx::wait_or_handle_timeout(hpx::async(action, gid_, key),
+            "hosted_component_namespace::unbind");
 #else
-        HPX_UNUSED(key);
         HPX_ASSERT(false);
         return true;
 #endif
     }
 
     void hosted_component_namespace::iterate_types(
-        iterate_types_function_type const& f)
+        [[maybe_unused]] iterate_types_function_type const& f)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-        server::component_namespace::iterate_types_action action;
-        return action(gid_, f);
+        constexpr server::component_namespace::iterate_types_action action;
+        return hpx::wait_or_handle_timeout(hpx::async(action, gid_, f),
+            "hosted_component_namespace::iterate_types");
 #else
-        HPX_UNUSED(f);
         HPX_ASSERT(false);
 #endif
     }
 
     std::string hosted_component_namespace::get_component_type_name(
-        components::component_type type)
+        [[maybe_unused]] components::component_type type)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-        server::component_namespace::get_component_type_name_action action;
-        return action(gid_, type);
+        constexpr server::component_namespace::get_component_type_name_action
+            action;
+        return hpx::wait_or_handle_timeout(hpx::async(action, gid_, type),
+            "hosted_component_namespace::get_component_type_name");
 #else
-        HPX_UNUSED(type);
         HPX_ASSERT(false);
         return std::string{};
 #endif
     }
 
     hpx::future<std::uint32_t> hosted_component_namespace::get_num_localities(
-        components::component_type type)
+        [[maybe_unused]] components::component_type type)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         server::component_namespace::get_num_localities_action action;
         return hpx::async(action, gid_, type);
 #else
-        HPX_UNUSED(type);
         HPX_ASSERT(false);
         return hpx::make_ready_future(std::uint32_t(1));
 #endif

--- a/libs/full/agas_base/src/detail/hosted_locality_namespace.cpp
+++ b/libs/full/agas_base/src/detail/hosted_locality_namespace.cpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2011 Bryce Lelbach
-//  Copyright (c) 2012-2021 Hartmut Kaiser
+//  Copyright (c) 2012-2026 Hartmut Kaiser
 //  Copyright (c) 2016 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -10,18 +10,18 @@
 
 #if defined(HPX_HAVE_NETWORKING)
 #include <hpx/assert.hpp>
+#include <hpx/modules/futures.hpp>
+#include <hpx/modules/serialization.hpp>
+#include <hpx/modules/type_support.hpp>
+
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/modules/parcelset_base.hpp>
-#include <hpx/modules/serialization.hpp>
-#include <hpx/modules/type_support.hpp>
 
 #include <hpx/agas_base/detail/hosted_locality_namespace.hpp>
 #include <hpx/agas_base/server/locality_namespace.hpp>
 
 #include <cstdint>
-#include <map>
-#include <string>
 #include <vector>
 
 namespace hpx::agas::detail {
@@ -42,22 +42,25 @@ namespace hpx::agas::detail {
         return 0;
     }
 
-    void hosted_locality_namespace::free(naming::gid_type const& locality)
+    bool hosted_locality_namespace::free(
+        [[maybe_unused]] naming::gid_type const& locality)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-        server::locality_namespace::free_action action;
-        action(gid_, locality);
+        constexpr server::locality_namespace::free_action action;
+        return hpx::wait_or_handle_timeout(hpx::async(action, gid_, locality),
+            "hosted_locality_namespace::free");
 #else
-        HPX_UNUSED(locality);
         HPX_ASSERT(false);
+        return false;
 #endif
     }
 
     std::vector<std::uint32_t> hosted_locality_namespace::localities()
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-        server::locality_namespace::localities_action action;
-        return action(gid_);
+        constexpr server::locality_namespace::localities_action action;
+        return hpx::wait_or_handle_timeout(
+            hpx::async(action, gid_), "hosted_locality_namespace::localities");
 #else
         HPX_ASSERT(false);
         return std::vector<std::uint32_t>{};
@@ -65,10 +68,10 @@ namespace hpx::agas::detail {
     }
 
     parcelset::endpoints_type hosted_locality_namespace::resolve_locality(
-        naming::gid_type const& locality)
+        [[maybe_unused]] naming::gid_type const& locality)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-        server::locality_namespace::resolve_locality_action action;
+        constexpr server::locality_namespace::resolve_locality_action action;
         future<parcelset::endpoints_type> endpoints_future =
             hpx::async(action, gid_, locality);
 
@@ -81,9 +84,9 @@ namespace hpx::agas::detail {
                 /**/;
         }
 
-        return endpoints_future.get();
+        return hpx::wait_or_handle_timeout(HPX_MOVE(endpoints_future),
+            "hosted_locality_namespace::resolve_locality");
 #else
-        HPX_UNUSED(locality);
         HPX_ASSERT(false);
         return parcelset::endpoints_type{};
 #endif
@@ -92,8 +95,9 @@ namespace hpx::agas::detail {
     std::uint32_t hosted_locality_namespace::get_num_localities()
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-        server::locality_namespace::get_num_localities_action action;
-        return action(gid_);
+        constexpr server::locality_namespace::get_num_localities_action action;
+        return hpx::wait_or_handle_timeout(hpx::async(action, gid_),
+            "hosted_locality_namespace::get_num_localities");
 #else
         HPX_ASSERT(false);
         return std::uint32_t{};
@@ -104,7 +108,7 @@ namespace hpx::agas::detail {
     hosted_locality_namespace::get_num_localities_async()
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-        server::locality_namespace::get_num_localities_action action;
+        constexpr server::locality_namespace::get_num_localities_action action;
         return hpx::async(action, gid_);
 #else
         HPX_ASSERT(false);
@@ -115,8 +119,9 @@ namespace hpx::agas::detail {
     std::vector<std::uint32_t> hosted_locality_namespace::get_num_threads()
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-        server::locality_namespace::get_num_threads_action action;
-        return action(gid_);
+        constexpr server::locality_namespace::get_num_threads_action action;
+        return hpx::wait_or_handle_timeout(hpx::async(action, gid_),
+            "hosted_locality_namespace::get_num_threads");
 #else
         HPX_ASSERT(false);
         return std::vector<std::uint32_t>{};
@@ -127,7 +132,7 @@ namespace hpx::agas::detail {
     hosted_locality_namespace::get_num_threads_async()
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-        server::locality_namespace::get_num_threads_action action;
+        constexpr server::locality_namespace::get_num_threads_action action;
         return hpx::async(action, gid_);
 #else
         HPX_ASSERT(false);
@@ -138,8 +143,10 @@ namespace hpx::agas::detail {
     std::uint32_t hosted_locality_namespace::get_num_overall_threads()
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-        server::locality_namespace::get_num_overall_threads_action action;
-        return action(gid_);
+        constexpr server::locality_namespace::get_num_overall_threads_action
+            action;
+        return hpx::wait_or_handle_timeout(hpx::async(action, gid_),
+            "hosted_locality_namespace::get_num_overall_threads");
 #else
         HPX_ASSERT(false);
         return hpx::resource::get_num_threads();
@@ -150,7 +157,8 @@ namespace hpx::agas::detail {
     hosted_locality_namespace::get_num_overall_threads_async()
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-        server::locality_namespace::get_num_overall_threads_action action;
+        constexpr server::locality_namespace::get_num_overall_threads_action
+            action;
         return hpx::async(action, gid_);
 #else
         HPX_ASSERT(false);

--- a/libs/full/agas_base/src/server/component_namespace_server.cpp
+++ b/libs/full/agas_base/src/server/component_namespace_server.cpp
@@ -47,7 +47,8 @@ namespace hpx::agas::server {
         char const* servicename, error_code& ec)
     {
         // now register this AGAS instance with AGAS :-P
-        instance_name_ = agas::service_name;
+        instance_name_ = hpx::util::format(agas::service_name,
+            agas::is_connecting() ? agas::get_locality_id() : 0);
         instance_name_ += servicename;
         instance_name_ += agas::server::component_namespace_service_name;
 

--- a/libs/full/agas_base/src/server/locality_namespace_server.cpp
+++ b/libs/full/agas_base/src/server/locality_namespace_server.cpp
@@ -51,7 +51,8 @@ namespace hpx::agas::server {
         char const* servicename, error_code& ec)
     {
         // now register this AGAS instance with AGAS :-P
-        instance_name_ = agas::service_name;
+        instance_name_ = hpx::util::format(agas::service_name,
+            agas::is_connecting() ? agas::get_locality_id() : 0);
         instance_name_ += servicename;
         instance_name_ += agas::server::locality_namespace_service_name;
 
@@ -109,7 +110,7 @@ namespace hpx::agas::server {
 
         // check if the suggested prefix can be used instead of the next
         // free one
-        std::uint32_t suggested_locality_id =
+        std::uint32_t const suggested_locality_id =
             naming::get_locality_id_from_gid(suggested_prefix);
 
         partition_table_type::iterator it = partitions_.end();
@@ -161,7 +162,7 @@ namespace hpx::agas::server {
         // table so that parcels can be sent to the memory of a locality.
         if (primary_)
         {
-            naming::gid_type id(naming::get_gid_from_locality_id(prefix));
+            naming::gid_type const id(naming::get_gid_from_locality_id(prefix));
             gva const g(id,
                 to_int(hpx::components::component_enum_type::runtime_support),
                 count);
@@ -191,10 +192,10 @@ namespace hpx::agas::server {
         counter_data_.increment_resolve_locality_count();
 
         using hpx::get;
-        std::uint32_t prefix = naming::get_locality_id_from_gid(locality);
+        std::uint32_t const prefix = naming::get_locality_id_from_gid(locality);
 
         std::lock_guard<mutex_type> l(mutex_);
-        partition_table_type::iterator it = partitions_.find(prefix);
+        partition_table_type::iterator const it = partitions_.find(prefix);
 
         if (it != partitions_.end())
         {
@@ -204,7 +205,7 @@ namespace hpx::agas::server {
         return parcelset::endpoints_type();
     }    // }}}
 
-    void locality_namespace::free(naming::gid_type const& locality)
+    bool locality_namespace::free(naming::gid_type const& locality)
     {    // {{{ free implementation
         util::scoped_timer<std::atomic<std::int64_t>> update(
             counter_data_.free_.time_, counter_data_.free_.enabled_);
@@ -213,24 +214,13 @@ namespace hpx::agas::server {
         using hpx::get;
 
         // parameters
-        std::uint32_t prefix = naming::get_locality_id_from_gid(locality);
+        std::uint32_t const prefix = naming::get_locality_id_from_gid(locality);
 
         std::unique_lock<mutex_type> l(mutex_);
 
-        partition_table_type::iterator pit = partitions_.find(prefix),
-                                       pend = partitions_.end();
-
+        auto const pit = partitions_.find(prefix), pend = partitions_.end();
         if (pit != pend)
         {
-            /*
-        // Wipe the locality from the tables.
-        naming::gid_type locality =
-            naming::get_gid_from_locality_id(get<0>(pit->second));
-
-        // first remove entry from reverse partition table
-        prefixes_.erase(get<0>(pit->second));
-        */
-
             // now remove it from the main partition table
             partitions_.erase(pit);
 
@@ -240,7 +230,7 @@ namespace hpx::agas::server {
 
                 // remove primary namespace
                 {
-                    naming::gid_type service(
+                    constexpr naming::gid_type service(
                         agas::primary_ns_msb, agas::primary_ns_lsb);
                     primary_->unbind_gid(
                         1, naming::replace_locality_id(service, prefix));
@@ -248,23 +238,18 @@ namespace hpx::agas::server {
 
                 // remove symbol namespace
                 {
-                    naming::gid_type service(
+                    constexpr naming::gid_type service(
                         agas::symbol_ns_msb, agas::symbol_ns_lsb);
                     primary_->unbind_gid(
                         1, naming::replace_locality_id(service, prefix));
                 }
 
                 // remove locality itself
-                {
-                    primary_->unbind_gid(0, locality);
-                }
+                primary_->unbind_gid(0, locality);
             }
-
-            /*LAGAS_(info).format("locality_namespace::free, ep({1})", ep);*/
+            return true;
         }
-
-        /*LAGAS_(info).format(
-            "locality_namespace::free, ep({1}), response(no_success)", ep);*/
+        return false;
     }    // }}}
 
     std::vector<std::uint32_t> locality_namespace::localities()
@@ -298,7 +283,7 @@ namespace hpx::agas::server {
         counter_data_.increment_num_localities_count();
         std::lock_guard<mutex_type> l(mutex_);
 
-        std::uint32_t num_localities =
+        std::uint32_t const num_localities =
             static_cast<std::uint32_t>(partitions_.size());
 
         LAGAS_(info).format(
@@ -314,7 +299,7 @@ namespace hpx::agas::server {
 
         std::vector<std::uint32_t> num_threads;
 
-        partition_table_type::iterator end = partitions_.end();
+        partition_table_type::iterator const end = partitions_.end();
         for (partition_table_type::iterator it = partitions_.begin(); it != end;
             ++it)
         {
@@ -335,7 +320,7 @@ namespace hpx::agas::server {
 
         std::uint32_t num_threads = 0;
 
-        partition_table_type::iterator end = partitions_.end();
+        partition_table_type::iterator const end = partitions_.end();
         for (partition_table_type::iterator it = partitions_.begin(); it != end;
             ++it)
         {

--- a/libs/full/agas_base/src/server/primary_namespace_server.cpp
+++ b/libs/full/agas_base/src/server/primary_namespace_server.cpp
@@ -12,6 +12,7 @@
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/modules/format.hpp>
 #include <hpx/modules/lock_registration.hpp>
 #include <hpx/modules/logging.hpp>
 #include <hpx/modules/timing.hpp>
@@ -57,7 +58,8 @@ namespace hpx::agas::server {
         this->base_type::set_locality_id(locality_id);
 
         // now register this AGAS instance with AGAS :-P
-        instance_name_ = agas::service_name;
+        instance_name_ = hpx::util::format(agas::service_name,
+            agas::is_connecting() ? agas::get_locality_id() : 0);
         instance_name_ += servicename;
         instance_name_ += agas::server::primary_namespace_service_name;
 

--- a/libs/full/agas_base/src/server/symbol_namespace_server.cpp
+++ b/libs/full/agas_base/src/server/symbol_namespace_server.cpp
@@ -55,7 +55,8 @@ namespace hpx::agas::server {
         this->base_type::set_locality_id(locality_id);
 
         // now register this AGAS instance with AGAS :-P
-        instance_name_ = agas::service_name;
+        instance_name_ = hpx::util::format(agas::service_name,
+            agas::is_connecting() ? agas::get_locality_id() : 0);
         instance_name_ += servicename;
         instance_name_ += agas::server::symbol_namespace_service_name;
 

--- a/libs/full/agas_base/src/symbol_namespace.cpp
+++ b/libs/full/agas_base/src/symbol_namespace.cpp
@@ -55,7 +55,7 @@ HPX_REGISTER_ACTION_ID(symbol_namespace::on_event_action,
 namespace hpx::agas {
 
     naming::gid_type symbol_namespace::get_service_instance(
-        std::uint32_t service_locality_id)
+        std::uint32_t const service_locality_id)
     {
         constexpr naming::gid_type service(
             agas::symbol_ns_msb, agas::symbol_ns_lsb);
@@ -99,9 +99,11 @@ namespace hpx::agas {
                 std::int32_t const locality_id =
                     util::from_string<std::int32_t>(key.substr(1, p - 1), -1);
 
-                if (locality_id >= 0 &&
-                    static_cast<std::uint32_t>(locality_id) <
-                        get_initial_num_localities())
+                if ((locality_id >= 0 &&
+                        static_cast<std::uint32_t>(locality_id) <
+                            get_initial_num_localities()) ||
+                    agas::get_locality_id() ==
+                        static_cast<std::uint32_t>(locality_id))
                 {
                     return {get_service_instance(locality_id),
                         hpx::id_type::management_type::unmanaged};
@@ -319,7 +321,7 @@ namespace hpx::agas {
 
     ///////////////////////////////////////////////////////////////////////////
     void symbol_namespace::register_server_instance(
-        std::uint32_t locality_id) const
+        std::uint32_t const locality_id) const
     {
         std::string const str("locality#" + std::to_string(locality_id) + "/");
         server_->register_server_instance(str.c_str(), locality_id);

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/async_implementations.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/async_implementations.hpp
@@ -8,6 +8,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/modules/allocator_support.hpp>
+#include <hpx/modules/async_base.hpp>
 #include <hpx/modules/concurrency.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>
@@ -18,8 +20,6 @@
 #include <hpx/modules/tracing.hpp>
 
 #include <hpx/modules/actions_base.hpp>
-#include <hpx/modules/allocator_support.hpp>
-#include <hpx/modules/async_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/modules/parcelset_base.hpp>
@@ -424,6 +424,16 @@ namespace hpx::detail {
         using action_type = hpx::traits::extract_action_t<Action>;
         using component_type = action_type::component_type;
 
+#if defined(HPX_HAVE_FORCE_DISCONNECT)
+        if (parcelset::locality_was_disconnected(
+                naming::get_locality_id_from_id(id)))
+        {
+            HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
+                "hpx::detail::async_impl",
+                "the requested locality {} was disconnected", id);
+        }
+#endif
+
         [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
         naming::address addr;
 
@@ -484,6 +494,16 @@ namespace hpx::detail {
         using action_type = hpx::traits::extract_action_t<Action>;
         using result_type = action_type::local_result_type;
         using component_type = action_type::component_type;
+
+#if defined(HPX_HAVE_FORCE_DISCONNECT)
+        if (parcelset::locality_was_disconnected(
+                naming::get_locality_id_from_id(id)))
+        {
+            HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
+                "hpx::detail::async_cb_impl",
+                "the requested locality {} was disconnected", id);
+        }
+#endif
 
         [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
         naming::address addr;
@@ -590,6 +610,16 @@ namespace hpx::detail {
         using result_type = action_type::local_result_type;
         using component_type = action_type::component_type;
 
+#if defined(HPX_HAVE_FORCE_DISCONNECT)
+        if (parcelset::locality_was_disconnected(
+                naming::get_locality_id_from_id(id)))
+        {
+            HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
+                "hpx::detail::async_impl",
+                "the requested locality {} was disconnected", id);
+        }
+#endif
+
         [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
         naming::address addr;
 
@@ -653,6 +683,16 @@ namespace hpx::detail {
         using action_type = hpx::traits::extract_action_t<Action>;
         using result_type = action_type::local_result_type;
         using component_type = action_type::component_type;
+
+#if defined(HPX_HAVE_FORCE_DISCONNECT)
+        if (parcelset::locality_was_disconnected(
+                naming::get_locality_id_from_id(id)))
+        {
+            HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
+                "hpx::detail::async_impl",
+                "the requested locality {} was disconnected", id);
+        }
+#endif
 
         [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
         naming::address addr;
@@ -731,6 +771,16 @@ namespace hpx::detail {
     {
         using action_type = hpx::traits::extract_action_t<Action>;
         using result_type = action_type::local_result_type;
+
+#if defined(HPX_HAVE_FORCE_DISCONNECT)
+        if (parcelset::locality_was_disconnected(
+                naming::get_locality_id_from_id(id)))
+        {
+            HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
+                "hpx::detail::async_impl",
+                "the requested locality {} was disconnected", id);
+        }
+#endif
 
         naming::address addr;
         [[maybe_unused]] bool result = agas::is_local_address_cached(id, addr);

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/async_unwrap_result_implementations.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/async_unwrap_result_implementations.hpp
@@ -8,8 +8,10 @@
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
-#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
+#include <hpx/modules/errors.hpp>
+
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/modules/parcelset_base.hpp>
@@ -63,6 +65,16 @@ namespace hpx::detail {
     {
         using action_type = hpx::traits::extract_action_t<Action>;
         using component_type = typename action_type::component_type;
+
+#if defined(HPX_HAVE_FORCE_DISCONNECT)
+        if (parcelset::locality_was_disconnected(
+                naming::get_locality_id_from_id(id)))
+        {
+            HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
+                "hpx::detail::async_unwrap_result_impl",
+                "the requested locality {} was disconnected", id);
+        }
+#endif
 
         [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
         naming::address addr;

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/post_implementations.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/post_implementations.hpp
@@ -39,6 +39,16 @@ namespace hpx::detail {
                 hpx::actions::detail::get_action_name<action_type>());
         }
 
+#if defined(HPX_HAVE_FORCE_DISCONNECT)
+        if (parcelset::locality_was_disconnected(
+                naming::get_locality_id_from_id(id)))
+        {
+            HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
+                "hpx::detail::post_impl",
+                "the requested locality {} was disconnected", id);
+        }
+#endif
+
         [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
         naming::address addr;
 
@@ -109,6 +119,16 @@ namespace hpx::detail {
                 hpx::actions::detail::get_action_name<action_type>());
         }
 
+#if defined(HPX_HAVE_FORCE_DISCONNECT)
+        if (parcelset::locality_was_disconnected(
+                naming::get_locality_id_from_id(id)))
+        {
+            HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
+                "hpx::detail::post_impl",
+                "the requested locality {} was disconnected", id);
+        }
+#endif
+
         if (naming::get_locality_id_from_gid(addr.locality_) ==
             agas::get_locality_id())
         {
@@ -151,6 +171,16 @@ namespace hpx::detail {
                 "the target (destination) does not match the action type ({})",
                 hpx::actions::detail::get_action_name<action_type>());
         }
+
+#if defined(HPX_HAVE_FORCE_DISCONNECT)
+        if (parcelset::locality_was_disconnected(
+                naming::get_locality_id_from_id(id)))
+        {
+            HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
+                "hpx::detail::post_impl",
+                "the requested locality {} was disconnected", id);
+        }
+#endif
 
         [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
         naming::address addr;
@@ -217,6 +247,16 @@ namespace hpx::detail {
                 hpx::actions::detail::get_action_name<action_type>());
         }
 
+#if defined(HPX_HAVE_FORCE_DISCONNECT)
+        if (parcelset::locality_was_disconnected(
+                naming::get_locality_id_from_id(id)))
+        {
+            HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
+                "hpx::detail::post_impl",
+                "the requested locality {} was disconnected", id);
+        }
+#endif
+
         if (naming::get_locality_id_from_gid(addr.locality_) ==
             agas::get_locality_id())
         {
@@ -261,6 +301,16 @@ namespace hpx::detail {
                 "the target (destination) does not match the action type ({})",
                 hpx::actions::detail::get_action_name<action_type>());
         }
+
+#if defined(HPX_HAVE_FORCE_DISCONNECT)
+        if (parcelset::locality_was_disconnected(
+                naming::get_locality_id_from_id(id)))
+        {
+            HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
+                "hpx::detail::post_impl",
+                "the requested locality {} was disconnected", id);
+        }
+#endif
 
         [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
         naming::address addr;
@@ -330,6 +380,16 @@ namespace hpx::detail {
                 "the target (destination) does not match the action type ({})",
                 hpx::actions::detail::get_action_name<action_type>());
         }
+
+#if defined(HPX_HAVE_FORCE_DISCONNECT)
+        if (parcelset::locality_was_disconnected(
+                naming::get_locality_id_from_id(id)))
+        {
+            HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
+                "hpx::detail::post_impl",
+                "the requested locality {} was disconnected", id);
+        }
+#endif
 
         [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
         naming::address addr;

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/sync_implementations.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/sync_implementations.hpp
@@ -7,13 +7,17 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/async_distributed/detail/async_implementations.hpp>
-#include <hpx/async_distributed/detail/sync_implementations_fwd.hpp>
-#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/async_local.hpp>
+#include <hpx/modules/errors.hpp>
+
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/naming_base.hpp>
+#include <hpx/modules/parcelset_base.hpp>
+
+#include <hpx/async_distributed/detail/async_implementations.hpp>
+#include <hpx/async_distributed/detail/sync_implementations_fwd.hpp>
 
 #include <utility>
 
@@ -57,6 +61,16 @@ namespace hpx::detail {
         using action_type = hpx::traits::extract_action_t<Action>;
         using result_type = action_type::local_result_type;
         using component_type = action_type::component_type;
+
+#if defined(HPX_HAVE_FORCE_DISCONNECT)
+        if (parcelset::locality_was_disconnected(
+                naming::get_locality_id_from_id(id)))
+        {
+            HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
+                "hpx::detail::sync_impl",
+                "the requested locality {} was disconnected", id);
+        }
+#endif
 
         [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
         naming::address addr;

--- a/libs/full/async_distributed/include/hpx/async_distributed/packaged_action.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/packaged_action.hpp
@@ -429,6 +429,16 @@ namespace hpx::lcos {
             using action_type = hpx::traits::extract_action_t<Action>;
             using component_type = action_type::component_type;
 
+#if defined(HPX_HAVE_FORCE_DISCONNECT)
+            if (parcelset::locality_was_disconnected(
+                    naming::get_locality_id_from_id(id)))
+            {
+                HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
+                    "hpx::detail::post",
+                    "the requested locality {} was disconnected", id);
+            }
+#endif
+
             [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
             naming::address addr;
 
@@ -488,6 +498,16 @@ namespace hpx::lcos {
             using action_type = hpx::traits::extract_action_t<Action>;
             using component_type = action_type::component_type;
 
+#if defined(HPX_HAVE_FORCE_DISCONNECT)
+            if (parcelset::locality_was_disconnected(
+                    naming::get_locality_id_from_id(id)))
+            {
+                HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
+                    "hpx::detail::post",
+                    "the requested locality {} was disconnected", id);
+            }
+#endif
+
             if (addr &&
                 naming::get_locality_id_from_gid(addr.locality_) ==
                     agas::get_locality_id())
@@ -527,6 +547,16 @@ namespace hpx::lcos {
         {
             using action_type = hpx::traits::extract_action_t<Action>;
             using component_type = action_type::component_type;
+
+#if defined(HPX_HAVE_FORCE_DISCONNECT)
+            if (parcelset::locality_was_disconnected(
+                    naming::get_locality_id_from_id(id)))
+            {
+                HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
+                    "hpx::detail::post_cb",
+                    "the requested locality {} was disconnected", id);
+            }
+#endif
 
             [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
             naming::address addr;
@@ -587,6 +617,16 @@ namespace hpx::lcos {
         void post_cb(naming::address&& addr, hpx::id_type const& id,
             Callback&& cb, Ts&&... vs)
         {
+#if defined(HPX_HAVE_FORCE_DISCONNECT)
+            if (parcelset::locality_was_disconnected(
+                    naming::get_locality_id_from_id(id)))
+            {
+                HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
+                    "hpx::detail::post_cb",
+                    "the requested locality {} was disconnected", id);
+            }
+#endif
+
             if (addr &&
                 naming::get_locality_id_from_gid(addr.locality_) ==
                     agas::get_locality_id())

--- a/libs/full/async_distributed/include/hpx/async_distributed/trigger.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/trigger.hpp
@@ -21,6 +21,31 @@
 
 namespace hpx::actions {
 
+    namespace detail {
+
+        HPX_CXX_EXPORT template <typename Result, typename RemoteResult>
+        void trigger_error(typed_continuation<Result, RemoteResult> const& cont,
+            std::exception_ptr const& ex) noexcept
+        {
+            hpx::detail::try_catch_exception_ptr(
+                [&] {
+                    // make sure hpx::exceptions are propagated back to the client
+                    cont.trigger_error(ex);
+                },
+                [&](std::exception_ptr const&) {
+#if defined(HPX_HAVE_FORCE_DISCONNECT)
+                    if (parcelset::locality_was_disconnected(
+                            naming::get_locality_id_from_id(cont.get_id())))
+                    {
+                        // ignore any errors as locality is now unreachable
+                        return;
+                    }
+#endif
+                    std::abort();    // nothing we can do here
+                });
+        }
+    }    // namespace detail
+
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Invoke \a f with the given arguments and forward its result to
     ///        \a cont.
@@ -40,16 +65,15 @@ namespace hpx::actions {
     void trigger(typed_continuation<Result, RemoteResult>&& cont, F&& f,
         Ts&&... vs) noexcept
     {
-        try
-        {
-            cont.trigger_value(
-                HPX_INVOKE(HPX_FORWARD(F, f), HPX_FORWARD(Ts, vs)...));
-        }
-        catch (...)
-        {
-            // make sure hpx::exceptions are propagated back to the client
-            cont.trigger_error(std::current_exception());
-        }
+        hpx::detail::try_catch_exception_ptr(
+            [&] {
+                cont.trigger_value(
+                    HPX_INVOKE(HPX_FORWARD(F, f), HPX_FORWARD(Ts, vs)...));
+            },
+            [&](std::exception_ptr const& ep) {
+                // make sure hpx::exceptions are propagated back to the client
+                detail::trigger_error(cont, ep);
+            });
     }
 
     /// \brief Invoke \a f with the given arguments and notify \a cont of
@@ -69,15 +93,14 @@ namespace hpx::actions {
     void trigger(typed_continuation<Result, util::unused_type>&& cont, F&& f,
         Ts&&... vs) noexcept
     {
-        try
-        {
-            HPX_INVOKE(HPX_FORWARD(F, f), HPX_FORWARD(Ts, vs)...);
-            cont.trigger();
-        }
-        catch (...)
-        {
-            // make sure hpx::exceptions are propagated back to the client
-            cont.trigger_error(std::current_exception());
-        }
+        hpx::detail::try_catch_exception_ptr(
+            [&] {
+                HPX_INVOKE(HPX_FORWARD(F, f), HPX_FORWARD(Ts, vs)...);
+                cont.trigger();
+            },
+            [&](std::exception_ptr const& ep) {
+                // make sure hpx::exceptions are propagated back to the client
+                detail::trigger_error(cont, ep);
+            });
     }
 }    // namespace hpx::actions

--- a/libs/full/components_base/include/hpx/components_base/agas_interface.hpp
+++ b/libs/full/components_base/include/hpx/components_base/agas_interface.hpp
@@ -38,6 +38,8 @@ namespace hpx::agas {
 
     ///////////////////////////////////////////////////////////////////////////
     HPX_CXX_EXPORT HPX_EXPORT bool is_console();
+    HPX_CXX_EXPORT HPX_EXPORT bool is_connecting(
+        naming::gid_type const& locality = naming::invalid_gid);
 
     ///////////////////////////////////////////////////////////////////////////
     HPX_CXX_EXPORT HPX_EXPORT bool register_name(launch::sync_policy,

--- a/libs/full/components_base/include/hpx/components_base/detail/agas_interface_functions.hpp
+++ b/libs/full/components_base/include/hpx/components_base/detail/agas_interface_functions.hpp
@@ -27,6 +27,8 @@ namespace hpx::agas::detail {
 
     ///////////////////////////////////////////////////////////////////////////
     HPX_CXX_EXPORT extern HPX_EXPORT bool (*is_console)();
+    HPX_CXX_EXPORT extern HPX_EXPORT bool (*is_connecting)(
+        naming::gid_type const&);
 
     ///////////////////////////////////////////////////////////////////////////
     HPX_CXX_EXPORT extern HPX_EXPORT bool (*register_name)(

--- a/libs/full/components_base/src/agas_interface.cpp
+++ b/libs/full/components_base/src/agas_interface.cpp
@@ -33,6 +33,11 @@ namespace hpx::agas {
         return detail::is_console();
     }
 
+    bool is_connecting(naming::gid_type const& locality)
+    {
+        return detail::is_connecting(locality);
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     bool register_name(launch::sync_policy, std::string const& name,
         naming::gid_type const& gid, error_code& ec)

--- a/libs/full/components_base/src/detail/agas_interface_functions.cpp
+++ b/libs/full/components_base/src/detail/agas_interface_functions.cpp
@@ -28,6 +28,7 @@ namespace hpx::agas::detail {
 
     ///////////////////////////////////////////////////////////////////////////
     bool (*is_console)() = nullptr;
+    bool (*is_connecting)(naming::gid_type const&) = nullptr;
 
     ///////////////////////////////////////////////////////////////////////////
     bool (*register_name)(std::string const& name, naming::gid_type const& gid,

--- a/libs/full/init_runtime/CMakeLists.txt
+++ b/libs/full/init_runtime/CMakeLists.txt
@@ -39,6 +39,7 @@ if(HPX_WITH_DISTRIBUTED_RUNTIME)
       hpx_collectives
       hpx_components_base
       hpx_naming
+      hpx_naming_base
       hpx_parcelports
       hpx_performance_counters
       hpx_runtime_components

--- a/libs/full/init_runtime/include/hpx/init_runtime/finalize.hpp
+++ b/libs/full/init_runtime/include/hpx/init_runtime/finalize.hpp
@@ -12,6 +12,9 @@
 
 #include <hpx/config.hpp>
 #include <hpx/modules/errors.hpp>
+#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
+#include <hpx/modules/naming_base.hpp>
+#endif
 
 #include <hpx/config/warnings_prefix.hpp>
 
@@ -196,6 +199,38 @@ namespace hpx {
     {
         return disconnect(-1.0, -1.0, ec);
     }
+
+#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
+    /// \brief Force disconnecting the given locality from the application.
+    ///
+    /// The function \a hpx::force_disconnect can be used to disconnect a
+    /// locality from a running HPX application.
+    ///
+    /// This function should be used from the console locality only to force the
+    /// disconnect of a different (i.e. the given) locality. It should not be
+    /// used by a locality to disconnect itself (use \a hpx::disconnect()
+    /// without the locality argument for this purpose).
+    ///
+    /// \param locality The locality to remove from the distributed connection
+    ///        caches
+    /// \param ec [in,out] this represents the error status on exit, if this
+    ///           is pre-initialized to \a hpx#throws the function will throw on
+    ///           error instead.
+    ///
+    /// \returns  This function will always return zero if successful, -1 otherwise.
+    ///
+    /// \note     As long as \a ec is not pre-initialized to \a hpx::throws this
+    ///           function doesn't throw but returns the result code using the
+    ///           parameter \a ec. Otherwise, it throws an instance of
+    ///           hpx::exception.
+    ///
+    /// This function will block and wait for this locality to finish executing
+    /// before returning to the caller. It should be the last HPX-function
+    /// called by any locality being disconnected.
+    ///
+    HPX_CXX_EXPORT HPX_EXPORT int force_disconnect(
+        hpx::id_type const& locality, hpx::error_code& ec = throws);
+#endif
 
     /// \brief Stop the runtime system
     ///

--- a/libs/full/init_runtime/src/hpx_init.cpp
+++ b/libs/full/init_runtime/src/hpx_init.cpp
@@ -93,7 +93,7 @@ namespace hpx_startup {
 namespace hpx::detail {
 
     // forward declarations only
-    void console_print(std::string const&);
+    static void console_print(std::string const&);
 
     int init_impl(
         hpx::function<int(hpx::program_options::variables_map&)> const& f,
@@ -182,8 +182,9 @@ namespace hpx::detail {
 namespace hpx::detail {
 
     // forward declarations only
-    void list_symbolic_name(std::string const&, hpx::id_type const&);
-    void list_component_type(std::string const&, components::component_type);
+    static void list_symbolic_name(std::string const&, hpx::id_type const&);
+    static void list_component_type(
+        std::string const&, components::component_type);
 }    // namespace hpx::detail
 
 HPX_PLAIN_ACTION_ID(hpx::detail::console_print, console_print_action,
@@ -214,7 +215,7 @@ namespace hpx::detail {
         std::cout << name << std::endl;
     }
 
-    inline void print(std::string const& name, error_code& ec = throws)
+    static void print(std::string const& name, error_code& ec = throws)
     {
 #if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
         hpx::id_type console(agas::get_console_locality(ec));
@@ -234,7 +235,7 @@ namespace hpx::detail {
 #if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
     ///////////////////////////////////////////////////////////////////////////
     // redirect the printing of the given counter name to the console
-    bool list_counter(
+    static bool list_counter(
         performance_counters::counter_info const& info, error_code& ec)
     {
         print(info.fullname_, ec);
@@ -242,7 +243,7 @@ namespace hpx::detail {
     }
 
     // List the names of all registered performance counters.
-    void list_counter_names_header(bool skeleton)
+    static void list_counter_names_header(bool const skeleton)
     {
         // print header
         print("List of available counter instances");
@@ -251,7 +252,7 @@ namespace hpx::detail {
         print(std::string(78, '-'));
     }
 
-    void list_counter_names_minimal()
+    static void list_counter_names_minimal()
     {
         // list all counter names
         list_counter_names_header(true);
@@ -259,7 +260,7 @@ namespace hpx::detail {
             performance_counters::discover_counters_mode::minimal);
     }
 
-    void list_counter_names_full()
+    static void list_counter_names_full()
     {
         // list all counter names
         list_counter_names_header(false);
@@ -269,7 +270,7 @@ namespace hpx::detail {
 
     ///////////////////////////////////////////////////////////////////////////
     // redirect the printing of the full counter info to the console
-    bool list_counter_info(
+    static bool list_counter_info(
         performance_counters::counter_info const& info, error_code& ec)
     {
         // compose the information to be printed for each of the counters
@@ -294,7 +295,7 @@ namespace hpx::detail {
     }
 
     // List the names of all registered performance counters.
-    void list_counter_infos_header(bool skeleton)
+    static void list_counter_infos_header(bool const skeleton)
     {
         // print header
         print("Information about available counter instances");
@@ -303,7 +304,7 @@ namespace hpx::detail {
         print("--------------------------------------------------------");
     }
 
-    void list_counter_infos_minimal()
+    static void list_counter_infos_minimal()
     {
         // list all counter information
         list_counter_infos_header(true);
@@ -311,7 +312,7 @@ namespace hpx::detail {
             performance_counters::discover_counters_mode::minimal);
     }
 
-    void list_counter_infos_full()
+    static void list_counter_infos_full()
     {
         // list all counter information
         list_counter_infos_header(false);
@@ -329,7 +330,7 @@ namespace hpx::detail {
         print(str);
     }
 
-    void list_symbolic_names()
+    static void list_symbolic_names()
     {
         print(std::string("List of all registered symbolic names:"));
         print(std::string("--------------------------------------"));
@@ -345,13 +346,13 @@ namespace hpx::detail {
 
     ///////////////////////////////////////////////////////////////////////////
     void list_component_type(
-        std::string const& name, components::component_type ctype)
+        std::string const& name, components::component_type const ctype)
     {
         print(hpx::util::format(
             "{1:-40}, {2}", name, components::get_component_type_name(ctype)));
     }
 
-    void list_component_types()
+    static void list_component_types()
     {
         print(std::string("List of all registered component types:"));
         print(std::string("---------------------------------------"));
@@ -365,7 +366,7 @@ namespace hpx::detail {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    void start_counters(std::shared_ptr<util::query_counters> const& qc)
+    static void start_counters(std::shared_ptr<util::query_counters> const& qc)
     {
         try
         {
@@ -408,7 +409,7 @@ namespace hpx {
     namespace detail {
 
         ///////////////////////////////////////////////////////////////////////
-        void activate_global_options(
+        static void activate_global_options(
             util::command_line_handling& cmdline, int argc, char** argv)
         {
 #if defined(__linux) || defined(linux) || defined(__linux__) ||                \
@@ -457,7 +458,7 @@ namespace hpx {
 
         ///////////////////////////////////////////////////////////////////////
 #if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
-        void handle_list_and_print_options(hpx::runtime& rt,
+        static void handle_list_and_print_options(hpx::runtime& rt,
             hpx::program_options::variables_map& vm,
             bool print_counters_locally)
         {
@@ -471,7 +472,7 @@ namespace hpx {
             if (vm.count("hpx:list-counters"))
             {
                 // Print the names of all registered performance counters.
-                std::string option(vm["hpx:list-counters"].as<std::string>());
+                auto option(vm["hpx:list-counters"].as<std::string>());
                 if (0 == std::string("minimal").find(option))
                     rt.add_startup_function(&list_counter_names_minimal);
                 else if (0 == std::string("full").find(option))
@@ -488,8 +489,7 @@ namespace hpx {
             if (vm.count("hpx:list-counter-infos"))
             {
                 // Print info about all registered performance counters.
-                std::string option(
-                    vm["hpx:list-counter-infos"].as<std::string>());
+                auto option(vm["hpx:list-counter-infos"].as<std::string>());
                 if (0 == std::string("minimal").find(option))
                     rt.add_startup_function(&list_counter_infos_minimal);
                 else if (0 == std::string("full").find(option))
@@ -582,11 +582,10 @@ namespace hpx {
 
                 // schedule the query function at startup, which will schedule
                 // itself to run after the given interval
-                std::shared_ptr<util::query_counters> qc =
-                    std::make_shared<util::query_counters>(std::ref(counters),
-                        std::ref(reset_counters), interval, destination,
-                        counter_format, counter_shortnames, csv_header,
-                        print_counters_locally, counter_types);
+                auto qc = std::make_shared<util::query_counters>(
+                    std::ref(counters), std::ref(reset_counters), interval,
+                    destination, counter_format, counter_shortnames, csv_header,
+                    print_counters_locally, counter_types);
 
                 // schedule to print counters at shutdown, if requested
                 if (get_config_entry("hpx.print_counter.shutdown", "0") == "1")
@@ -641,8 +640,8 @@ namespace hpx {
         }
 #endif
 
-        void add_startup_functions(hpx::runtime& rt,
-            hpx::program_options::variables_map& vm, runtime_mode mode,
+        static void add_startup_functions(hpx::runtime& rt,
+            hpx::program_options::variables_map& vm, runtime_mode const mode,
             startup_function_type startup, shutdown_function_type shutdown)
         {
             if (vm.count("hpx:app-config"))
@@ -684,10 +683,10 @@ namespace hpx {
         }
 
         ///////////////////////////////////////////////////////////////////////
-        int run(hpx::runtime& rt,
+        static int run(hpx::runtime& rt,
             hpx::function<int(hpx::program_options::variables_map& vm)> const&
                 f,
-            hpx::program_options::variables_map& vm, runtime_mode mode,
+            hpx::program_options::variables_map& vm, runtime_mode const mode,
             startup_function_type startup, shutdown_function_type shutdown)
         {
             LPROGRESS_;
@@ -703,10 +702,10 @@ namespace hpx {
             return rt.run();
         }
 
-        int start(hpx::runtime& rt,
+        static int start(hpx::runtime& rt,
             hpx::function<int(hpx::program_options::variables_map& vm)> const&
                 f,
-            hpx::program_options::variables_map& vm, runtime_mode mode,
+            hpx::program_options::variables_map& vm, runtime_mode const mode,
             startup_function_type startup, shutdown_function_type shutdown)
         {
             LPROGRESS_;
@@ -724,9 +723,9 @@ namespace hpx {
             return rt.start();
         }
 
-        int run_or_start(bool blocking, std::unique_ptr<hpx::runtime> rt,
-            util::command_line_handling& cfg, startup_function_type startup,
-            shutdown_function_type shutdown)
+        static int run_or_start(bool const blocking,
+            std::unique_ptr<hpx::runtime> rt, util::command_line_handling& cfg,
+            startup_function_type startup, shutdown_function_type shutdown)
         {
             if (blocking)
             {
@@ -746,7 +745,7 @@ namespace hpx {
         }
 
         ////////////////////////////////////////////////////////////////////////
-        void init_environment(
+        static void init_environment(
             [[maybe_unused]] hpx::util::runtime_configuration const& cfg)
         {
             HPX_UNUSED(hpx::filesystem::initial_path());
@@ -820,7 +819,7 @@ namespace hpx {
         }
 
         // make sure the runtime system is not active yet
-        int ensure_no_runtime_is_up()
+        static int ensure_no_runtime_is_up()
         {
             // make sure the runtime system is not active yet
             if (get_runtime_ptr() != nullptr)
@@ -850,7 +849,8 @@ namespace hpx {
         int run_or_start(
             hpx::function<int(hpx::program_options::variables_map& vm)> const&
                 f,
-            int argc, char** argv, init_params const& params, bool blocking)
+            int const argc, char** argv, init_params const& params,
+            bool const blocking)
         {
             int result;
             try
@@ -1000,7 +1000,7 @@ namespace hpx {
 
         ////////////////////////////////////////////////////////////////////////
         template <typename T>
-        inline T get_option(std::string const& config, T default_ = T())
+        static T get_option(std::string const& config, T const& default_ = T())
         {
             if (!config.empty())
             {
@@ -1128,11 +1128,85 @@ namespace hpx {
         p->call_shutdown_functions(true);
         p->call_shutdown_functions(false);
 
-        p->stop(shutdown_timeout, hpx::invalid_id, true);
+        p->stop(shutdown_timeout, hpx::invalid_id, true, false);
 #endif
 
         return 0;
     }
+
+#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
+    ///////////////////////////////////////////////////////////////////////////
+    int force_disconnect(
+        [[maybe_unused]] hpx::id_type const& locality, error_code& ec)
+    {
+#if defined(HPX_HAVE_FORCE_DISCONNECT)
+        if (!threads::get_self_ptr())
+        {
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "hpx::force_disconnect",
+                "this function can be called from an HPX thread only");
+            return -1;
+        }
+
+        if (!is_running())
+        {
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "hpx::force_disconnect",
+                "the runtime system is not active (did you already "
+                "call finalize?)");
+            return -1;
+        }
+
+        if (!agas::is_console())
+        {
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "hpx::force_disconnect",
+                "hpx::force_disconnect should be called on the console "
+                "locality only.");
+            return -1;
+        }
+
+        if (locality == hpx::find_here())
+        {
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "hpx::force_disconnect",
+                "hpx::force_disconnect cannot be used to disconnect the "
+                "console locality itself.");
+            return -1;
+        }
+
+        if (!agas::is_connecting(locality.get_gid()))
+        {
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "hpx::force_disconnect",
+                "hpx::force_disconnect can be called to disconnect only a "
+                "locality that was connecting late.");
+            return -1;
+        }
+
+        auto* p = static_cast<components::server::runtime_support*>(
+            get_runtime_distributed().get_runtime_support_lva());
+
+        if (nullptr == p)
+        {
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "hpx::force_disconnect",
+                "the runtime system is not active (did you already "
+                "call finalize?)");
+            return -1;
+        }
+
+        bool const res = p->remove_locality(locality, ec);
+        return ec || !res ? -1 : 0;
+#else
+        HPX_THROWS_IF(ec, hpx::error::invalid_status, "hpx::force_disconnect",
+            "hpx::force_disconnect is not supported in this configuration, "
+            "configure HPX with `-DHPX_WITH_FORCE_DISCONNECT=On` to enable "
+            "it.");
+        return -1;
+#endif
+    }
+#endif
 
     ///////////////////////////////////////////////////////////////////////////
     void terminate()

--- a/libs/full/init_runtime/tests/unit/CMakeLists.txt
+++ b/libs/full/init_runtime/tests/unit/CMakeLists.txt
@@ -13,6 +13,34 @@ if(HPX_WITH_DISTRIBUTED_RUNTIME)
   set(tests ${tests} handled_exception unhandled_exception)
 endif()
 
+if(HPX_WITH_SUPERVISION)
+  if(HPX_WITH_NETWORKING AND HPX_WITH_PARCELPORT_TCP)
+    set(tests ${tests} force_disconnect)
+
+    # add executable needed for the force_disconnect test
+    add_hpx_executable(
+      force_disconnect_worker INTERNAL_FLAGS
+      SOURCES force_disconnect_worker.cpp
+      EXCLUDE_FROM_ALL
+      HPX_PREFIX ${HPX_BUILD_PREFIX}
+      FOLDER "Tests/Unit/Modules/Full/InitRuntime"
+    )
+
+    # cmake-format: off
+    set(force_disconnect_PARAMETERS
+        RUN_SERIAL
+        --launch=$<TARGET_FILE:force_disconnect_worker>
+        # Force use of the TCP parcelport
+        --hpx:ini=hpx.parcel.tcp.priority=1000
+        --hpx:ini=hpx.parcel.bootstrap=tcp
+    )
+    set(force_disconnect_FLAGS
+        DEPENDENCIES process_component supervision_dispatch_component
+    )
+    # cmake-format: on
+  endif()
+endif()
+
 set(unhandled_exception_PARAMETERS FAILURE_EXPECTED)
 
 foreach(test ${tests})
@@ -34,3 +62,25 @@ foreach(test ${tests})
 
   add_hpx_unit_test("modules.init_runtime" ${test} ${${test}_PARAMETERS})
 endforeach()
+
+if(HPX_WITH_SUPERVISION
+   AND HPX_WITH_NETWORKING
+   AND HPX_WITH_PARCELPORT_TCP
+)
+  # MSVC V1951 and V1952 expose ICE compiling this in C++20 module mode
+  if(HPX_WITH_CXX_MODULES
+     AND (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+     AND (MSVC_VERSION LESS_EQUAL 1952)
+  )
+    target_compile_definitions(
+      force_disconnect_worker PRIVATE HPX_HAVE_FORCE_NO_CXX_MODULES
+    )
+    target_compile_definitions(
+      force_disconnect_test PRIVATE HPX_HAVE_FORCE_NO_CXX_MODULES
+    )
+  endif()
+
+  add_hpx_pseudo_dependencies(
+    tests.unit.modules.init_runtime.force_disconnect force_disconnect_worker
+  )
+endif()

--- a/libs/full/init_runtime/tests/unit/force_disconnect.cpp
+++ b/libs/full/init_runtime/tests/unit/force_disconnect.cpp
@@ -1,0 +1,603 @@
+//  Copyright (c) 2026 The STE||AR-Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// non-HPX thread, or trying to disconnect the console locality itself, both
+// fail with hpx::error::invalid_status, both through the error_code overload
+// and by throwing), as well as the happy path, where disconnecting a valid
+// remote locality succeeds and actually removes it from AGAS/the connection
+// caches while leaving the remaining localities unaffected. Calling
+// force_disconnect a second time on an already-disconnected locality does not
+// hang. Once a locality has been removed, its gid no longer reports
+// is_connecting() == true, so the eligibility check in force_disconnect fails
+// fast with hpx::error::bad_parameter rather than attempting a second removal
+// or blocking.
+//
+// Beyond that baseline, this test also covers: disconnecting a locality while
+// an action is still in flight to it; repeated connect/disconnect cycles across
+// distinct localities; two concurrent force_disconnect calls racing on the same
+// target; and disconnecting a locality whose process has already been killed
+// outright (rather than one that is cooperatively still running).
+//
+// The remote localities are spawned as separate worker processes (see
+// force_disconnect_worker.cpp) via process::launch_connecting_locality(), since
+// this test itself is always run as a single, console-only locality.
+
+#include <hpx/config.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/include/process.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/actions.hpp>
+#include <hpx/modules/agas.hpp>
+#include <hpx/modules/async_distributed.hpp>
+#include <hpx/modules/components_base.hpp>
+#include <hpx/modules/errors.hpp>
+#include <hpx/modules/filesystem.hpp>
+#include <hpx/modules/naming_base.hpp>
+#include <hpx/modules/prefix.hpp>
+#include <hpx/modules/runtime_distributed.hpp>
+#include <hpx/modules/runtime_local.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <system_error>
+#include <thread>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace process = hpx::components::process;
+namespace fs = hpx::filesystem;
+
+// Calling hpx::force_disconnect from a thread that is not an HPX-thread should
+// fail with hpx::error::invalid_status, regardless of the given locality, since
+// this check is performed before any locality validation.
+void test_non_hpx_thread_guard()
+{
+    hpx::id_type const target = hpx::find_here();
+
+    // ec-based overload
+    {
+        int retval = 0;
+        hpx::error_code ec(hpx::throwmode::lightweight);
+
+        std::thread t([&]() { retval = hpx::force_disconnect(target, ec); });
+        t.join();
+
+        HPX_TEST_EQ(retval, -1);
+        HPX_TEST(ec);
+        HPX_TEST_EQ(ec.value(), static_cast<int>(hpx::error::invalid_status));
+    }
+
+    // throwing overload
+    {
+        bool caught_exception = false;
+        hpx::error thrown_error = hpx::error::success;
+
+        std::thread t([&]() {
+            try
+            {
+                hpx::force_disconnect(target);
+                HPX_TEST(false);
+            }
+            catch (hpx::exception const& e)
+            {
+                caught_exception = true;
+                thrown_error = e.get_error();
+            }
+        });
+        t.join();
+
+        HPX_TEST(caught_exception);
+        HPX_TEST_EQ(thrown_error, hpx::error::invalid_status);
+    }
+}
+
+// The console locality is not allowed to disconnect itself; calling
+// hpx::force_disconnect(hpx::find_here(), ...) from console must fail.
+void test_console_cannot_disconnect_itself(std::uint32_t const locality_id)
+{
+    if (locality_id != 0)
+    {
+        return;
+    }
+
+    hpx::id_type const here = hpx::find_here();
+
+    // error_code overload
+    {
+        hpx::error_code ec(hpx::throwmode::lightweight);
+        int const result = hpx::force_disconnect(here, ec);
+        HPX_TEST_EQ(result, -1);
+        HPX_TEST(ec);
+        HPX_TEST_EQ(ec.value(), static_cast<int>(hpx::error::bad_parameter));
+        std::string const msg = ec.get_message();
+        HPX_TEST(msg.find("HPX(bad_parameter)") != std::string::npos ||
+            msg.find("cannot be used to disconnect the ") != std::string::npos);
+    }
+
+    // throwing overload
+    {
+        bool caught_exception = false;
+        try
+        {
+            hpx::force_disconnect(here);
+            HPX_TEST(false);
+        }
+        catch (hpx::exception const& e)
+        {
+            caught_exception = true;
+            HPX_TEST(e.get_error() == hpx::error::bad_parameter);
+            std::string const msg = e.what();
+            HPX_TEST(msg.find("HPX(bad_parameter)") != std::string::npos ||
+                msg.find("cannot be used to disconnect the ") !=
+                    std::string::npos);
+        }
+        HPX_TEST(caught_exception);
+    }
+}
+
+// A trivial action used to probe whether a given locality is still reachable,
+// i.e. still registered with AGAS and present in the connection caches.
+std::uint32_t ping_locality()
+{
+    return hpx::get_locality_id();
+}
+HPX_PLAIN_ACTION(ping_locality, ping_locality_action)
+
+// A long-running action used to simulate a parcel that is still in flight while
+// the target locality is being force-disconnected.
+std::uint32_t sleep_locality(int const ms)
+{
+    hpx::this_thread::sleep_for(std::chrono::milliseconds(ms));
+    return hpx::get_locality_id();
+}
+HPX_PLAIN_ACTION(sleep_locality, sleep_locality_action)
+
+// Launches a new connecting-locality worker process and identifies the
+// hpx::id_type it registered as, by diffing the set of known localities before
+// and after the launch. Returns both the child handle (so the caller can, e.g.,
+// terminate it abruptly) and the newly registered locality id.
+std::pair<process::child, hpx::id_type> launch_worker(
+    fs::path const& exe, std::uint64_t spawn_id)
+{
+    std::unordered_set<hpx::id_type> before;
+    for (hpx::id_type const& id : hpx::find_all_localities())
+    {
+        before.insert(id);
+    }
+
+    process::child worker = process::launch_connecting_locality(
+        fs::to_string(exe), {"--hpx:threads=1"}, {}, spawn_id);
+    worker.wait();
+    HPX_TEST(worker);
+
+    hpx::id_type new_locality;
+    for (hpx::id_type const& id : hpx::find_all_localities())
+    {
+        if (!before.contains(id))
+        {
+            new_locality = id;
+            break;
+        }
+    }
+    HPX_TEST(new_locality);
+
+    return std::make_pair(HPX_MOVE(worker), new_locality);
+}
+
+// Calling hpx::force_disconnect on a valid, non-console, non-self locality must
+// succeed and actually remove that locality from AGAS/the connection caches (so
+// that further action dispatches to it fail), while leaving all remaining
+// localities, including console itself, fully operational.
+//
+// Returns the id of the disconnected (now removed) locality, together with the
+// id of the still-reachable control locality, so that a follow-up
+// double-disconnect test (see below) can reuse the same setup instead of
+// re-deriving it.
+std::pair<hpx::id_type, hpx::id_type> test_force_disconnect_removes_locality()
+{
+    std::vector<hpx::id_type> const localities = hpx::find_all_localities();
+    HPX_TEST(localities.size() >= 3);
+    if (localities.size() < 3)
+    {
+        return {};
+    }
+
+    hpx::id_type const here = hpx::find_here();
+    hpx::id_type target;
+    hpx::id_type control;
+    for (hpx::id_type const& id : localities)
+    {
+        if (id == here)
+        {
+            continue;
+        }
+        if (!target)
+        {
+            target = id;
+        }
+        else if (!control)
+        {
+            control = id;
+        }
+    }
+    HPX_TEST(target);
+    HPX_TEST(control);
+
+    // The launched locality must be reported to have been connecting late.
+    HPX_TEST(hpx::agas::is_connecting(target.get_gid()));
+
+    // Disconnect the target locality; this must succeed.
+    hpx::error_code ec(hpx::throwmode::lightweight);
+    int const result = hpx::force_disconnect(target, ec);
+    HPX_TEST_EQ(result, 0);
+    HPX_TEST(!ec);
+
+    // Dispatching an action to the disconnected locality must now fail, proving
+    // that it was actually removed from AGAS/the connection caches.
+    {
+        bool caught_exception = false;
+        try
+        {
+            constexpr ping_locality_action act;
+            [[maybe_unused]] auto const r = act(target);
+            HPX_TEST(false);
+        }
+        catch (hpx::exception const&)
+        {
+            caught_exception = true;
+        }
+        HPX_TEST(caught_exception);
+    }
+
+    // Confirm removal directly at the AGAS level, not just inferred from a
+    // failed action dispatch (which could also be explained by a stale
+    // connection-cache entry rather than actual deregistration).
+    {
+        hpx::error_code ec2(hpx::throwmode::lightweight);
+        hpx::naming::address const addr =
+            hpx::agas::resolve(hpx::launch::sync, target, ec2);
+        HPX_TEST(ec2 || !addr);
+    }
+
+    // A third, uninvolved locality must still respond normally.
+    {
+        constexpr ping_locality_action act;
+        HPX_TEST_EQ(
+            act(control), hpx::naming::get_locality_id_from_id(control));
+    }
+
+    // The console locality itself must remain fully operational.
+    HPX_TEST(hpx::agas::is_console());
+
+    return std::make_pair(target, control);
+}
+
+// Calling force_disconnect a second time on an already-disconnected
+// locality does not hang. Once a locality has been removed, its gid no
+// longer reports is_connecting() == true, so the eligibility check in
+// force_disconnect fails fast with hpx::error::bad_parameter rather than
+// attempting a second removal or blocking.
+void test_double_disconnect_should_fail(hpx::id_type const& target)
+{
+    if (!target)
+    {
+        return;
+    }
+
+    // error_code overload
+    {
+        hpx::error_code ec(hpx::throwmode::lightweight);
+        int const result = hpx::force_disconnect(target, ec);
+        HPX_TEST_EQ(result, -1);
+        HPX_TEST(ec);
+        HPX_TEST_EQ(ec.value(), static_cast<int>(hpx::error::bad_parameter));
+    }
+
+    // throwing overload
+    {
+        bool caught_exception = false;
+        try
+        {
+            hpx::force_disconnect(target);
+        }
+        catch (hpx::exception const& e)
+        {
+            caught_exception = true;
+            HPX_TEST(e.get_error() == hpx::error::bad_parameter);
+        }
+        HPX_TEST(caught_exception);
+    }
+}
+
+// Disconnecting more than one locality in the same run must work: the second
+// disconnect is independent of the first and must not be affected by state
+// left over from having already removed a different locality (e.g. stale
+// cache entries or partition-table bookkeeping for the earlier target).
+void test_sequential_disconnects(hpx::id_type const& second_target)
+{
+    if (!second_target)
+    {
+        return;
+    }
+
+    // The launched locality must be reported to have been connecting late.
+    HPX_TEST(hpx::agas::is_connecting(second_target.get_gid()));
+
+    hpx::error_code ec(hpx::throwmode::lightweight);
+    int const result = hpx::force_disconnect(second_target, ec);
+    HPX_TEST_EQ(result, 0);
+    HPX_TEST(!ec);
+
+    // Confirm this second locality is also actually gone, not just the first.
+    bool caught_exception = false;
+    try
+    {
+        constexpr ping_locality_action act;
+        [[maybe_unused]] auto const r = act(second_target);
+        HPX_TEST(false);
+    }
+    catch (hpx::exception const&)
+    {
+        caught_exception = true;
+    }
+    HPX_TEST(caught_exception);
+}
+
+// Disconnecting a locality while an action is still in flight to it must not
+// hang: the in-flight call either completes normally (it was already
+// dispatched before the disconnect took effect) or fails with
+// hpx::error::locality_was_disconnected (the dispatch guard or the
+// connection teardown caught it); any other outcome is a failure.
+void test_disconnect_with_inflight_parcel(hpx::id_type const& target)
+{
+    if (!target)
+    {
+        return;
+    }
+
+    constexpr sleep_locality_action act;
+    hpx::future<std::uint32_t> f = hpx::async(act, target, 2000);
+
+    hpx::error_code ec(hpx::throwmode::lightweight);
+    int const result = hpx::force_disconnect(target, ec);
+    HPX_TEST_EQ(result, 0);
+    HPX_TEST(!ec);
+
+    bool outcome_is_acceptable = false;
+    try
+    {
+        [[maybe_unused]] std::uint32_t const r = f.get();
+        outcome_is_acceptable = true;
+    }
+    catch (hpx::exception const& e)
+    {
+        outcome_is_acceptable =
+            (e.get_error() == hpx::error::locality_was_disconnected);
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+    HPX_TEST(outcome_is_acceptable);
+}
+
+// Repeatedly launching and force-disconnecting distinct worker localities
+// must not leak state or cross-contaminate: each cycle must independently
+// register with, and then be fully removed from, AGAS.
+void test_repeated_connect_disconnect_cycles(fs::path const& exe,
+    std::size_t const iterations, std::uint64_t const first_spawn_id)
+{
+    for (std::size_t i = 0; i != iterations; ++i)
+    {
+        auto [worker, id] = launch_worker(exe, first_spawn_id + i);
+
+        HPX_TEST(hpx::agas::is_connecting(id.get_gid()));
+
+        hpx::error_code ec(hpx::throwmode::lightweight);
+        int const result = hpx::force_disconnect(id, ec);
+        HPX_TEST_EQ(result, 0);
+        HPX_TEST(!ec);
+
+        hpx::error_code resolve_ec(hpx::throwmode::lightweight);
+        hpx::naming::address const addr =
+            hpx::agas::resolve(hpx::launch::sync, id, resolve_ec);
+        HPX_TEST(resolve_ec || !addr);
+
+        int const exit_code = worker.wait_for_exit(hpx::launch::sync);
+        HPX_TEST_EQ(exit_code, 0);
+    }
+}
+
+// Two concurrent hpx::force_disconnect calls targeting the same locality
+// must not corrupt state or hang: at most one may succeed, and the losing
+// call must fail cleanly instead of duplicating the removal.
+void test_concurrent_double_disconnect_race(hpx::id_type const& target)
+{
+    if (!target)
+    {
+        return;
+    }
+
+    hpx::error_code ec1(hpx::throwmode::lightweight);
+    hpx::error_code ec2(hpx::throwmode::lightweight);
+
+    hpx::future<int> f1 = hpx::async(
+        [&target, &ec1]() { return hpx::force_disconnect(target, ec1); });
+    hpx::future<int> f2 = hpx::async(
+        [&target, &ec2]() { return hpx::force_disconnect(target, ec2); });
+
+    int const r1 = f1.get();
+    int const r2 = f2.get();
+
+    bool const succeeded1 = (r1 == 0) && !ec1;
+    bool const succeeded2 = (r2 == 0) && !ec2;
+    HPX_TEST(succeeded1 != succeeded2);
+}
+
+// Force-disconnecting a locality whose process has already been killed (rather
+// than one that is cooperatively still running) must complete within the
+// best-effort notify timeout instead of hanging, and must still succeed in
+// cleaning up the local AGAS/connection-cache state.
+void test_disconnect_unreachable_locality(
+    process::child& worker, hpx::id_type const& target)
+{
+    if (!target)
+    {
+        return;
+    }
+
+    worker.terminate(hpx::launch::sync);
+
+    auto const start = std::chrono::steady_clock::now();
+
+    hpx::error_code ec(hpx::throwmode::lightweight);
+    int const result = hpx::force_disconnect(target, ec);
+
+    auto const elapsed_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - start);
+
+    // Bounded well above the ~5s best-effort notify window used internally for
+    // an unreachable target, but far below the ctest timeout for this test.
+    HPX_TEST_LT(elapsed_ms.count(), 10000);
+
+    HPX_TEST_EQ(result, 0);
+    HPX_TEST(!ec);
+}
+
+// hpx::finalize() is asynchronous: it merely flags all localities to stop
+// scheduling new work and returns almost immediately, regardless of
+// whether shutdown actually completes promptly (or hangs, e.g. because of
+// a just-disconnected locality). The real end-to-end shutdown duration is
+// the time between the point where finalize() is invoked and hpx::init()
+// actually returning in main(); since hpx_main() and main() do not share a
+// live call stack across the shutdown boundary, the starting timestamp is
+// stashed in a variable with static storage duration.
+std::chrono::steady_clock::time_point finalize_time;
+
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    // enable fault tolerance
+    hpx::get_config().tolerate_node_faults(true);
+
+    std::uint32_t const locality_id = hpx::get_locality_id();
+    std::cout << "locality " << locality_id << " reached hpx_main\n";
+
+    test_non_hpx_thread_guard();
+    test_console_cannot_disconnect_itself(locality_id);
+
+    // find where the HPX core libraries are located
+    fs::path base_dir = hpx::util::find_prefix();
+    base_dir /= "bin";
+
+    fs::path exe =
+        base_dir / "force_disconnect_worker" HPX_EXECUTABLE_EXTENSION;
+    if (vm.contains("launch"))
+    {
+        exe = vm["launch"].as<std::string>();
+    }
+
+    std::cout << "Launching " << exe << "\n";
+
+    process::child w1 = process::launch_connecting_locality(
+        fs::to_string(exe), {"--hpx:threads=1"}, {}, 1);
+    w1.wait();
+    HPX_TEST(w1);
+
+    process::child w2 = process::launch_connecting_locality(
+        fs::to_string(exe), {"--hpx:threads=1"}, {}, 2);
+    w2.wait();
+    HPX_TEST(w2);
+
+    HPX_TEST_EQ(hpx::find_all_localities().size(), static_cast<std::size_t>(3));
+
+    auto const [first, second] = test_force_disconnect_removes_locality();
+    test_double_disconnect_should_fail(first);
+    test_sequential_disconnects(second);
+
+    int const exit_code1 = w1.wait_for_exit(hpx::launch::sync);
+    HPX_TEST_EQ(exit_code1, 0);
+    int const exit_code2 = w2.wait_for_exit(hpx::launch::sync);
+    HPX_TEST_EQ(exit_code2, 0);
+
+    std::cout
+        << "Disconnecting a locality with an action still in flight to it.\n";
+    {
+        auto [w3, id3] = launch_worker(exe, 3);
+        test_disconnect_with_inflight_parcel(id3);
+        int const exit_code3 = w3.wait_for_exit(hpx::launch::sync);
+        HPX_TEST_EQ(exit_code3, 0);
+    }
+
+    std::cout
+        << "Repeated connect/disconnect cycles across distinct localities.\n";
+    test_repeated_connect_disconnect_cycles(exe, 2, 4);
+
+    std::cout << "Concurrent double force_disconnect on the same locality.\n";
+    {
+        auto [w6, id6] = launch_worker(exe, 6);
+        test_concurrent_double_disconnect_race(id6);
+        int const exit_code6 = w6.wait_for_exit(hpx::launch::sync);
+        HPX_TEST_EQ(exit_code6, 0);
+    }
+
+    std::cout << "Disconnecting a locality whose process is already gone.\n";
+    {
+        auto [w7, id7] = launch_worker(exe, 7);
+        test_disconnect_unreachable_locality(w7, id7);
+    }
+
+    finalize_time = std::chrono::steady_clock::now();
+    return hpx::finalize();
+}
+
+int main(int const argc, char* argv[])
+{
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    // clang-format off
+    desc_commandline.add_options()
+        ("launch,l", value<std::string>(),
+         "the process that will be launched and which connects back");
+    // clang-format on
+
+    std::vector<std::string> const cfg = {
+        "hpx.expect_connecting_localities!=1"};
+
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    // Measure the actual end-to-end shutdown duration, i.e. the time it took
+    // hpx::init() to return after hpx::finalize() was called above. This is a
+    // generous but still meaningful bound (far above normal shutdown time, but
+    // far below the ctest timeout for this test), meant to catch shutdown
+    // hanging or taking excessively long because of the locality that was
+    // disconnected above; the ctest timeout remains the ultimate backstop
+    // against an actual hang.
+    auto const duration = std::chrono::steady_clock::now() - finalize_time;
+    auto const shutdown_milliseconds =
+        std::chrono::duration_cast<std::chrono::milliseconds>(duration);
+
+    std::cout << "shutdown after force_disconnect took "
+              << shutdown_milliseconds.count() << " milliseconds\n";
+    HPX_TEST_LT(shutdown_milliseconds.count(), 30000);
+
+    return hpx::util::report_errors();
+}
+
+#endif

--- a/libs/full/init_runtime/tests/unit/force_disconnect_worker.cpp
+++ b/libs/full/init_runtime/tests/unit/force_disconnect_worker.cpp
@@ -1,0 +1,60 @@
+//  Copyright (c) 2026 The STE||AR-Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Helper for the force_disconnect test. This executable is launched multiple
+// times by force_disconnect.cpp (see process::launch_connecting_locality()
+// there), each time connecting to the running test as an additional locality.
+// Each instance simply keeps the runtime alive and is force-disconnected by
+// the console locality (via hpx::force_disconnect); it never waits on a latch
+// or initiates its own disconnection.
+
+#include <hpx/config.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/modules/actions.hpp>
+#include <hpx/modules/collectives.hpp>
+
+#include <chrono>
+#include <cstdint>
+
+// A trivial action used to probe whether a given locality is still reachable,
+// i.e. still registered with AGAS and present in the connection caches.
+std::uint32_t ping_locality()
+{
+    return hpx::get_locality_id();
+}
+HPX_PLAIN_ACTION(ping_locality, ping_locality_action)
+
+// A long-running action used to simulate a parcel that is still in flight while
+// the target locality is being force-disconnected.
+std::uint32_t sleep_locality(int const ms)
+{
+    hpx::this_thread::sleep_for(std::chrono::milliseconds(ms));
+    return hpx::get_locality_id();
+}
+HPX_PLAIN_ACTION(sleep_locality, sleep_locality_action)
+
+int hpx_main()
+{
+    // This locality doesn't call hpx::disconnect itself, but will be either
+    // disconnected by the console (using hpx::force_disconnect) or forcefully
+    // terminated.
+    return 0;
+}
+
+int main(int argc, char* argv[])
+{
+    // Note: this uses runtime_mode::connect to instruct this locality to
+    // connect to the existing HPX application
+    hpx::init_params init_args;
+    init_args.mode = hpx::runtime_mode::connect;
+
+    return hpx::init(argc, argv, init_args);
+}
+
+#endif

--- a/libs/full/parcelset/include/hpx/parcelset/message_handler_fwd.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/message_handler_fwd.hpp
@@ -11,6 +11,7 @@
 #if defined(HPX_HAVE_NETWORKING)
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/modules/functional.hpp>
 
 #include <hpx/parcelset/parcelset_fwd.hpp>
 

--- a/libs/full/parcelset/include/hpx/parcelset/parcelhandler.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/parcelhandler.hpp
@@ -33,6 +33,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <set>
 #include <sstream>
 #include <string>
 #include <system_error>
@@ -215,6 +216,9 @@ namespace hpx::parcelset {
         {
             return find_parcelport(name)->create_locality();
         }
+
+        /// \brief return whether the given locality was disconnected
+        bool locality_was_disconnected(std::uint32_t id) const;
 
         /// Return the name of this locality as retrieved from the active
         /// parcelport
@@ -454,6 +458,9 @@ namespace hpx::parcelset {
 
         /// the endpoints corresponding to the parcel-ports
         endpoints_type endpoints_;
+
+        /// the list of disconnected localities
+        std::set<std::uint32_t> disconnected_localities_;
 
         /// the thread-manager to use (optional)
         threads::threadmanager* tm_;

--- a/libs/full/parcelset/include/hpx/parcelset/parcelport_impl.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/parcelport_impl.hpp
@@ -409,12 +409,19 @@ namespace hpx::parcelset {
 
         void remove_from_connection_cache(locality const& loc) override
         {
-            connection_handler().reschedule_on_thread(
-                util::deferred_call(
-                    &parcelport_impl::remove_from_connection_cache_delayed,
-                    this, loc),
-                threads::thread_schedule_state::pending,
-                "remove_from_connection_cache_delayed");
+            if (hpx::threads::get_self_ptr() == nullptr)
+            {
+                connection_handler().reschedule_on_thread(
+                    util::deferred_call(
+                        &parcelport_impl::remove_from_connection_cache_delayed,
+                        this, loc),
+                    threads::thread_schedule_state::pending,
+                    "remove_from_connection_cache");
+            }
+            else
+            {
+                remove_from_connection_cache_delayed(loc);
+            }
         }
 
         /// Return the name of this locality

--- a/libs/full/parcelset/src/parcelhandler.cpp
+++ b/libs/full/parcelset/src/parcelhandler.cpp
@@ -103,14 +103,23 @@ namespace hpx::parcelset {
                 }
             }
 
-            hpx::error_code ec1(hpx::throwmode::lightweight);
-            endpoints_type const& dest_endpoints =
-                agas::resolve_locality(p.destination(), ec1);
-            if (dest_endpoints.empty())
+#if defined(HPX_HAVE_FORCE_DISCONNECT)
+            // check if the destination locality is (still) known
+            auto const dest = p.destination();
+            if (locality_was_disconnected(
+                    naming::get_locality_id_from_gid(dest)))
             {
                 return true;
             }
 
+            hpx::error_code ec1(hpx::throwmode::lightweight);
+            endpoints_type const& dest_endpoints =
+                agas::resolve_locality(dest, ec1);
+            if (hpx::tolerate_node_faults() && dest_endpoints.empty())
+            {
+                return true;
+            }
+#endif
             // all unhandled exceptions are rethrown here
             std::exception_ptr const exception = hpx::detail::get_exception(
                 hpx::exception(ec), "default_parcel_write_handler", __FILE__,
@@ -404,6 +413,12 @@ namespace hpx::parcelset {
     void parcelhandler::remove_from_connection_cache(
         naming::gid_type const& gid, endpoints_type const& endpoints)
     {
+        {
+            std::lock_guard<mutex_type> l(mtx_);
+            disconnected_localities_.insert(
+                naming::get_locality_id_from_gid(gid));
+        }
+
         for (auto const& endpoint : endpoints | std::views::values)
         {
             for (auto const& pport : pports_ | std::views::values)
@@ -416,6 +431,12 @@ namespace hpx::parcelset {
         }
 
         agas::remove_resolved_locality(gid);
+    }
+
+    bool parcelhandler::locality_was_disconnected(std::uint32_t const id) const
+    {
+        std::lock_guard<mutex_type> l(mtx_);
+        return disconnected_localities_.contains(id);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -636,7 +657,22 @@ namespace hpx::parcelset {
                 "parcelhandler::put_parcel: handled: {}", p.parcel_id());
         };
 
-        put_parcel_impl(HPX_MOVE(p), HPX_MOVE(handler));
+        if (hpx::tolerate_node_faults())
+        {
+            parcelset::parcel const hold_p = p;
+            auto hold_handler = handler;
+            hpx::detail::try_catch_exception_ptr(
+                [&]() { put_parcel_impl(HPX_MOVE(p), HPX_MOVE(handler)); },
+                [&](std::exception_ptr const& ep) {
+                    error_code const ec =
+                        make_error_code(get_error(ep), throwmode::rethrow);
+                    hold_handler(ec, hold_p);
+                });
+        }
+        else
+        {
+            put_parcel_impl(HPX_MOVE(p), HPX_MOVE(handler));
+        }
     }
 
     void parcelhandler::put_parcel(parcelset::parcel p, write_handler_type f)
@@ -668,7 +704,22 @@ namespace hpx::parcelset {
                 "parcelhandler::put_parcel: handled: {}", p.parcel_id());
         };
 
-        put_parcel_impl(HPX_MOVE(p), HPX_MOVE(handler));
+        if (hpx::tolerate_node_faults())
+        {
+            parcelset::parcel const hold_p = p;
+            auto hold_handler = handler;
+            hpx::detail::try_catch_exception_ptr(
+                [&]() { put_parcel_impl(HPX_MOVE(p), HPX_MOVE(handler)); },
+                [&](std::exception_ptr const& ep) {
+                    error_code const ec =
+                        make_error_code(get_error(ep), throwmode::rethrow);
+                    hold_handler(ec, hold_p);
+                });
+        }
+        else
+        {
+            put_parcel_impl(HPX_MOVE(p), HPX_MOVE(handler));
+        }
     }
 
     void parcelhandler::put_parcel_impl(parcel&& p, write_handler_type&& f)
@@ -776,7 +827,27 @@ namespace hpx::parcelset {
                     "parcelhandler::put_parcels: handled: {}", p.parcel_id());
             });
 
-        put_parcels_impl(HPX_MOVE(parcels), HPX_MOVE(handlers));
+        if (hpx::tolerate_node_faults())
+        {
+            std::vector<parcel> const hold_parcels = parcels;
+            std::vector<write_handler_type> const hold_handlers = handlers;
+            hpx::detail::try_catch_exception_ptr(
+                [&]() {
+                    put_parcels_impl(HPX_MOVE(parcels), HPX_MOVE(handlers));
+                },
+                [&](std::exception_ptr const& ep) {
+                    for (std::size_t i = 0; i != hold_parcels.size(); ++i)
+                    {
+                        error_code ec =
+                            make_error_code(get_error(ep), throwmode::rethrow);
+                        hold_handlers[i](ec, hold_parcels[i]);
+                    }
+                });
+        }
+        else
+        {
+            put_parcels_impl(HPX_MOVE(parcels), HPX_MOVE(handlers));
+        }
     }
 
     void parcelhandler::put_parcels(
@@ -820,7 +891,27 @@ namespace hpx::parcelset {
             });
         }
 
-        put_parcels_impl(HPX_MOVE(parcels), HPX_MOVE(handlers));
+        if (hpx::tolerate_node_faults())
+        {
+            std::vector<parcel> const hold_parcels = parcels;
+            std::vector<write_handler_type> const hold_handlers = handlers;
+            hpx::detail::try_catch_exception_ptr(
+                [&]() {
+                    put_parcels_impl(HPX_MOVE(parcels), HPX_MOVE(handlers));
+                },
+                [&](std::exception_ptr const& ep) {
+                    for (std::size_t i = 0; i != hold_parcels.size(); ++i)
+                    {
+                        error_code ec =
+                            make_error_code(get_error(ep), throwmode::rethrow);
+                        hold_handlers[i](ec, hold_parcels[i]);
+                    }
+                });
+        }
+        else
+        {
+            put_parcels_impl(HPX_MOVE(parcels), HPX_MOVE(handlers));
+        }
     }
 
     void parcelhandler::put_parcels_impl(std::vector<parcel>&& parcels,

--- a/libs/full/parcelset_base/include/hpx/parcelset_base/detail/locality_interface_functions.hpp
+++ b/libs/full/parcelset_base/include/hpx/parcelset_base/detail/locality_interface_functions.hpp
@@ -13,6 +13,7 @@
 
 #include <hpx/parcelset_base/parcelset_base_fwd.hpp>
 
+#include <cstdint>
 #include <string>
 #include <system_error>
 
@@ -22,6 +23,8 @@ namespace hpx::parcelset::detail {
     extern HPX_EXPORT parcelset::parcel (*create_parcel)();
 
     extern HPX_EXPORT locality (*create_locality)(std::string const& name);
+
+    extern HPX_EXPORT bool (*locality_was_disconnected)(std::uint32_t);
 
     extern HPX_EXPORT parcel_write_handler_type (*set_parcel_write_handler)(
         parcel_write_handler_type const& f);

--- a/libs/full/parcelset_base/include/hpx/parcelset_base/locality_interface.hpp
+++ b/libs/full/parcelset_base/include/hpx/parcelset_base/locality_interface.hpp
@@ -13,6 +13,7 @@
 
 #include <hpx/parcelset_base/parcelset_base_fwd.hpp>
 
+#include <cstdint>
 #include <string>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -21,6 +22,8 @@ namespace hpx::parcelset {
     HPX_CXX_EXPORT HPX_EXPORT parcelset::parcel create_parcel();
 
     HPX_CXX_EXPORT HPX_EXPORT locality create_locality(std::string const& name);
+
+    HPX_CXX_EXPORT HPX_EXPORT bool locality_was_disconnected(std::uint32_t id);
 
     ///////////////////////////////////////////////////////////////////////////
     // initialize locality interface function wrappers

--- a/libs/full/parcelset_base/src/detail/locality_interface_functions.cpp
+++ b/libs/full/parcelset_base/src/detail/locality_interface_functions.cpp
@@ -10,6 +10,7 @@
 #include <hpx/parcelset_base/detail/locality_interface_functions.hpp>
 #include <hpx/parcelset_base/locality.hpp>
 
+#include <cstdint>
 #include <string>
 #include <system_error>
 
@@ -19,6 +20,8 @@ namespace hpx::parcelset::detail {
     parcelset::parcel (*create_parcel)() = nullptr;
 
     locality (*create_locality)(std::string const& name) = nullptr;
+
+    bool (*locality_was_disconnected)(std::uint32_t) = nullptr;
 
     parcel_write_handler_type (*set_parcel_write_handler)(
         parcel_write_handler_type const& f) = nullptr;

--- a/libs/full/parcelset_base/src/locality_interface.cpp
+++ b/libs/full/parcelset_base/src/locality_interface.cpp
@@ -16,6 +16,7 @@
 #include <hpx/parcelset_base/parcel_interface.hpp>
 #include <hpx/parcelset_base/policies/message_handler.hpp>
 
+#include <cstdint>
 #include <string>
 #include <system_error>
 
@@ -30,6 +31,11 @@ namespace hpx::parcelset {
     locality create_locality(std::string const& name)
     {
         return detail::create_locality(name);
+    }
+
+    bool locality_was_disconnected(std::uint32_t const id)
+    {
+        return detail::locality_was_disconnected(id);
     }
 
     namespace detail {

--- a/libs/full/performance_counters/src/counter_creators.cpp
+++ b/libs/full/performance_counters/src/counter_creators.cpp
@@ -12,6 +12,7 @@
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/modules/format.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/modules/type_support.hpp>
@@ -595,7 +596,9 @@ namespace hpx::performance_counters {
         if (paths.instancename_ == "total" && paths.instanceindex_ == -1)
         {
             // find the referenced AGAS instance and dispatch the request there
-            std::string service(agas::service_name);
+            std::string service = hpx::util::format(agas::service_name,
+                agas::is_connecting() ? agas::get_locality_id() : 0);
+
             service += paths.parentinstancename_;
 
             if (-1 == paths.parentinstanceindex_)

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/big_boot_barrier.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/big_boot_barrier.hpp
@@ -96,11 +96,11 @@ namespace hpx::agas {
                 delete f;
         }
 
-        parcelset::locality here()
+        parcelset::locality here() const
         {
             return bootstrap_agas;
         }
-        parcelset::endpoints_type const& get_endpoints()
+        parcelset::endpoints_type const& get_endpoints() const
         {
             return endpoints;
         }
@@ -120,9 +120,23 @@ namespace hpx::agas {
             notification_header&& hdr);
 
         void wait_bootstrap();
+
+        /// Wait for a hosted (non-bootstrap) locality to register itself with
+        /// AGAS during startup.
+        ///
+        /// \param locality_name  Name of the locality being registered.
+        /// \param primary_ns_ptr Address of the primary namespace component
+        ///                       on the hosted locality.
+        /// \param symbol_ns_ptr  Address of the symbol namespace component
+        ///                       on the hosted locality.
+        /// \param is_connecting  Controls the locality registration mode:
+        ///                       true if the locality is joining as a
+        ///                       connecting (not yet fully registered)
+        ///                       locality, false for normal registration.
         void wait_hosted(std::string const& locality_name,
-            naming::address::address_type primary_ns_ptr,
-            naming::address::address_type symbol_ns_ptr);
+            naming::address::address_type const& primary_ns_ptr,
+            naming::address::address_type const& symbol_ns_ptr,
+            bool is_connecting);
 
         // no-op on non-bootstrap localities
         void trigger();

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/server/runtime_support.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/server/runtime_support.hpp
@@ -134,7 +134,8 @@ namespace hpx::components::server {
             std::shared_ptr<Component> const& p, hpx::id_type);
 
         /// \brief Gracefully shutdown this runtime system instance
-        void shutdown(double timeout, hpx::id_type const& respond_to);
+        void shutdown(double timeout, hpx::id_type const& respond_to,
+            bool force_disconnect);
 
         /// \brief Gracefully shutdown runtime system instances on all localities
         void shutdown_all(double timeout);
@@ -228,10 +229,18 @@ namespace hpx::components::server {
         ///
         /// \note      This function can be called from any thread.
         void stop(double timeout, hpx::id_type const& respond_to,
-            bool remove_from_remote_caches);
+            bool remove_from_remote_caches, bool force_disconnect);
 
-        /// called locally only
-        void remove_locality(
+        /// \brief Remove the given locality from this locality's runtime
+        ///        support component.
+        ///
+        /// \param locality  The locality to be removed.
+        /// \param ec        Used to hold error code value originating from
+        ///                  the AGAS operations invoked by this function.
+        ///
+        /// \note This function must be called locally only; it is not
+        ///       exposed as a component action.
+        bool remove_locality(
             hpx::id_type const& locality, error_code& ec = hpx::throws);
         void stopped();
         void notify_waiting_main();
@@ -246,8 +255,22 @@ namespace hpx::components::server {
         void add_pre_shutdown_function(shutdown_function_type f);
         void add_shutdown_function(shutdown_function_type f);
 
+        /// \brief Broadcast a request to remove the given locality from the
+        ///        connection caches of all remote, non-console localities.
+        ///
+        /// \param locality      The locality to remove from the remote
+        ///                      connection caches.
+        /// \param skip_current  If true, omits the locality identified by
+        ///                      \a locality from this broadcast (that locality
+        ///                      will not receive a removal request for itself).
         static void remove_locality_from_connection_cache(
             hpx::naming::gid_type const& locality, bool skip_current = false);
+
+        /// \brief Remove the given locality from the console's connection
+        ///        cache.
+        ///
+        /// \param locality  The locality to remove from the console's
+        ///                  connection cache.
         static void remove_locality_from_console_connection_cache(
             hpx::naming::gid_type const& locality);
 

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/stubs/runtime_support.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/stubs/runtime_support.hpp
@@ -228,10 +228,10 @@ namespace hpx::components::stubs {
             hpx::id_type const& gid, bool pre_startup);
 
         /// \brief Shutdown the given runtime system
-        static hpx::future<void> shutdown_async(
-            hpx::id_type const& targetgid, double timeout = -1);
-        static void shutdown(
-            hpx::id_type const& targetgid, double timeout = -1);
+        static hpx::future<void> shutdown_async(hpx::id_type const& targetgid,
+            double timeout = -1, bool force_disconnect = false);
+        static void shutdown(hpx::id_type const& targetgid, double timeout = -1,
+            bool force_disconnect = false);
 
         /// \brief Shutdown the runtime systems of all localities
         static void shutdown_all(

--- a/libs/full/runtime_distributed/src/big_boot_barrier.cpp
+++ b/libs/full/runtime_distributed/src/big_boot_barrier.cpp
@@ -178,7 +178,7 @@ namespace hpx::agas::detail {
                 // Yes, we look up the unassigned typenames twice, but this allows
                 // to avoid using globals and protects from race conditions during
                 // de-serialization.
-                std::vector<std::string> typenames =
+                std::vector<std::string> const typenames =
                     registry.get_unassigned_typenames();
 
                 // we should have received as many ids as we have unassigned names
@@ -201,7 +201,7 @@ namespace hpx::agas::detail {
                 // Yes, we look up the unassigned typenames twice, but this allows
                 // to avoid using globals and protects from race conditions during
                 // de-serialization.
-                std::vector<std::string> typenames =
+                std::vector<std::string> const typenames =
                     registry.get_unassigned_typenames();
 
                 // we should have received as many ids as we have unassigned names
@@ -227,8 +227,8 @@ namespace hpx::agas {
 
     template <typename Action, typename... Args>
     void big_boot_barrier::apply(std::uint32_t source_locality_id,
-        std::uint32_t target_locality_id, parcelset::locality dest, Action act,
-        Args&&... args)
+        std::uint32_t const target_locality_id, parcelset::locality dest,
+        Action act, Args&&... args)
     {    // {{{
         HPX_ASSERT(pp);
         naming::address addr(
@@ -257,7 +257,8 @@ namespace hpx::agas {
     template <typename Action, typename... Args>
     void big_boot_barrier::apply_late(std::uint32_t /* source_locality_id */
         ,
-        std::uint32_t target_locality_id, parcelset::locality const& /* dest */
+        std::uint32_t const target_locality_id,
+        parcelset::locality const& /* dest */
         ,
         Action act, Args&&... args)
     {    // {{{
@@ -287,21 +288,15 @@ namespace hpx::agas {
     // (first round trip)
     struct registration_header
     {
-        registration_header()
-          : primary_ns_ptr(nullptr)
-          , symbol_ns_ptr(nullptr)
-          , cores_needed(0)
-          , num_threads(0)
-        {
-        }
+        registration_header() = default;
 
-        // TODO: pass head address as a GVA
         registration_header(parcelset::endpoints_type const& endpoints_,
-            naming::address_type primary_ns_ptr_,
-            naming::address_type symbol_ns_ptr_, std::uint32_t cores_needed_,
-            std::uint32_t num_threads_, std::string const& hostname_,
+            naming::address_type const primary_ns_ptr_,
+            naming::address_type const symbol_ns_ptr_,
+            std::uint32_t const cores_needed_, std::uint32_t const num_threads_,
+            std::string const& hostname_,
             detail::unassigned_typename_sequence const& typenames_,
-            naming::gid_type prefix_ = naming::gid_type())
+            naming::gid_type prefix_, bool is_connecting_)
           : endpoints(endpoints_)
           , primary_ns_ptr(primary_ns_ptr_)
           , symbol_ns_ptr(symbol_ns_ptr_)
@@ -310,17 +305,19 @@ namespace hpx::agas {
           , hostname(hostname_)
           , typenames(typenames_)
           , prefix(prefix_)
+          , is_connecting(is_connecting_)
         {
         }
 
         parcelset::endpoints_type endpoints;
-        naming::address_type primary_ns_ptr;
-        naming::address_type symbol_ns_ptr;
-        std::uint32_t cores_needed;
-        std::uint32_t num_threads;
+        naming::address_type primary_ns_ptr = nullptr;
+        naming::address_type symbol_ns_ptr = nullptr;
+        std::uint32_t cores_needed = 0;
+        std::uint32_t num_threads = 0;
         std::string hostname;    // hostname of locality
         detail::unassigned_typename_sequence typenames;
         naming::gid_type prefix;    // suggested prefix (optional)
+        bool is_connecting = false;
 
         template <typename Archive>
         void serialize(Archive& ar, unsigned int const)
@@ -341,6 +338,7 @@ namespace hpx::agas {
             ar & hostname;
             ar & typenames;
             ar & prefix;
+            ar & is_connecting;
             // clang-format on
         }
     };
@@ -349,11 +347,7 @@ namespace hpx::agas {
     // is trying to register (first roundtrip).
     struct notification_header
     {
-        notification_header()
-          : num_localities(0)
-          , used_cores(0)
-        {
-        }
+        notification_header() = default;
 
         notification_header(naming::gid_type const& prefix_,
             parcelset::locality const& agas_locality_,
@@ -361,7 +355,8 @@ namespace hpx::agas {
             naming::address const& primary_ns_address_,
             naming::address const& component_ns_address_,
             naming::address const& symbol_ns_address_,
-            std::uint32_t num_localities_, std::uint32_t used_cores_,
+            std::uint32_t const num_localities_,
+            std::uint32_t const used_cores_,
             parcelset::endpoints_type const& agas_endpoints_,
             detail::assigned_id_sequence const& ids_)
           : prefix(prefix_)
@@ -383,8 +378,8 @@ namespace hpx::agas {
         naming::address primary_ns_address;
         naming::address component_ns_address;
         naming::address symbol_ns_address;
-        std::uint32_t num_localities;
-        std::uint32_t used_cores;
+        std::uint32_t num_localities = 0;
+        std::uint32_t used_cores = 0;
         parcelset::endpoints_type agas_endpoints;
         detail::assigned_id_sequence ids;
         std::vector<parcelset::endpoints_type> endpoints;
@@ -427,8 +422,11 @@ namespace hpx::agas {
 using hpx::agas::notify_worker_action;
 using hpx::agas::register_worker_action;
 
-HPX_ACTION_HAS_CRITICAL_PRIORITY(register_worker_action)
-HPX_ACTION_HAS_CRITICAL_PRIORITY(notify_worker_action)
+// The two startup actions acquire a lock on the big boot barrier spanning
+// possible suspensions. Using thread_priority::bound ensures that the lock is
+// released by the same thread that acquired it.
+HPX_ACTION_HAS_BOUND_PRIORITY(register_worker_action)
+HPX_ACTION_HAS_BOUND_PRIORITY(notify_worker_action)
 
 HPX_REGISTER_ACTION_ID(register_worker_action, register_worker_action,
     hpx::actions::register_worker_action_id)
@@ -472,8 +470,8 @@ namespace hpx::agas {
             return;
         }
 
-        if (!agas_client.register_locality(
-                header.endpoints, prefix, header.num_threads))
+        if (!agas_client.register_locality(header.endpoints, prefix,
+                header.num_threads, header.is_connecting))
         {
             HPX_THROW_EXCEPTION(hpx::error::internal_server_error,
                 "agas::register_worker",
@@ -620,8 +618,9 @@ namespace hpx::agas {
     }
     // }}}
 
-    void big_boot_barrier::apply_notification(std::uint32_t source_locality_id,
-        std::uint32_t target_locality_id, parcelset::locality const& dest,
+    void big_boot_barrier::apply_notification(
+        std::uint32_t const source_locality_id,
+        std::uint32_t const target_locality_id, parcelset::locality const& dest,
         notification_header&& hdr)
     {
         hdr.endpoints = localities;
@@ -629,7 +628,8 @@ namespace hpx::agas {
             notify_worker_action(), HPX_MOVE(hdr));
     }
 
-    void big_boot_barrier::add_locality_endpoints(std::uint32_t locality_id,
+    void big_boot_barrier::add_locality_endpoints(
+        std::uint32_t const locality_id,
         parcelset::endpoints_type const& endpoints_data)
     {
         if (localities.size() < static_cast<std::size_t>(locality_id) + 1)
@@ -658,12 +658,12 @@ namespace hpx::agas {
     inline std::size_t get_number_of_bootstrap_connections(
         util::runtime_configuration const& ini)
     {
-        service_mode service_type = ini.get_agas_service_mode();
+        service_mode const service_type = ini.get_agas_service_mode();
         std::size_t result = 1;
 
         if (service_mode::bootstrap == service_type)
         {
-            std::size_t num_localities =
+            std::size_t const num_localities =
                 static_cast<std::size_t>(ini.get_num_localities());
             result = num_localities ? num_localities - 1 : 0;
         }
@@ -702,14 +702,14 @@ namespace hpx::agas {
 
     namespace detail {
 
-        std::uint32_t get_number_of_pus_in_cores(std::uint32_t num_cores)
+        std::uint32_t get_number_of_pus_in_cores(std::uint32_t const num_cores)
         {
-            threads::topology& top = threads::create_topology();
+            threads::topology const& top = threads::create_topology();
 
             std::uint32_t num_pus = 0;
             for (std::uint32_t i = 0; i != num_cores; ++i)
             {
-                std::uint32_t num_pus_core = static_cast<std::uint32_t>(
+                std::uint32_t const num_pus_core = static_cast<std::uint32_t>(
                     top.get_number_of_core_pus(std::size_t(i)));
                 if (num_pus_core == ~std::uint32_t(0))
                     return num_cores;    // assume one pu per core
@@ -722,8 +722,9 @@ namespace hpx::agas {
     }    // namespace detail
 
     void big_boot_barrier::wait_hosted(std::string const& locality_name,
-        naming::address::address_type primary_ns_server,
-        naming::address::address_type symbol_ns_server)
+        naming::address::address_type const& primary_ns_server,
+        naming::address::address_type const& symbol_ns_server,
+        bool is_connecting)
     {    // {{{
         HPX_ASSERT(service_mode::bootstrap != service_type);
 
@@ -735,13 +736,13 @@ namespace hpx::agas {
 
         // get the number of cores we need for our locality. This respects the
         // affinity description. Cores that are partially used are counted as well
-        std::uint32_t cores_needed = rt.assign_cores();
-        std::uint32_t num_threads =
-            std::uint32_t(rt.get_config().get_os_thread_count());
+        std::uint32_t const cores_needed = rt.assign_cores();
+        std::uint32_t const num_threads =
+            static_cast<std::uint32_t>(rt.get_config().get_os_thread_count());
 
         naming::gid_type suggested_prefix;
 
-        std::string locality_str =
+        std::string const locality_str =
             rt.get_config().get_entry("hpx.locality", "-1");
         if (locality_str != "-1")
         {
@@ -750,12 +751,12 @@ namespace hpx::agas {
         }
 
         // pre-load all unassigned ids
-        detail::unassigned_typename_sequence unassigned(true);
+        detail::unassigned_typename_sequence const unassigned(true);
 
         // contact the bootstrap AGAS node
         registration_header hdr(parcelset::get_parcel_handler().endpoints(),
             primary_ns_server, symbol_ns_server, cores_needed, num_threads,
-            locality_name, unassigned, suggested_prefix);
+            locality_name, unassigned, suggested_prefix, is_connecting);
 
         // random first parcel id
         apply(static_cast<std::uint32_t>(std::random_device{}()), 0,
@@ -772,7 +773,7 @@ namespace hpx::agas {
 #endif
     void big_boot_barrier::notify()
     {
-        agas::addressing_service& agas_client = naming::get_agas_client();
+        agas::addressing_service const& agas_client = naming::get_agas_client();
 
         bool notify = false;
         {

--- a/libs/full/runtime_distributed/src/locality_interface.cpp
+++ b/libs/full/runtime_distributed/src/locality_interface.cpp
@@ -10,6 +10,7 @@
 #include <hpx/assert.hpp>
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/errors.hpp>
+
 #include <hpx/modules/parcelset.hpp>
 #include <hpx/modules/parcelset_base.hpp>
 #include <hpx/runtime_distributed.hpp>
@@ -17,6 +18,7 @@
 #include <hpx/runtime_distributed/runtime_fwd.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <string>
 #include <system_error>
 #include <vector>
@@ -44,6 +46,14 @@ namespace hpx::parcelset {
             return get_runtime_distributed()
                 .get_parcel_handler()
                 .create_locality(name);
+        }
+
+        bool locality_was_disconnected(std::uint32_t const id)
+        {
+            HPX_ASSERT(get_runtime_ptr());
+            return get_runtime_distributed()
+                .get_parcel_handler()
+                .locality_was_disconnected(id);
         }
 
         parcel_write_handler_type set_parcel_write_handler(
@@ -141,6 +151,8 @@ namespace hpx::parcelset {
         {
             detail::create_parcel = &detail::impl::create_parcel;
             detail::create_locality = &detail::impl::create_locality;
+            detail::locality_was_disconnected =
+                &detail::impl::locality_was_disconnected;
             detail::set_parcel_write_handler =
                 &detail::impl::set_parcel_write_handler;
 

--- a/libs/full/runtime_distributed/src/runtime_distributed.cpp
+++ b/libs/full/runtime_distributed/src/runtime_distributed.cpp
@@ -326,7 +326,7 @@ namespace hpx {
             agas::get_big_boot_barrier().wait_hosted(
                 pp ? pp->get_locality_name() : "<console>",
                 agas_client_.get_primary_ns_lva(),
-                agas_client_.get_symbol_ns_lva());
+                agas_client_.get_symbol_ns_lva(), agas_client_.is_connecting());
         }
 
         agas_client_.initialize(
@@ -533,12 +533,15 @@ namespace hpx {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    std::string locality_prefix(util::runtime_configuration const& cfg)
+    static std::string locality_prefix(util::runtime_configuration const& cfg)
     {
         std::string const localities = cfg.get_entry("hpx.localities", "1");
         std::size_t const num_localities =
             util::from_string<std::size_t>(localities, 1);
-        if (num_localities > 1)
+        bool const expect_connecting_localities =
+            cfg.get_entry("hpx.expect_connecting_localities", "0") != "0";
+        if (num_localities > 1 || expect_connecting_localities ||
+            cfg.mode_ == runtime_mode::connect)
         {
             std::string locality = cfg.get_entry("hpx.locality", "");
             if (!locality.empty())

--- a/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
+++ b/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
@@ -140,11 +140,11 @@ namespace hpx::components::server {
 
     // function to be called during shutdown
     // Action: shut down this runtime system instance
-    void runtime_support::shutdown(
-        double const timeout, hpx::id_type const& respond_to)
+    void runtime_support::shutdown(double const timeout,
+        hpx::id_type const& respond_to, bool force_disconnect)
     {
         // initiate system shutdown
-        stop(timeout, respond_to, false);
+        stop(timeout, respond_to, false, force_disconnect);
     }
 
     // function to be called to terminate this locality immediately
@@ -475,7 +475,7 @@ namespace hpx::components::server {
 
         // Now make sure this local locality gets shut down as well.
         // There is no need to respond...
-        stop(timeout, hpx::invalid_id, false);
+        stop(timeout, hpx::invalid_id, false, false);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -589,8 +589,8 @@ namespace hpx::components::server {
         }
     }
 
-    void runtime_support::stop(double const timeout,
-        hpx::id_type const& respond_to, bool const remove_from_remote_caches)
+    void runtime_support::stop(double timeout, hpx::id_type const& respond_to,
+        bool const remove_from_remote_caches, bool const force_disconnect)
     {
         std::unique_lock<std::mutex> l(mtx_);
         if (!stop_called_)
@@ -610,6 +610,11 @@ namespace hpx::components::server {
 
             {
                 unlock_guard<std::mutex> ul(mtx_);
+
+                if (timeout == -1.0)
+                {
+                    timeout = 0.0;
+                }
 
                 auto const duration_timeout = hpx::chrono::steady_duration(
                     std::chrono::duration_cast<std::chrono::nanoseconds>(
@@ -662,7 +667,8 @@ namespace hpx::components::server {
                 if (remove_from_remote_caches)
                     remove_locality_from_connection_cache(agas::get_locality());
 
-                agas_client.unregister_locality(here, ec);
+                if (!force_disconnect)
+                    agas_client.unregister_locality(here, ec);
 
                 if (remove_from_remote_caches)
                     remove_locality_from_console_connection_cache(
@@ -713,15 +719,69 @@ namespace hpx::components::server {
         }
     }
 
-    void runtime_support::remove_locality(
+    namespace {
+
+        // working around non-copy-ability of packaged_task
+        struct indirect_packaged_task
+        {
+            using packaged_task_type = hpx::packaged_task<void()>;
+
+            indirect_packaged_task()
+              : pt(std::make_shared<packaged_task_type>([]() {}))
+            {
+            }
+
+            hpx::future<void> get_future() const
+            {
+                return pt->get_future();
+            }
+
+            template <typename... Ts>
+            void operator()(Ts&&... /* vs */)
+            {
+                // This needs to be run on a HPX thread
+                hpx::post(HPX_MOVE(*pt));
+                pt.reset();
+            }
+
+            std::shared_ptr<packaged_task_type> pt;
+        };
+    }    // namespace
+
+    bool runtime_support::remove_locality(
         hpx::id_type const& locality, error_code& ec)
     {
+#if !defined(HPX_COMPUTE_DEVICE_CODE) && defined(HPX_HAVE_NETWORKING)
+        // try to inform the locality that it has been disconnected (ignore any
+        // errors)
+        using action_type = server::runtime_support::shutdown_action;
+
+        indirect_packaged_task ipt;
+        future<void> callback = ipt.get_future();
+
+        hpx::post_cb(action_type(), locality, HPX_MOVE(ipt), -1.0,
+            hpx::invalid_id, true);
+
+        // Bounded wait: don't let an unreachable/partitioned locality block
+        // forced cleanup indefinitely. Best-effort - ignore timeout/errors.
+        constexpr std::chrono::seconds shutdown_notify_timeout(5);
+        if (callback.wait_for(shutdown_notify_timeout) ==
+            hpx::future_status::ready)
+        {
+            error_code cb_ec(throwmode::lightweight);
+            callback.get(cb_ec);    // swallow any errors
+        }
+#endif
+
         remove_locality_from_connection_cache(locality.get_gid(), true);
 
         agas::addressing_service& agas_client = naming::get_agas_client();
-        agas_client.unregister_locality(locality.get_gid(), ec);
+        bool const result =
+            agas_client.unregister_locality(locality.get_gid(), ec);
 
         remove_locality_from_console_connection_cache(locality.get_gid());
+
+        return result;
     }
 
     void runtime_support::notify_waiting_main()
@@ -869,32 +929,6 @@ namespace hpx::components::server {
         }
     }
 
-    // working around non-copy-ability of packaged_task
-    struct indirect_packaged_task
-    {
-        using packaged_task_type = hpx::packaged_task<void()>;
-
-        indirect_packaged_task()
-          : pt(std::make_shared<packaged_task_type>([]() {}))
-        {
-        }
-
-        hpx::future<void> get_future() const
-        {
-            return pt->get_future();
-        }
-
-        template <typename... Ts>
-        void operator()(Ts&&... /* vs */)
-        {
-            // This needs to be run on a HPX thread
-            hpx::post(HPX_MOVE(*pt));
-            pt.reset();
-        }
-
-        std::shared_ptr<packaged_task_type> pt;
-    };
-
     void runtime_support::remove_locality_from_connection_cache(
         [[maybe_unused]] hpx::naming::gid_type const& locality,
         [[maybe_unused]] bool const skip_current)
@@ -939,11 +973,20 @@ namespace hpx::components::server {
     void runtime_support::remove_locality_from_console_connection_cache(
         [[maybe_unused]] hpx::naming::gid_type const& locality)
     {
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
-#if defined(HPX_HAVE_NETWORKING)
-        runtime_distributed const* rtd = get_runtime_distributed_ptr();
+        runtime_distributed* rtd = get_runtime_distributed_ptr();
         if (rtd == nullptr)
             return;
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#if defined(HPX_HAVE_NETWORKING)
+        if (agas::is_console() &&
+            locality == agas::get_console_locality().get_gid())
+        {
+            // do it locally, if possible
+            rtd->get_parcel_handler().remove_from_connection_cache(
+                locality, rtd->endpoints());
+            return;
+        }
 
         using action_type =
             server::runtime_support::remove_from_connection_cache_action;

--- a/libs/full/runtime_distributed/src/stubs/runtime_support_stubs.cpp
+++ b/libs/full/runtime_distributed/src/stubs/runtime_support_stubs.cpp
@@ -81,7 +81,8 @@ namespace hpx::components::stubs {
     /// \brief Shutdown the given runtime system
     hpx::future<void> runtime_support::shutdown_async(
         [[maybe_unused]] hpx::id_type const& targetgid,
-        [[maybe_unused]] double timeout)
+        [[maybe_unused]] double timeout,
+        [[maybe_unused]] bool const force_disconnect)
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         // Create a promise directly and execute the required action.
@@ -95,7 +96,7 @@ namespace hpx::components::stubs {
         // We need to make it unmanaged to avoid late refcnt requests
         id_type gid(
             value.get_id().get_gid(), id_type::management_type::unmanaged);
-        hpx::post<action_type>(targetgid, timeout, gid);
+        hpx::post<action_type>(targetgid, timeout, gid, force_disconnect);
 
         return f;
 #else
@@ -105,11 +106,11 @@ namespace hpx::components::stubs {
     }
 
     void runtime_support::shutdown(
-        hpx::id_type const& targetgid, double timeout)
+        hpx::id_type const& targetgid, double timeout, bool force_disconnect)
     {
         // The following get yields control while the action above
         // is executed and the result is returned to the future
-        shutdown_async(targetgid, timeout).get();
+        shutdown_async(targetgid, timeout, force_disconnect).get();
     }
 
     /// \brief Shutdown the runtime systems of all localities

--- a/libs/full/supervision/include/hpx/supervision/supervision_fwd.hpp
+++ b/libs/full/supervision/include/hpx/supervision/supervision_fwd.hpp
@@ -17,7 +17,7 @@ namespace hpx::supervision {
 
     ////////////////////////////////////////////////////////////////////////////
     HPX_CXX_EXPORT inline constexpr char const* const service_name =
-        "/0/supervision/";
+        "/{}/supervision/";
 
     namespace detail {
 

--- a/libs/full/supervision/src/server/activity_agent_server.cpp
+++ b/libs/full/supervision/src/server/activity_agent_server.cpp
@@ -6,13 +6,15 @@
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/modules/errors.hpp>
+#include <hpx/modules/functional.hpp>
+#include <hpx/modules/logging.hpp>
+
 #include <hpx/modules/actions.hpp>
 #include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components.hpp>
 #include <hpx/modules/components_base.hpp>
-#include <hpx/modules/functional.hpp>
-#include <hpx/modules/logging.hpp>
 #include <hpx/modules/runtime_components.hpp>
 
 #include <hpx/supervision/server/activity_agent.hpp>
@@ -61,21 +63,19 @@ namespace hpx::supervision::server {
         }
 
         bool result = true;
-        try
-        {
-            if (f_)
-            {
-                result = f_(notify);
-            }
-        }
-        catch (...)
-        {
-            finish_delivery();
-            std::rethrow_exception(std::current_exception());
-        }
+        hpx::detail::try_catch_exception_ptr(
+            [&]() {
+                if (f_)
+                {
+                    result = f_(notify);
+                }
+            },
+            [&](std::exception_ptr const& e) {
+                finish_delivery();
+                std::rethrow_exception(e);
+            });
 
         finish_delivery();
-
         return result;
     }
 

--- a/libs/full/supervision/src/server/agent_server.cpp
+++ b/libs/full/supervision/src/server/agent_server.cpp
@@ -6,13 +6,15 @@
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/modules/errors.hpp>
+#include <hpx/modules/functional.hpp>
+#include <hpx/modules/logging.hpp>
+
 #include <hpx/modules/actions.hpp>
 #include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components.hpp>
 #include <hpx/modules/components_base.hpp>
-#include <hpx/modules/functional.hpp>
-#include <hpx/modules/logging.hpp>
 #include <hpx/modules/runtime_components.hpp>
 
 #include <hpx/supervision/server/agent.hpp>
@@ -54,21 +56,19 @@ namespace hpx::supervision::server {
         }
 
         bool result = true;
-        try
-        {
-            if (f_)
-            {
-                result = f_(notify);
-            }
-        }
-        catch (...)
-        {
-            finish_delivery();
-            std::rethrow_exception(std::current_exception());
-        }
+        hpx::detail::try_catch_exception_ptr(
+            [&]() {
+                if (f_)
+                {
+                    result = f_(notify);
+                }
+            },
+            [&](std::exception_ptr const& e) {
+                finish_delivery();
+                std::rethrow_exception(e);
+            });
 
         finish_delivery();
-
         return result;
     }
 

--- a/libs/full/supervision/src/server/supervision_manager_server.cpp
+++ b/libs/full/supervision/src/server/supervision_manager_server.cpp
@@ -6,14 +6,15 @@
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
-#include <hpx/format.hpp>
-#include <hpx/modules/async_distributed.hpp>
-#include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/modules/format.hpp>
 #include <hpx/modules/futures.hpp>
-#include <hpx/modules/naming_base.hpp>
 #include <hpx/modules/thread_support.hpp>
 #include <hpx/modules/type_support.hpp>
+
+#include <hpx/modules/async_distributed.hpp>
+#include <hpx/modules/components_base.hpp>
+#include <hpx/modules/naming_base.hpp>
 
 #include <hpx/supervision/server/activity_agent.hpp>
 #include <hpx/supervision/server/agent.hpp>
@@ -764,15 +765,11 @@ namespace hpx::supervision::server {
 
         // now fire event for all observers of this target
         auto f = fire_events(target, notification);
-        try
-        {
-            f.get();
-        }
-        catch (...)
-        {
-            record_error(target, notification.event_sequence_number,
-                hpx::make_error_code(std::current_exception()));
-        }
+        hpx::detail::try_catch_exception_ptr([&]() { f.get(); },
+            [&](std::exception_ptr const& e) {
+                record_error(target, notification.event_sequence_number,
+                    hpx::make_error_code(e));
+            });
 
         // Delivery ordering: per-target register_observer callbacks (above)
         // fire before activity-observer callbacks (below), both synchronous for
@@ -833,15 +830,13 @@ namespace hpx::supervision::server {
             {
                 f = f.then([this, target, agent, notification](
                                hpx::future<void>&& prev_f) {
-                    try
-                    {
-                        prev_f.get();
-                    }
-                    catch (...)
-                    {
-                        record_error(target, notification.event_sequence_number,
-                            hpx::make_error_code(std::current_exception()));
-                    }
+                    hpx::detail::try_catch_exception_ptr(
+                        [&]() { prev_f.get(); },
+                        [&](std::exception_ptr const& e) {
+                            record_error(target,
+                                notification.event_sequence_number,
+                                hpx::make_error_code(e));
+                        });
                     return fire_event(target, agent, notification);
                 });
             }
@@ -887,15 +882,11 @@ namespace hpx::supervision::server {
 
         return fut.then([this, target, agent](hpx::future<bool>&& f) mutable {
             bool keep_registered = true;
+
             std::exception_ptr ep;
-            try
-            {
-                keep_registered = f.get();
-            }
-            catch (...)
-            {
-                ep = std::current_exception();
-            }
+            hpx::detail::try_catch_exception_ptr(
+                [&]() { keep_registered = f.get(); },
+                [&](std::exception_ptr const& e) { ep = e; });
 
             bool deactivated = false;
 
@@ -1093,15 +1084,11 @@ namespace hpx::supervision::server {
                 initial_notification->event_sequence_number;
 
             auto f = fire_event(target, agent, HPX_MOVE(*initial_notification));
-            try
-            {
-                f.get();
-            }
-            catch (...)
-            {
-                record_error(target, initial_sequence,
-                    hpx::make_error_code(std::current_exception()));
-            }
+            hpx::detail::try_catch_exception_ptr([&]() { f.get(); },
+                [&](std::exception_ptr const& e) {
+                    record_error(
+                        target, initial_sequence, hpx::make_error_code(e));
+                });
         }
 
         // Delivery ordering: the per-target register_observer replay above
@@ -1216,7 +1203,8 @@ namespace hpx::supervision::server {
 
                 HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "supervision_manager::unregister_observer",
-                    "observer_handle was not returned by register_observer()");
+                    "observer_handle was not returned by "
+                    "register_observer()");
             }
             else
             {
@@ -1226,7 +1214,8 @@ namespace hpx::supervision::server {
 
                 HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "supervision_manager::unregister_observer",
-                    "observer_handle does not represent a handle previously "
+                    "observer_handle does not represent a handle "
+                    "previously "
                     "returned by register_observer()");
             }
 
@@ -1376,18 +1365,14 @@ namespace hpx::supervision::server {
                 continue;
             }
 
-            try
-            {
-                fire_activity_event(observer, notification).get();
-            }
-            // NOLINTNEXTLINE(bugprone-empty-catch)
-            catch (...)
-            {
-                // Best effort: one activity observer's failure must not
-                // prevent delivery to the remaining activity observers, and
-                // there is no per-target latch to record this failure into
-                // (unlike record_error() for per-target observers).
-            }
+            hpx::detail::try_catch_exception_ptr(
+                [&]() { fire_activity_event(observer, notification).get(); },
+                [&](std::exception_ptr const&) {
+                    // Best effort: one activity observer's failure must not
+                    // prevent delivery to the remaining activity observers, and
+                    // there is no per-target latch to record this failure into
+                    // (unlike record_error() for per-target observers).
+                });
         }
 
         return hpx::make_ready_future();
@@ -1408,28 +1393,27 @@ namespace hpx::supervision::server {
             }
         }
 
-        try
-        {
-            using action_type =
-                activity_agent_component::invoke_if_active_action;
-            hpx::future<bool> keep_registered = hpx::async(hpx::launch::task,
-                action_type(), agent, HPX_MOVE(notification));
+        return hpx::detail::try_catch_exception_ptr(
+            [&]() {
+                using action_type =
+                    activity_agent_component::invoke_if_active_action;
+                hpx::future<bool> keep_registered =
+                    hpx::async(hpx::launch::task, action_type(), agent,
+                        HPX_MOVE(notification));
 
-            if (!keep_registered.get())
-            {
-                std::unique_lock<hpx::spinlock> l(mtx_);
-                std::erase_if(
-                    activity_observers_, [&agent](observer_entry const& entry) {
-                        return entry.agent == agent;
-                    });
-            }
-        }
-        catch (...)
-        {
-            return hpx::make_exceptional_future<void>(std::current_exception());
-        }
-
-        return hpx::make_ready_future();
+                if (!keep_registered.get())
+                {
+                    std::unique_lock<hpx::spinlock> l(mtx_);
+                    std::erase_if(activity_observers_,
+                        [&agent](observer_entry const& entry) {
+                            return entry.agent == agent;
+                        });
+                }
+                return hpx::make_ready_future();
+            },
+            [&](std::exception_ptr const& e) {
+                return hpx::make_exceptional_future<void>(e);
+            });
     }
 
     hpx::id_type supervision_manager::register_activity_observer(
@@ -1525,18 +1509,14 @@ namespace hpx::supervision::server {
         // this remains safe even if `agent` is concurrently unregistered.
         for (auto const& notification : replay)
         {
-            try
-            {
-                fire_activity_event(agent, notification).get();
-            }
-            // NOLINTNEXTLINE(bugprone-empty-catch)
-            catch (...)
-            {
-                // Best effort, mirroring deliver_activity_notification(): one
-                // replay delivery failing must not prevent delivery of the
-                // remaining replay notifications, nor this registration call
-                // from returning.
-            }
+            hpx::detail::try_catch_exception_ptr(
+                [&]() { fire_activity_event(agent, notification).get(); },
+                [&](std::exception_ptr const&) {
+                    // Best effort, mirroring deliver_activity_notification(): one
+                    // replay delivery failing must not prevent delivery of the
+                    // remaining replay notifications, nor this registration call
+                    // from returning.
+                });
         }
 
         return agent;
@@ -1570,7 +1550,8 @@ namespace hpx::supervision::server {
 
                     HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                         "supervision_manager::unregister_activity_observer",
-                        "observer_handle was returned by register_observer(), "
+                        "observer_handle was returned by "
+                        "register_observer(), "
                         "not register_activity_observer()");
                 }
 
@@ -1580,7 +1561,8 @@ namespace hpx::supervision::server {
 
                 HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "supervision_manager::unregister_activity_observer",
-                    "observer_handle does not represent a handle previously "
+                    "observer_handle does not represent a handle "
+                    "previously "
                     "returned by register_activity_observer()");
             }
         }
@@ -1707,7 +1689,8 @@ namespace hpx::supervision::server {
         this->base_type::set_locality_id(locality_id);
 
         // now register this supervision instance with AGAS
-        std::string instance_name = supervision::service_name;
+        std::string instance_name =
+            hpx::util::format(supervision::service_name, locality_id);
         instance_name += service_name;
         instance_name += supervision::server::supervision_manager_name;
 
@@ -1720,23 +1703,18 @@ namespace hpx::supervision::server {
         if (ec)
             return;
 
-        instance_name_ = service_name;
+        instance_name_ = HPX_MOVE(instance_name);
 
         // register a gid (not the id) to avoid AGAS holding a reference to this
         // component
-        agas::register_name(launch::sync, instance_name, gid, ec);
+        agas::register_name(launch::sync, instance_name_, gid, ec);
     }
 
     void supervision_manager::unregister_server_instance(error_code& ec) const
     {
         if (!instance_name_.empty())
         {
-            std::string instance_name = supervision::service_name;
-            instance_name += instance_name_;
-            instance_name += supervision::server::supervision_manager_name;
-
-            agas::unregister_name(launch::sync, instance_name, ec);
-
+            agas::unregister_name(launch::sync, instance_name_, ec);
             instance_name_.clear();
         }
     }


### PR DESCRIPTION
## Forced locality disconnection and runtime changes

### Summary
This PR adds support for forcibly and gracefully disconnecting localities from a running HPX distributed application, along with the supporting AGAS, parcelset, and runtime-support infrastructure needed to make disconnection safe and observable.

### Key changes

**Locality lifecycle & AGAS**
- Tracks *connecting* localities separately from fully registered/disconnected ones in `addressing_service` and the hosted component/locality namespace servers, so partially-joined localities don't leak state or block cleanup.
- Adds forced-removal paths for disconnected localities across `primary_namespace_server`, `symbol_namespace_server`, `locality_namespace_server`, and `component_namespace_server`.
- Extends `agas_fwd.hpp` / `agas_interface` with new hooks for force-disconnect and locality-removal operations, exposed through `components_base` agas interface functions.

**Parcel transport & big-boot-barrier**
- `parcelhandler`, `parcelport_impl`, and `locality_interface` gain timeout and fault-tolerance handling so parcel delivery/registration can fail gracefully when a peer locality is being removed.
- `big_boot_barrier` (18 ranges) is updated with disconnection-aware bootstrap/shutdown logic and timeout support during locality registration.

**Runtime & dispatch**
- `runtime_local.cpp`, `runtime_configuration`, and `hpx_init.cpp` (26 ranges) wire the new disconnection semantics into startup/shutdown and finalize logic (`init_runtime/finalize.hpp`).
- `async_distributed` post/async/sync implementation headers and `packaged_action`/`trigger` add distributed dispatch checks that detect and reject operations targeting removed/disconnecting localities.
- `try_catch_exception_ptr.hpp` and `future_data.cpp`/`future.hpp` improve exception propagation for tolerated failures during disconnection.

**Supervision & dispatch components**
- `supervision_manager_server.cpp` (14 ranges), `agent_server.cpp`, `activity_agent_server.cpp`, and `supervision_dispatch` (`dispatch_api.cpp`, `registry_server.cpp`) add fault-tolerance/tolerated-failure handling when a supervised locality disconnects.

**Testing**
- New regression tests: `agas/tests/regressions/departed_locality_7384.cpp` (+ child) validate locality departure behavior.
- New integration tests: `init_runtime/tests/unit/force_disconnect.cpp` and `force_disconnect_worker.cpp`, wired into `CMakeLists.txt`, exercise forced disconnection end-to-end across multiple localities.

### Affected areas
AGAS (addressing, namespaces), parcelset/parcelset_base, runtime_distributed (big-boot-barrier, runtime_support), async_distributed, core runtime/futures/errors, supervision components, and new unit/regression tests.

### Testing
- New `force_disconnect` unit test suite and `departed_locality_7384` regression tests cover the new disconnection paths.