### PR TITLE
components_base: add reflection-based default for get_component_name

### DIFF
--- a/docs/sphinx/manual/writing_distributed_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_distributed_hpx_applications.rst
@@ -714,6 +714,21 @@ For instance::
     //
     HPX_REGISTER_COMPONENT(some_component_type, some_component);
 
+.. note::
+
+   When C++26 reflection is enabled (``HPX_WITH_CXX26_REFLECTION=ON``),
+   the second argument to :c:macro:`HPX_REGISTER_COMPONENT` can be omitted.
+   The component name is then derived automatically from the server type
+   via ``std::meta::identifier_of``::
+
+       // With C++26 reflection -- single argument, name derived automatically
+       HPX_REGISTER_COMPONENT(some_component_type)
+
+   The derived name is fully qualified (includes enclosing namespaces) and
+   is equivalent to the explicit two-argument form. Explicit names always
+   take precedence over reflection-derived ones.
+
+
     // The parameters for this macro have to be the same as used in the corresponding
     // HPX_REGISTER_ACTION_DECLARATION() macro invocation in the corresponding
     // header file.

--- a/libs/full/components_base/include/hpx/components_base/component_type.hpp
+++ b/libs/full/components_base/include/hpx/components_base/component_type.hpp
@@ -297,3 +297,65 @@ namespace hpx::components {
         traits::component_type_database<Component>::set(type);
     }
 }    // namespace hpx::components
+
+#if defined(HPX_HAVE_CXX26_REFLECTION)
+#include <hpx/serialization/detail/refl_qualified_name_of.hpp>
+
+namespace hpx::components {
+
+    namespace detail {
+
+        // Primary: component has no type_holder -- name unknown via reflection.
+        template <typename Component, typename = void>
+        struct reflect_component_name
+        {
+            static constexpr char const* get() noexcept
+            {
+                return nullptr;
+            }
+        };
+
+        /// \brief Specialization for components with type_holder.
+        ///
+        /// Derives the fully-qualified component name from
+        /// Component::type_holder via qualified_name_of, so the
+        /// name passed to AGAS includes enclosing namespaces.
+        ///
+        /// \tparam Component The component type.
+        template <typename Component>
+        struct reflect_component_name<Component,
+            std::void_t<typename Component::type_holder>>
+        {
+            static char const* get() noexcept
+            {
+                using qualified = hpx::serialization::detail::qualified_name_of<
+                    typename Component::type_holder>;
+                return qualified::value.data;
+            }
+        };
+
+    }    // namespace detail
+
+    // Primary template definitions -- use reflection when type_holder exists
+    // and no explicit HPX_DEFINE_COMPONENT_NAME specialization is present.
+    template <typename Component, typename Enable>
+    HPX_ALWAYS_EXPORT char const* get_component_name() noexcept
+    {
+        return detail::reflect_component_name<Component>::get();
+    }
+
+    /// \brief Reflection-based default for get_component_base_name.
+    ///
+    /// Returns nullptr when no explicit base component is registered.
+    ///
+    /// \tparam Component The component type.
+    /// \tparam Enable    Unused -- matches primary template signature.
+    /// \return nullptr
+    template <typename Component, typename Enable>
+    HPX_ALWAYS_EXPORT char const* get_component_base_name() noexcept
+    {
+        return nullptr;
+    }
+
+}    // namespace hpx::components
+#endif    // HPX_HAVE_CXX26_REFLECTION

--- a/libs/full/runtime_components/tests/unit/components/reflect_client_test.cpp
+++ b/libs/full/runtime_components/tests/unit/components/reflect_client_test.cpp
@@ -67,6 +67,24 @@ HPX_CLIENT(reflect_test_server2)
 HPX_CLIENT(reflect_test_server)
 
 ///////////////////////////////////////////////////////////////////////////////
+// Server for testing reflection-based get_component_name.
+// Uses single-argument HPX_REGISTER_COMPONENT -- no explicit name.
+// get_component_name<reflect_test_server3_type>() must derive the
+// name automatically via reflection from type_holder.
+struct reflect_test_server3
+  : hpx::components::component_base<reflect_test_server3>
+{
+    std::int32_t value() const
+    {
+        return 42;
+    }
+};
+using reflect_test_server3_type =
+    hpx::components::component<reflect_test_server3>;
+// Single-argument form -- name derived via reflection.
+HPX_REGISTER_COMPONENT(reflect_test_server3_type)
+
+///////////////////////////////////////////////////////////////////////////////
 int main()
 {
     std::vector<hpx::id_type> localities = hpx::find_all_localities();
@@ -95,6 +113,28 @@ int main()
         HPX_TEST_EQ(f3.get(), std::int32_t(42));
     }
 
+    // Test reflection-based get_component_name.
+    // reflect_test_server3 uses HPX_REGISTER_COMPONENT with a single
+    // argument -- no explicit HPX_DEFINE_COMPONENT_NAME specialization.
+    // The name must be derived automatically via reflection.
+    {
+        char const* name =
+            hpx::components::get_component_name<reflect_test_server3_type>();
+        // Guard string conversion: HPX_TEST is non-fatal so check
+        // explicitly before dereferencing to avoid undefined behaviour.
+        HPX_TEST(name != nullptr);
+        if (name != nullptr)
+        {
+            std::string const name_str(name);
+            // The derived name must contain the type_holder identifier.
+            HPX_TEST(
+                name_str.find("reflect_test_server3") != std::string::npos);
+        }
+        // Test reflection-based get_component_base_name returns nullptr.
+        char const* base_name = hpx::components::get_component_base_name<
+            reflect_test_server3_type>();
+        HPX_TEST(base_name == nullptr);
+    }
     return hpx::util::report_errors();
 }
 #endif    // !HPX_COMPUTE_DEVICE_CODE && HPX_HAVE_CXX26_REFLECTION


### PR DESCRIPTION
## Summary

When `HPX_HAVE_CXX26_REFLECTION` is enabled, automatically derives the
component name from `Component::type_holder` via
`std::meta::identifier_of`, eliminating the need to pass the name
manually to `HPX_REGISTER_COMPONENT`.

## Before / After

```cpp
// Before (two args always required):
typedef hpx::components::component<block_component> block_component_type;
HPX_REGISTER_COMPONENT(block_component_type, block_component)

// After (one arg sufficient when reflection is available):
typedef hpx::components::component<block_component> block_component_type;
HPX_REGISTER_COMPONENT(block_component_type)
// "block_component" derived automatically from type_holder
```

## Design

Adds a reflection-based default template specialization for
`get_component_name<Component>` and `get_component_base_name<Component>`
in `component_type.hpp`. The default participates only when
`Component::type_holder` exists (SFINAE via `std::void_t`).

An explicit `HPX_DEFINE_COMPONENT_NAME` specialization always wins
because it is a full explicit specialization (`Enable = void`), while
this default uses `Enable = std::void_t<typename Component::type_holder>`.

Uses `fixed_string` from `refl_qualified_name_of.hpp` to store the name
as a stable compile-time constant with static storage duration.

## Related

Requested by @hkaiser. Builds on #7298, #7311, #7385.
Part of the GSoC 2026 project: C++26 Reflection for HPX Remote Operations.