### PR TITLE
Fix pairwise all_to_all build with Clang 17 and OpenMP

### DIFF
--- a/libs/full/collectives/include/hpx/collectives/detail/pairwise_all_to_all_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/pairwise_all_to_all_helpers.hpp
@@ -188,14 +188,20 @@ namespace hpx::collectives::detail {
                     std::vector<T> result;
                     result.reserve(num_sites);
 
-                    for (std::size_t source = 0; source != num_sites; ++source)
+                    for (std::size_t source = 0; source != this_site; ++source)
                     {
-                        if (source == this_site)
-                        {
-                            result.push_back(HPX_MOVE(diagonal));
-                            continue;
-                        }
+                        // received[k - 1] came from the peer k hops behind
+                        // this site, matching the receive order posted above.
+                        std::size_t const k =
+                            (this_site + num_sites - source) % num_sites;
+                        result.push_back(received[k - 1].get());
+                    }
 
+                    result.push_back(HPX_MOVE(diagonal));
+
+                    for (std::size_t source = this_site + 1;
+                        source != num_sites; ++source)
+                    {
                         // received[k - 1] came from the peer k hops behind
                         // this site, matching the receive order posted above.
                         std::size_t const k =

--- a/libs/full/collectives/include/hpx/collectives/detail/pairwise_all_to_all_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/pairwise_all_to_all_helpers.hpp
@@ -187,25 +187,20 @@ namespace hpx::collectives::detail {
 
                     std::vector<T> result;
                     result.reserve(num_sites);
-                    auto append_received = [&](std::size_t const source) {
+
+                    for (std::size_t source = 0; source != num_sites; ++source)
+                    {
+                        if (source == this_site)
+                        {
+                            result.push_back(HPX_MOVE(diagonal));
+                            continue;
+                        }
+
                         // received[k - 1] came from the peer k hops behind
                         // this site, matching the receive order posted above.
                         std::size_t const k =
                             (this_site + num_sites - source) % num_sites;
                         result.push_back(received[k - 1].get());
-                    };
-
-                    for (std::size_t source = 0; source != this_site; ++source)
-                    {
-                        append_received(source);
-                    }
-
-                    result.push_back(HPX_MOVE(diagonal));
-
-                    for (std::size_t source = this_site + 1;
-                        source != num_sites; ++source)
-                    {
-                        append_received(source);
                     }
 
                     return result;


### PR DESCRIPTION
## Proposed changes

Clang 17 rejects the pairwise `all_to_all` helper when `-fopenmp` is enabled because the nested `append_received` lambda captures the `received` structured binding. This appeared in the [LSU build for #7412](https://cdash.rostam.cct.lsu.edu/build/70842).

Replace the nested lambda and its two caller loops with one source-ordered loop. The loop inserts the local diagonal at `this_site`; remote sources keep the existing `k - 1` receive mapping. Result order, public APIs, includes, and CMake configuration are unchanged.

## Validation

Built `pairwise_all_to_all_test`, `pairwise_all_to_all_dispatch_test`, and `benchmark_collectives_test` with the local Release configuration. Both pairwise TCP unit tests passed (2/2), and `clang-format` 20.1.7 reported no changes.

The exact Clang 17 and OpenMP configuration is not available locally. LSU CI will verify that configuration. No new test was added because the existing targets instantiate the failing code and the pairwise unit tests cover the result order.

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
