### PR TITLE
Remove stale hpx_tag_invoke module dependencies

### DIFF
--- a/libs/core/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/CMakeLists.txt
@@ -297,7 +297,6 @@ add_hpx_module(
     hpx_properties
     hpx_serialization
     hpx_synchronization
-    hpx_tag_invoke
     hpx_threading_base
     hpx_tracing
     hpx_type_support

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/contains.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/contains.hpp
@@ -7,7 +7,6 @@
 
 #include <hpx/config.hpp>
 #include <hpx/modules/functional.hpp>
-#include <hpx/modules/tag_invoke.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/util/loop.hpp>
 
@@ -19,13 +18,11 @@ namespace hpx::parallel::detail {
 
     HPX_CXX_CORE_EXPORT template <typename ExPolicy>
     struct sequential_contains_t final
-      : hpx::functional::detail::tag_fallback<sequential_contains_t<ExPolicy>>
     {
-    private:
         template <typename Iterator, typename Sentinel, typename T,
             typename Proj>
-        friend constexpr bool tag_fallback_invoke(sequential_contains_t,
-            Iterator first, Sentinel last, T const& val, Proj&& proj)
+        constexpr bool operator()(
+            Iterator first, Sentinel last, T const& val, Proj&& proj) const
         {
             using difference_type =
                 typename std::iterator_traits<Iterator>::difference_type;
@@ -44,9 +41,8 @@ namespace hpx::parallel::detail {
         }
 
         template <typename Iterator, typename T, typename Token, typename Proj>
-        friend constexpr void tag_fallback_invoke(sequential_contains_t,
-            Iterator first, T const& val, std::size_t count, Token& tok,
-            Proj&& proj)
+        constexpr void operator()(Iterator first, T const& val,
+            std::size_t count, Token& tok, Proj&& proj) const
         {
             util::const_loop_n<ExPolicy>(
                 first, count, tok, [&val, &tok, &proj](auto const& cur) {

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/iota.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/iota.hpp
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/tag_invoke.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/util/loop.hpp>
@@ -32,14 +31,12 @@ namespace hpx::parallel::detail {
         return first;
     }
 
-    HPX_CXX_CORE_EXPORT struct sequential_iota_t
-      : hpx::functional::detail::tag_fallback<sequential_iota_t>
+    HPX_CXX_CORE_EXPORT struct sequential_iota_t final
     {
-    private:
         template <typename ExPolicy, typename FwdIter, typename Sent,
             typename T>
-        friend constexpr FwdIter tag_fallback_invoke(
-            sequential_iota_t, ExPolicy&&, FwdIter first, Sent last, T& value)
+        constexpr FwdIter operator()(
+            ExPolicy&&, FwdIter first, Sent last, T& value) const
         {
             return sequential_iota_helper(first, last, value);
         }

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/iota.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/iota.hpp
@@ -35,7 +35,7 @@ namespace hpx::parallel::detail {
     {
         template <typename ExPolicy, typename FwdIter, typename Sent,
             typename T>
-        constexpr FwdIter operator()(
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr FwdIter operator()(
             ExPolicy&&, FwdIter first, Sent last, T& value) const
         {
             return sequential_iota_helper(first, last, value);

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/reduce_deterministic.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/reduce_deterministic.hpp
@@ -26,7 +26,8 @@ namespace hpx::parallel::detail {
     {
         template <typename InIterB, typename InIterE, typename T,
             typename Reduce>
-        constexpr T operator()(ExPolicy&&, InIterB first, InIterE last, T init,
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr T operator()(ExPolicy&&,
+            InIterB first, InIterE last, T init,
             [[maybe_unused]] Reduce&& r) const
         {
             /// TODO: Put constraint on Reduce to be a binary plus operator
@@ -65,10 +66,10 @@ namespace hpx::parallel::detail {
     struct sequential_reduce_deterministic_rfa_t final
     {
         template <typename InIterB, typename T>
-        constexpr hpx::parallel::detail::rfa::reproducible_floating_accumulator<
-            T>
-        operator()(ExPolicy&&, InIterB first, std::size_t partition_size,
-            T init, std::true_type&&) const
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr hpx::parallel::detail::rfa::
+            reproducible_floating_accumulator<T>
+            operator()(ExPolicy&&, InIterB first, std::size_t partition_size,
+                T init, std::true_type&&) const
         {
             // hpx_rfa_bin_host_buffer should be initialized by the frontend of
             // this method
@@ -101,8 +102,9 @@ namespace hpx::parallel::detail {
         }
 
         template <typename InIterB, typename T>
-        constexpr T operator()(ExPolicy&&, InIterB first,
-            std::size_t partition_size, T init, std::false_type&&) const
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr T operator()(ExPolicy&&,
+            InIterB first, std::size_t partition_size, T init,
+            std::false_type&&) const
         {
             // hpx_rfa_bin_host_buffer should be initialized by the frontend of
             // this method

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/detail/reduce_deterministic.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/detail/reduce_deterministic.hpp
@@ -8,7 +8,6 @@
 
 #include <hpx/config.hpp>
 #include <hpx/modules/functional.hpp>
-#include <hpx/modules/tag_invoke.hpp>
 #include <hpx/modules/type_support.hpp>
 #include <hpx/parallel/algorithms/detail/rfa.hpp>
 #include <hpx/parallel/util/loop.hpp>
@@ -24,15 +23,11 @@ namespace hpx::parallel::detail {
 
     HPX_CXX_CORE_EXPORT template <typename ExPolicy>
     struct sequential_reduce_deterministic_t final
-      : hpx::functional::detail::tag_fallback<
-            sequential_reduce_deterministic_t<ExPolicy>>
     {
-    private:
         template <typename InIterB, typename InIterE, typename T,
             typename Reduce>
-        friend constexpr T tag_fallback_invoke(
-            sequential_reduce_deterministic_t, ExPolicy&&, InIterB first,
-            InIterE last, T init, [[maybe_unused]] Reduce&& r)
+        constexpr T operator()(ExPolicy&&, InIterB first, InIterE last, T init,
+            [[maybe_unused]] Reduce&& r) const
         {
             /// TODO: Put constraint on Reduce to be a binary plus operator
 
@@ -68,16 +63,12 @@ namespace hpx::parallel::detail {
 
     HPX_CXX_CORE_EXPORT template <typename ExPolicy>
     struct sequential_reduce_deterministic_rfa_t final
-      : hpx::functional::detail::tag_fallback<
-            sequential_reduce_deterministic_rfa_t<ExPolicy>>
     {
-    private:
         template <typename InIterB, typename T>
-        friend constexpr hpx::parallel::detail::rfa::
-            reproducible_floating_accumulator<T>
-            tag_fallback_invoke(sequential_reduce_deterministic_rfa_t,
-                ExPolicy&&, InIterB first, std::size_t partition_size, T init,
-                std::true_type&&)
+        constexpr hpx::parallel::detail::rfa::reproducible_floating_accumulator<
+            T>
+        operator()(ExPolicy&&, InIterB first, std::size_t partition_size,
+            T init, std::true_type&&) const
         {
             // hpx_rfa_bin_host_buffer should be initialized by the frontend of
             // this method
@@ -110,9 +101,8 @@ namespace hpx::parallel::detail {
         }
 
         template <typename InIterB, typename T>
-        friend constexpr T tag_fallback_invoke(
-            sequential_reduce_deterministic_rfa_t, ExPolicy&&, InIterB first,
-            std::size_t partition_size, T init, std::false_type&&)
+        constexpr T operator()(ExPolicy&&, InIterB first,
+            std::size_t partition_size, T init, std::false_type&&) const
         {
             // hpx_rfa_bin_host_buffer should be initialized by the frontend of
             // this method

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/contains.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/contains.hpp
@@ -151,8 +151,7 @@ namespace hpx::parallel::detail {
 namespace hpx::ranges {
 
     HPX_CXX_CORE_EXPORT inline constexpr struct contains_t final
-      : hpx::detail::tag_dispatch<contains_t,
-            hpx::functional::detail::tag_fallback<contains_t>>
+      : hpx::detail::tag_dispatch<contains_t, hpx::detail::no_base>
     {
         template <typename Iterator, typename Sentinel, typename T,
             typename Proj = hpx::identity>
@@ -235,8 +234,7 @@ namespace hpx::ranges {
     } contains{};
 
     HPX_CXX_CORE_EXPORT inline constexpr struct contains_subrange_t final
-      : hpx::detail::tag_dispatch<contains_subrange_t,
-            hpx::functional::detail::tag_fallback<contains_subrange_t>>
+      : hpx::detail::tag_dispatch<contains_subrange_t, hpx::detail::no_base>
     {
         template <typename FwdIter1, typename Sent1, typename FwdIter2,
             typename Sent2, typename Pred = ranges::equal_to,

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/ends_with.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/ends_with.hpp
@@ -286,7 +286,6 @@ namespace hpx { namespace ranges {
 #include <hpx/modules/concepts.hpp>
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/iterator_support.hpp>
-#include <hpx/modules/tag_invoke.hpp>
 #include <hpx/parallel/algorithms/detail/tag_dispatch.hpp>
 #include <hpx/parallel/algorithms/ends_with.hpp>
 
@@ -300,8 +299,7 @@ namespace hpx::ranges {
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::ranges::copy
     HPX_CXX_CORE_EXPORT inline constexpr struct ends_with_t final
-      : hpx::detail::tag_dispatch<ends_with_t,
-            hpx::functional::detail::tag_fallback<ends_with_t>>
+      : hpx::detail::tag_dispatch<ends_with_t, hpx::detail::no_base>
     {
         template <typename Iter1, typename Sent1, typename Iter2,
             typename Sent2, typename Pred = ranges::equal_to,

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/exclusive_scan.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/exclusive_scan.hpp
@@ -329,7 +329,6 @@ namespace hpx { namespace ranges {
 #include <hpx/config.hpp>
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/iterator_support.hpp>
-#include <hpx/modules/tag_invoke.hpp>
 #include <hpx/parallel/algorithms/detail/tag_dispatch.hpp>
 #include <hpx/parallel/algorithms/exclusive_scan.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/inclusive_scan.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/inclusive_scan.hpp
@@ -648,7 +648,6 @@ namespace hpx { namespace ranges {
 #include <hpx/config.hpp>
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/iterator_support.hpp>
-#include <hpx/modules/tag_invoke.hpp>
 #include <hpx/parallel/algorithms/detail/tag_dispatch.hpp>
 #include <hpx/parallel/algorithms/inclusive_scan.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/starts_with.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/starts_with.hpp
@@ -287,7 +287,6 @@ namespace hpx { namespace ranges {
 #include <hpx/modules/concepts.hpp>
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/iterator_support.hpp>
-#include <hpx/modules/tag_invoke.hpp>
 #include <hpx/parallel/algorithms/detail/tag_dispatch.hpp>
 #include <hpx/parallel/algorithms/starts_with.hpp>
 
@@ -301,8 +300,7 @@ namespace hpx::ranges {
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::ranges::copy
     HPX_CXX_CORE_EXPORT inline constexpr struct starts_with_t final
-      : hpx::detail::tag_dispatch<starts_with_t,
-            hpx::functional::detail::tag_fallback<starts_with_t>>
+      : hpx::detail::tag_dispatch<starts_with_t, hpx::detail::no_base>
     {
         template <typename Iter1, typename Sent1, typename Iter2,
             typename Sent2, typename Pred = ranges::equal_to,

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/transform_exclusive_scan.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/transform_exclusive_scan.hpp
@@ -429,7 +429,6 @@ namespace hpx { namespace ranges {
 #include <hpx/config.hpp>
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/iterator_support.hpp>
-#include <hpx/modules/tag_invoke.hpp>
 #include <hpx/parallel/algorithms/detail/tag_dispatch.hpp>
 #include <hpx/parallel/algorithms/transform_exclusive_scan.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/transform_reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/transform_reduce.hpp
@@ -888,7 +888,6 @@ namespace hpx {
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/iterator_support.hpp>
-#include <hpx/modules/tag_invoke.hpp>
 #include <hpx/parallel/algorithms/detail/tag_dispatch.hpp>
 #include <hpx/parallel/algorithms/transform_reduce.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>

--- a/libs/core/async_base/CMakeLists.txt
+++ b/libs/core/async_base/CMakeLists.txt
@@ -45,6 +45,5 @@ add_hpx_module(
     hpx_coroutines
     hpx_execution_base
     hpx_serialization
-    hpx_tag_invoke
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/async_combinators/CMakeLists.txt
+++ b/libs/core/async_combinators/CMakeLists.txt
@@ -55,7 +55,6 @@ add_hpx_module(
     hpx_memory
     hpx_pack_traversal
     hpx_preprocessor
-    hpx_tag_invoke
     hpx_thread_support
     hpx_timing
     hpx_type_support

--- a/libs/core/async_cuda/CMakeLists.txt
+++ b/libs/core/async_cuda/CMakeLists.txt
@@ -79,7 +79,6 @@ add_hpx_module(
     hpx_memory
     hpx_runtime_local
     hpx_synchronization
-    hpx_tag_invoke
     hpx_threading_base
     hpx_type_support
   DEPENDENCIES ${async_cuda_extra_deps}

--- a/libs/core/async_mpi/CMakeLists.txt
+++ b/libs/core/async_mpi/CMakeLists.txt
@@ -51,6 +51,5 @@ add_hpx_module(
     hpx_threading_base
     hpx_runtime_local
     hpx_synchronization
-    hpx_tag_invoke
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/async_mpi/tests/unit/algorithm_transform_mpi.cpp
+++ b/libs/core/async_mpi/tests/unit/algorithm_transform_mpi.cpp
@@ -29,7 +29,7 @@ namespace tt = hpx::this_thread::experimental;
 template <typename T>
 auto hpx_invoke(mpi::transform_mpi_t, custom_type<T>& c)
 {
-    c.tag_invoke_overload_called = true;
+    c.overload_called = true;
     return mpi::transform_mpi(
         ex::just(&c.x, 1, MPI_INT, 0, MPI_COMM_WORLD), MPI_Ibcast);
 }

--- a/libs/core/execution/include/hpx/execution/algorithms/keep_future.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/keep_future.hpp
@@ -391,14 +391,6 @@ namespace hpx::execution::experimental {
         };
     }    // namespace detail
 
-    template <typename Future, typename Scheduler>
-    auto tag_invoke(continues_on_t, detail::keep_future_sender<Future>&& sndr,
-        Scheduler&& scheduler)
-    {
-        return detail::keep_future_continues_on_sender<Future, Scheduler>{
-            HPX_MOVE(sndr.future), HPX_FORWARD(Scheduler, scheduler)};
-    }
-
     HPX_CXX_CORE_EXPORT inline constexpr struct keep_future_t final
     {
         // clang-format off

--- a/libs/core/execution/tests/unit/algorithm_bulk.cpp
+++ b/libs/core/execution/tests/unit/algorithm_bulk.cpp
@@ -21,7 +21,7 @@ namespace ex = hpx::execution::experimental;
 
 struct custom_bulk_operation
 {
-    std::atomic<bool>& tag_invoke_overload_called;
+    std::atomic<bool>& overload_called;
     std::atomic<bool>& call_operator_called;
     std::atomic<int>& call_operator_count;
     bool throws;
@@ -217,11 +217,11 @@ int main()
     // sender-specific customization hook here)
     {
         std::atomic<bool> receiver_set_value_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> overload_called{false};
         std::atomic<bool> custom_bulk_call_operator_called{false};
         std::atomic<int> custom_bulk_call_count{0};
         auto s = ex::bulk(ex::just(), 10,
-            custom_bulk_operation{tag_invoke_overload_called,
+            custom_bulk_operation{overload_called,
                 custom_bulk_call_operator_called, custom_bulk_call_count,
                 false});
 
@@ -238,7 +238,7 @@ int main()
         ex::start(os);
         HPX_TEST(receiver_set_value_called);
         // no sender-specific bulk customization in this test
-        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!overload_called);
         HPX_TEST(custom_bulk_call_operator_called);
         HPX_TEST_EQ(custom_bulk_call_count, 10);
     }
@@ -313,11 +313,11 @@ int main()
 
     {
         std::atomic<bool> receiver_set_error_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> overload_called{false};
         std::atomic<bool> custom_bulk_call_operator_called{false};
         std::atomic<int> custom_bulk_call_count{0};
         auto s = ex::bulk(ex::just(), 10,
-            custom_bulk_operation{tag_invoke_overload_called,
+            custom_bulk_operation{overload_called,
                 custom_bulk_call_operator_called, custom_bulk_call_count,
                 true});
 
@@ -334,7 +334,7 @@ int main()
         ex::start(os);
         HPX_TEST(receiver_set_error_called);
         // no sender-specific bulk customization in this test
-        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!overload_called);
         HPX_TEST(custom_bulk_call_operator_called);
         HPX_TEST_EQ(custom_bulk_call_count, 3);
     }

--- a/libs/core/execution/tests/unit/algorithm_continues_on.cpp
+++ b/libs/core/execution/tests/unit/algorithm_continues_on.cpp
@@ -31,10 +31,10 @@ int main()
         std::atomic<bool> set_value_called{false};
         std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> overload_called{false};
         auto s = ex::continues_on(ex::just(),
             example_scheduler{scheduler_schedule_called,
-                scheduler_execute_called, tag_invoke_overload_called});
+                scheduler_execute_called, overload_called});
         static_assert(ex::is_sender_v<decltype(s)>);
         static_assert(ex::is_sender_in_v<decltype(s), ex::empty_env>);
 
@@ -47,7 +47,7 @@ int main()
         auto os = ex::connect(std::move(s), std::move(r));
         ex::start(os);
         HPX_TEST(set_value_called);
-        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!overload_called);
         HPX_TEST(scheduler_schedule_called);
         HPX_TEST(!scheduler_execute_called);
     }
@@ -56,10 +56,10 @@ int main()
         std::atomic<bool> set_value_called{false};
         std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> overload_called{false};
         auto s = ex::continues_on(ex::just(3),
             example_scheduler{scheduler_schedule_called,
-                scheduler_execute_called, tag_invoke_overload_called});
+                scheduler_execute_called, overload_called});
         static_assert(ex::is_sender_v<decltype(s)>);
         static_assert(ex::is_sender_in_v<decltype(s), ex::empty_env>);
 
@@ -72,7 +72,7 @@ int main()
         auto os = ex::connect(std::move(s), std::move(r));
         ex::start(os);
         HPX_TEST(set_value_called);
-        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!overload_called);
         HPX_TEST(scheduler_schedule_called);
         HPX_TEST(!scheduler_execute_called);
     }
@@ -81,11 +81,11 @@ int main()
         std::atomic<bool> set_value_called{false};
         std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> overload_called{false};
         auto s = ex::continues_on(
             ex::just(custom_type_non_default_constructible{42}),
             example_scheduler{scheduler_schedule_called,
-                scheduler_execute_called, tag_invoke_overload_called});
+                scheduler_execute_called, overload_called});
         static_assert(ex::is_sender_v<decltype(s)>);
         static_assert(ex::is_sender_in_v<decltype(s), ex::empty_env>);
 
@@ -99,7 +99,7 @@ int main()
         auto os = ex::connect(std::move(s), std::move(r));
         ex::start(os);
         HPX_TEST(set_value_called);
-        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!overload_called);
         HPX_TEST(scheduler_schedule_called);
         HPX_TEST(!scheduler_execute_called);
     }
@@ -108,11 +108,11 @@ int main()
         std::atomic<bool> set_value_called{false};
         std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> overload_called{false};
         auto s = ex::continues_on(
             ex::just(custom_type_non_default_constructible_non_copyable{42}),
             example_scheduler{scheduler_schedule_called,
-                scheduler_execute_called, tag_invoke_overload_called});
+                scheduler_execute_called, overload_called});
         static_assert(ex::is_sender_v<decltype(s)>);
         static_assert(ex::is_sender_in_v<decltype(s), ex::empty_env>);
         check_value_types<hpx::variant<
@@ -125,7 +125,7 @@ int main()
         auto os = ex::connect(std::move(s), std::move(r));
         ex::start(os);
         HPX_TEST(set_value_called);
-        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!overload_called);
         HPX_TEST(scheduler_schedule_called);
         HPX_TEST(!scheduler_execute_called);
     }
@@ -134,10 +134,10 @@ int main()
         std::atomic<bool> set_value_called{false};
         std::atomic<bool> scheduler_execute_called{false};
         std::atomic<bool> scheduler_schedule_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> overload_called{false};
         auto s = ex::continues_on(ex::just(std::string("hello"), 3),
             example_scheduler{scheduler_schedule_called,
-                scheduler_execute_called, tag_invoke_overload_called});
+                scheduler_execute_called, overload_called});
         static_assert(ex::is_sender_v<decltype(s)>);
         static_assert(ex::is_sender_in_v<decltype(s), ex::empty_env>);
 
@@ -153,7 +153,7 @@ int main()
         auto os = ex::connect(std::move(s), std::move(r));
         ex::start(os);
         HPX_TEST(set_value_called);
-        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!overload_called);
         HPX_TEST(!scheduler_execute_called);
         HPX_TEST(scheduler_schedule_called);
     }
@@ -163,10 +163,10 @@ int main()
         std::atomic<bool> set_value_called{false};
         std::atomic<bool> scheduler_execute_called{false};
         std::atomic<bool> scheduler_schedule_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> overload_called{false};
         auto s = ex::just(std::string("hello"), 3) |
             ex::continues_on(example_scheduler{scheduler_schedule_called,
-                scheduler_execute_called, tag_invoke_overload_called});
+                scheduler_execute_called, overload_called});
         static_assert(ex::is_sender_v<decltype(s)>);
         static_assert(ex::is_sender_in_v<decltype(s), ex::empty_env>);
 
@@ -182,7 +182,7 @@ int main()
         auto os = ex::connect(std::move(s), r);
         ex::start(os);
         HPX_TEST(set_value_called);
-        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!overload_called);
         HPX_TEST(scheduler_schedule_called);
         HPX_TEST(!scheduler_execute_called);
     }
@@ -190,12 +190,12 @@ int main()
     // Failure path
     {
         std::atomic<bool> set_error_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> overload_called{false};
         std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
         auto s = ex::continues_on(error_sender{},
             example_scheduler{scheduler_schedule_called,
-                scheduler_execute_called, tag_invoke_overload_called});
+                scheduler_execute_called, overload_called});
         static_assert(ex::is_sender_v<decltype(s)>);
         static_assert(ex::is_sender_in_v<decltype(s), ex::empty_env>);
 
@@ -208,7 +208,7 @@ int main()
         auto os = ex::connect(std::move(s), std::move(r));
         ex::start(os);
         HPX_TEST(set_error_called);
-        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!overload_called);
         // schedule is called anyways
         HPX_TEST(scheduler_schedule_called);
         HPX_TEST(!scheduler_execute_called);

--- a/libs/core/execution/tests/unit/algorithm_ensure_started.cpp
+++ b/libs/core/execution/tests/unit/algorithm_ensure_started.cpp
@@ -142,9 +142,8 @@ int main()
     // hook is exercised here.
     {
         std::atomic<bool> receiver_set_value_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
-        auto s = custom_sender_tag_invoke{tag_invoke_overload_called} |
-            ex::ensure_started();
+        std::atomic<bool> overload_called{false};
+        auto s = custom_sender_overload{overload_called} | ex::ensure_started();
         static_assert(ex::is_sender_v<decltype(s)>);
         static_assert(ex::is_sender_in_v<decltype(s), ex::empty_env>);
 
@@ -159,7 +158,7 @@ int main()
         auto os = ex::connect(std::move(s), std::move(r));
         ex::start(os);
         HPX_TEST(receiver_set_value_called);
-        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!overload_called);
     }
 
     // Failure path

--- a/libs/core/execution/tests/unit/algorithm_start_detached.cpp
+++ b/libs/core/execution/tests/unit/algorithm_start_detached.cpp
@@ -24,49 +24,49 @@ int main()
     {
         std::atomic<bool> start_called{false};
         std::atomic<bool> connect_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
-        ex::start_detached(custom_sender{
-            start_called, connect_called, tag_invoke_overload_called});
+        std::atomic<bool> overload_called{false};
+        ex::start_detached(
+            custom_sender{start_called, connect_called, overload_called});
         HPX_TEST(start_called);
         HPX_TEST(connect_called);
-        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!overload_called);
     }
 
     {
         std::atomic<bool> start_called{false};
         std::atomic<bool> connect_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> overload_called{false};
         ex::start_detached(custom_typed_sender<int>{
-            0, start_called, connect_called, tag_invoke_overload_called});
+            0, start_called, connect_called, overload_called});
         HPX_TEST(start_called);
         HPX_TEST(connect_called);
-        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!overload_called);
     }
 
     {
         std::atomic<bool> start_called{false};
         std::atomic<bool> connect_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> overload_called{false};
         ex::start_detached(
             custom_typed_sender<custom_type_non_default_constructible>{
                 custom_type_non_default_constructible{0}, start_called,
-                connect_called, tag_invoke_overload_called});
+                connect_called, overload_called});
         HPX_TEST(start_called);
         HPX_TEST(connect_called);
-        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!overload_called);
     }
 
     {
         std::atomic<bool> start_called{false};
         std::atomic<bool> connect_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> overload_called{false};
         ex::start_detached(custom_typed_sender<
             custom_type_non_default_constructible_non_copyable>{
             custom_type_non_default_constructible_non_copyable{0}, start_called,
-            connect_called, tag_invoke_overload_called});
+            connect_called, overload_called});
         HPX_TEST(start_called);
         HPX_TEST(connect_called);
-        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!overload_called);
     }
 
     // operator| overload

--- a/libs/core/execution/tests/unit/algorithm_sync_wait.cpp
+++ b/libs/core/execution/tests/unit/algorithm_sync_wait.cpp
@@ -28,12 +28,12 @@ int hpx_main()
     {
         std::atomic<bool> start_called{false};
         std::atomic<bool> connect_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
-        tt::sync_wait(custom_sender{
-            start_called, connect_called, tag_invoke_overload_called});
+        std::atomic<bool> overload_called{false};
+        tt::sync_wait(
+            custom_sender{start_called, connect_called, overload_called});
         HPX_TEST(start_called);
         HPX_TEST(connect_called);
-        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!overload_called);
     }
 
     {
@@ -84,12 +84,12 @@ int hpx_main()
     {
         std::atomic<bool> start_called{false};
         std::atomic<bool> connect_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
-        tt::sync_wait(custom_sender{
-            start_called, connect_called, tag_invoke_overload_called});
+        std::atomic<bool> overload_called{false};
+        tt::sync_wait(
+            custom_sender{start_called, connect_called, overload_called});
         HPX_TEST(start_called);
         HPX_TEST(connect_called);
-        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!overload_called);
     }
 
     {

--- a/libs/core/execution/tests/unit/algorithm_sync_wait_with_variant.cpp
+++ b/libs/core/execution/tests/unit/algorithm_sync_wait_with_variant.cpp
@@ -31,12 +31,12 @@ int hpx_main()
     {
         std::atomic<bool> start_called{false};
         std::atomic<bool> connect_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
-        tt::sync_wait_with_variant(custom_sender{
-            start_called, connect_called, tag_invoke_overload_called});
+        std::atomic<bool> overload_called{false};
+        tt::sync_wait_with_variant(
+            custom_sender{start_called, connect_called, overload_called});
         HPX_TEST(start_called);
         HPX_TEST(connect_called);
-        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!overload_called);
     }
     // sync_wait_with_variant can accept single value senders :
     // assume currently have one tuple
@@ -148,23 +148,23 @@ int hpx_main()
     {
         std::atomic<bool> start_called{false};
         std::atomic<bool> connect_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> overload_called{false};
         tt::sync_wait_with_variant(custom_sender_multi_tuple{
-            start_called, connect_called, tag_invoke_overload_called, true});
+            start_called, connect_called, overload_called, true});
         HPX_TEST(start_called);
         HPX_TEST(connect_called);
-        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!overload_called);
     }
 
     {
         std::atomic<bool> start_called{false};
         std::atomic<bool> connect_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> overload_called{false};
         tt::sync_wait_with_variant(custom_sender_multi_tuple{
-            start_called, connect_called, tag_invoke_overload_called, false});
+            start_called, connect_called, overload_called, false});
         HPX_TEST(start_called);
         HPX_TEST(connect_called);
-        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!overload_called);
     }
 
     {
@@ -223,12 +223,12 @@ int hpx_main()
     {
         std::atomic<bool> start_called{false};
         std::atomic<bool> connect_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
-        tt::sync_wait_with_variant(custom_sender{
-            start_called, connect_called, tag_invoke_overload_called});
+        std::atomic<bool> overload_called{false};
+        tt::sync_wait_with_variant(
+            custom_sender{start_called, connect_called, overload_called});
         HPX_TEST(start_called);
         HPX_TEST(connect_called);
-        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!overload_called);
     }
 
     {

--- a/libs/core/execution/tests/unit/algorithm_then.cpp
+++ b/libs/core/execution/tests/unit/algorithm_then.cpp
@@ -26,7 +26,7 @@ namespace ex = hpx::execution::experimental;
 
 struct custom_transformer
 {
-    std::atomic<bool>& tag_invoke_overload_called;
+    std::atomic<bool>& overload_called;
     std::atomic<bool>& call_operator_called;
     bool throws;
 

--- a/libs/core/execution/tests/unit/algorithm_transfer.cpp
+++ b/libs/core/execution/tests/unit/algorithm_transfer.cpp
@@ -31,10 +31,10 @@ int main()
         std::atomic<bool> set_value_called{false};
         std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> overload_called{false};
         auto s = ex::continues_on(ex::just(),
             example_scheduler{scheduler_schedule_called,
-                scheduler_execute_called, tag_invoke_overload_called});
+                scheduler_execute_called, overload_called});
         static_assert(ex::is_sender_v<decltype(s)>);
         static_assert(ex::is_sender_in_v<decltype(s), ex::empty_env>);
 
@@ -47,7 +47,7 @@ int main()
         auto os = ex::connect(std::move(s), std::move(r));
         ex::start(os);
         HPX_TEST(set_value_called);
-        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!overload_called);
         HPX_TEST(scheduler_schedule_called);
         HPX_TEST(!scheduler_execute_called);
     }
@@ -56,10 +56,10 @@ int main()
         std::atomic<bool> set_value_called{false};
         std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> overload_called{false};
         auto s = ex::continues_on(ex::just(3),
             example_scheduler{scheduler_schedule_called,
-                scheduler_execute_called, tag_invoke_overload_called});
+                scheduler_execute_called, overload_called});
         static_assert(ex::is_sender_v<decltype(s)>);
         static_assert(ex::is_sender_in_v<decltype(s), ex::empty_env>);
 
@@ -72,7 +72,7 @@ int main()
         auto os = ex::connect(std::move(s), std::move(r));
         ex::start(os);
         HPX_TEST(set_value_called);
-        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!overload_called);
         HPX_TEST(scheduler_schedule_called);
         HPX_TEST(!scheduler_execute_called);
     }
@@ -81,11 +81,11 @@ int main()
         std::atomic<bool> set_value_called{false};
         std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> overload_called{false};
         auto s = ex::continues_on(
             ex::just(custom_type_non_default_constructible{42}),
             example_scheduler{scheduler_schedule_called,
-                scheduler_execute_called, tag_invoke_overload_called});
+                scheduler_execute_called, overload_called});
         static_assert(ex::is_sender_v<decltype(s)>);
         static_assert(ex::is_sender_in_v<decltype(s), ex::empty_env>);
 
@@ -99,7 +99,7 @@ int main()
         auto os = ex::connect(std::move(s), std::move(r));
         ex::start(os);
         HPX_TEST(set_value_called);
-        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!overload_called);
         HPX_TEST(scheduler_schedule_called);
         HPX_TEST(!scheduler_execute_called);
     }
@@ -108,11 +108,11 @@ int main()
         std::atomic<bool> set_value_called{false};
         std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> overload_called{false};
         auto s = ex::continues_on(
             ex::just(custom_type_non_default_constructible_non_copyable{42}),
             example_scheduler{scheduler_schedule_called,
-                scheduler_execute_called, tag_invoke_overload_called});
+                scheduler_execute_called, overload_called});
         static_assert(ex::is_sender_v<decltype(s)>);
         static_assert(ex::is_sender_in_v<decltype(s), ex::empty_env>);
         check_value_types<hpx::variant<
@@ -125,7 +125,7 @@ int main()
         auto os = ex::connect(std::move(s), std::move(r));
         ex::start(os);
         HPX_TEST(set_value_called);
-        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!overload_called);
         HPX_TEST(scheduler_schedule_called);
         HPX_TEST(!scheduler_execute_called);
     }
@@ -134,10 +134,10 @@ int main()
         std::atomic<bool> set_value_called{false};
         std::atomic<bool> scheduler_execute_called{false};
         std::atomic<bool> scheduler_schedule_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> overload_called{false};
         auto s = ex::continues_on(ex::just(std::string("hello"), 3),
             example_scheduler{scheduler_schedule_called,
-                scheduler_execute_called, tag_invoke_overload_called});
+                scheduler_execute_called, overload_called});
         static_assert(ex::is_sender_v<decltype(s)>);
         static_assert(ex::is_sender_in_v<decltype(s), ex::empty_env>);
 
@@ -153,7 +153,7 @@ int main()
         auto os = ex::connect(std::move(s), std::move(r));
         ex::start(os);
         HPX_TEST(set_value_called);
-        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!overload_called);
         HPX_TEST(!scheduler_execute_called);
         HPX_TEST(scheduler_schedule_called);
     }
@@ -163,10 +163,10 @@ int main()
         std::atomic<bool> set_value_called{false};
         std::atomic<bool> scheduler_execute_called{false};
         std::atomic<bool> scheduler_schedule_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> overload_called{false};
         auto s = ex::just(std::string("hello"), 3) |
             ex::continues_on(example_scheduler{scheduler_schedule_called,
-                scheduler_execute_called, tag_invoke_overload_called});
+                scheduler_execute_called, overload_called});
         static_assert(ex::is_sender_v<decltype(s)>);
         static_assert(ex::is_sender_in_v<decltype(s), ex::empty_env>);
 
@@ -182,7 +182,7 @@ int main()
         auto os = ex::connect(std::move(s), r);
         ex::start(os);
         HPX_TEST(set_value_called);
-        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!overload_called);
         HPX_TEST(scheduler_schedule_called);
         HPX_TEST(!scheduler_execute_called);
     }
@@ -190,12 +190,12 @@ int main()
     // Failure path
     {
         std::atomic<bool> set_error_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> overload_called{false};
         std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
         auto s = ex::continues_on(error_sender{},
             example_scheduler{scheduler_schedule_called,
-                scheduler_execute_called, tag_invoke_overload_called});
+                scheduler_execute_called, overload_called});
         static_assert(ex::is_sender_v<decltype(s)>);
         static_assert(ex::is_sender_in_v<decltype(s), ex::empty_env>);
 
@@ -208,7 +208,7 @@ int main()
         auto os = ex::connect(std::move(s), std::move(r));
         ex::start(os);
         HPX_TEST(set_error_called);
-        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!overload_called);
         // schedule is called anyways
         HPX_TEST(scheduler_schedule_called);
         HPX_TEST(!scheduler_execute_called);

--- a/libs/core/execution/tests/unit/algorithm_transfer_when_all.cpp
+++ b/libs/core/execution/tests/unit/algorithm_transfer_when_all.cpp
@@ -41,10 +41,10 @@ int main()
         std::atomic<bool> set_value_called{false};
         std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> overload_called{false};
 
         auto sched = example_scheduler{scheduler_schedule_called,
-            scheduler_execute_called, tag_invoke_overload_called};
+            scheduler_execute_called, overload_called};
         auto s = ex::transfer_when_all(sched, ex::just(42));
         static_assert(ex::is_sender_v<decltype(s)>,
             "transfer_when_all must return a sender");
@@ -54,7 +54,7 @@ int main()
         auto os = ex::connect(std::move(s), std::move(r));
         ex::start(os);
         HPX_TEST(set_value_called);
-        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!overload_called);
         HPX_TEST(scheduler_schedule_called);
         HPX_TEST(!scheduler_execute_called);
     }
@@ -63,10 +63,10 @@ int main()
         std::atomic<bool> set_value_called{false};
         std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> overload_called{false};
 
         auto sched = example_scheduler{scheduler_schedule_called,
-            scheduler_execute_called, tag_invoke_overload_called};
+            scheduler_execute_called, overload_called};
         auto s = ex::transfer_when_all(sched, ex::just(42),
             ex::just(std::string("hello")), ex::just(3.14));
         static_assert(ex::is_sender_v<decltype(s)>,
@@ -81,7 +81,7 @@ int main()
         auto os = ex::connect(std::move(s), std::move(r));
         ex::start(os);
         HPX_TEST(set_value_called);
-        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!overload_called);
         HPX_TEST(scheduler_schedule_called);
         HPX_TEST(!scheduler_execute_called);
     }
@@ -90,10 +90,10 @@ int main()
         std::atomic<bool> set_value_called{false};
         std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> overload_called{false};
 
         auto sched = example_scheduler{scheduler_schedule_called,
-            scheduler_execute_called, tag_invoke_overload_called};
+            scheduler_execute_called, overload_called};
         auto s = ex::transfer_when_all(
             sched, ex::just(), ex::just(std::string("hello")), ex::just(3.14));
         static_assert(ex::is_sender_v<decltype(s)>,
@@ -107,7 +107,7 @@ int main()
         auto os = ex::connect(std::move(s), std::move(r));
         ex::start(os);
         HPX_TEST(set_value_called);
-        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!overload_called);
         HPX_TEST(scheduler_schedule_called);
         HPX_TEST(!scheduler_execute_called);
     }
@@ -117,10 +117,10 @@ int main()
         std::atomic<bool> set_error_called{false};
         std::atomic<bool> scheduler_schedule_called{false};
         std::atomic<bool> scheduler_execute_called{false};
-        std::atomic<bool> tag_invoke_overload_called{false};
+        std::atomic<bool> overload_called{false};
 
         auto sched = example_scheduler{scheduler_schedule_called,
-            scheduler_execute_called, tag_invoke_overload_called};
+            scheduler_execute_called, overload_called};
         auto s = ex::transfer_when_all(sched, error_typed_sender<double>{});
         auto r = error_callback_receiver<check_exception_ptr>{
             check_exception_ptr{}, set_error_called};
@@ -128,7 +128,7 @@ int main()
         ex::start(os);
 
         HPX_TEST(set_error_called);
-        HPX_TEST(!tag_invoke_overload_called);
+        HPX_TEST(!overload_called);
         HPX_TEST(scheduler_schedule_called);
         HPX_TEST(!scheduler_execute_called);
     }

--- a/libs/core/execution_base/include/hpx/execution_base/execution.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/execution.hpp
@@ -11,6 +11,7 @@
 #include <hpx/config.hpp>
 #include <hpx/execution_base/detail/execution_member_detect.hpp>
 #include <hpx/execution_base/traits/is_executor.hpp>
+#include <hpx/functional/tag_invoke.hpp>
 #include <hpx/modules/iterator_support.hpp>
 
 #include <concepts>
@@ -120,9 +121,27 @@ namespace hpx::parallel::execution {
                 .sync_execute(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
+        // Deprecated: ADL tag_invoke backwards compatibility
+        template <typename Executor, typename F, typename... Ts>
+            requires(!detail::has_sync_execute_member<Executor, F, Ts...> &&
+                hpx::functional::is_tag_invocable_v<sync_execute_t, Executor &&,
+                    F &&, Ts && ...>)
+        HPX_DEPRECATED_V(2, 0,
+            "tag_invoke overloads for sync_execute are deprecated. "
+            "Define a .sync_execute() member function instead.")
+        HPX_FORCEINLINE decltype(auto)
+        operator()(Executor&& exec, F&& f, Ts&&... ts) const
+        {
+            return hpx::functional::tag_invoke_ns::tag_invoke(sync_execute_t{},
+                HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f),
+                HPX_FORWARD(Ts, ts)...);
+        }
+
         // Fallback: use fn_helper
         template <executor_any Executor, typename F, typename... Ts>
             requires(!detail::has_sync_execute_member<Executor, F, Ts...> &&
+                !hpx::functional::is_tag_invocable_v<sync_execute_t,
+                    Executor &&, F &&, Ts && ...> &&
                 (std::invocable<F &&, Ts && ...> ||
                     hpx::traits::is_action_v<std::decay_t<F>>) )
         HPX_FORCEINLINE decltype(auto) operator()(
@@ -174,9 +193,27 @@ namespace hpx::parallel::execution {
                 .async_execute(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
+        // Deprecated: ADL tag_invoke backwards compatibility
+        template <typename Executor, typename F, typename... Ts>
+            requires(!detail::has_async_execute_member<Executor, F, Ts...> &&
+                hpx::functional::is_tag_invocable_v<async_execute_t,
+                    Executor &&, F &&, Ts && ...>)
+        HPX_DEPRECATED_V(2, 0,
+            "tag_invoke overloads for async_execute are deprecated. "
+            "Define an .async_execute() member function instead.")
+        HPX_FORCEINLINE decltype(auto)
+        operator()(Executor&& exec, F&& f, Ts&&... ts) const
+        {
+            return hpx::functional::tag_invoke_ns::tag_invoke(async_execute_t{},
+                HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f),
+                HPX_FORWARD(Ts, ts)...);
+        }
+
         // Fallback: use fn_helper
         template <executor_any Executor, typename F, typename... Ts>
             requires(!detail::has_async_execute_member<Executor, F, Ts...> &&
+                !hpx::functional::is_tag_invocable_v<async_execute_t,
+                    Executor &&, F &&, Ts && ...> &&
                 (std::invocable<F &&, Ts && ...> ||
                     hpx::traits::is_action_v<std::decay_t<F>>) )
         HPX_FORCEINLINE decltype(auto) operator()(
@@ -223,11 +260,32 @@ namespace hpx::parallel::execution {
                     HPX_FORWARD(Future, predecessor), HPX_FORWARD(Ts, ts)...);
         }
 
+        // Deprecated: ADL tag_invoke backwards compatibility
+        template <typename Executor, typename F, typename Future,
+            typename... Ts>
+            requires(
+                !detail::has_then_execute_member<Executor, F, Future, Ts...> &&
+                hpx::functional::is_tag_invocable_v<then_execute_t, Executor &&,
+                    F &&, Future &&, Ts && ...>)
+        HPX_DEPRECATED_V(2, 0,
+            "tag_invoke overloads for then_execute are deprecated. "
+            "Define a .then_execute() member function instead.")
+        HPX_FORCEINLINE decltype(auto)
+        operator()(
+            Executor&& exec, F&& f, Future&& predecessor, Ts&&... ts) const
+        {
+            return hpx::functional::tag_invoke_ns::tag_invoke(then_execute_t{},
+                HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f),
+                HPX_FORWARD(Future, predecessor), HPX_FORWARD(Ts, ts)...);
+        }
+
         // Fallback: use fn_helper
         template <executor_any Executor, typename F, typename Future,
             typename... Ts>
             requires(
                 !detail::has_then_execute_member<Executor, F, Future, Ts...> &&
+                !hpx::functional::is_tag_invocable_v<then_execute_t,
+                    Executor &&, F &&, Future &&, Ts && ...> &&
                 std::invocable<F &&, Future &&, Ts && ...>)
         HPX_FORCEINLINE decltype(auto) operator()(
             Executor&& exec, F&& f, Future&& predecessor, Ts&&... ts) const
@@ -271,9 +329,27 @@ namespace hpx::parallel::execution {
                 .post(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
+        // Deprecated: ADL tag_invoke backwards compatibility
+        template <typename Executor, typename F, typename... Ts>
+            requires(!detail::has_post_member<Executor, F, Ts...> &&
+                hpx::functional::is_tag_invocable_v<post_t, Executor &&, F &&,
+                    Ts && ...>)
+        HPX_DEPRECATED_V(2, 0,
+            "tag_invoke overloads for post are deprecated. "
+            "Define a .post() member function instead.")
+        HPX_FORCEINLINE decltype(auto)
+        operator()(Executor&& exec, F&& f, Ts&&... ts) const
+        {
+            return hpx::functional::tag_invoke_ns::tag_invoke(post_t{},
+                HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f),
+                HPX_FORWARD(Ts, ts)...);
+        }
+
         // Fallback: use fn_helper
         template <executor_any Executor, typename F, typename... Ts>
-            requires(!detail::has_post_member<Executor, F, Ts...>)
+            requires(!detail::has_post_member<Executor, F, Ts...> &&
+                !hpx::functional::is_tag_invocable_v<post_t, Executor &&, F &&,
+                    Ts && ...>)
         HPX_FORCEINLINE decltype(auto) operator()(
             Executor&& exec, F&& f, Ts&&... ts) const
         {
@@ -336,12 +412,32 @@ namespace hpx::parallel::execution {
                     HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
         }
 
+        // Deprecated: ADL tag_invoke backwards compatibility
+        template <typename Executor, typename F, typename Shape, typename... Ts>
+            requires(!std::integral<Shape> &&
+                !detail::has_bulk_sync_execute_member<Executor, F, Shape,
+                    Ts...> &&
+                hpx::functional::is_tag_invocable_v<bulk_sync_execute_t,
+                    Executor &&, F &&, Shape const&, Ts && ...>)
+        HPX_DEPRECATED_V(2, 0,
+            "tag_invoke overloads for bulk_sync_execute are deprecated. "
+            "Define a .bulk_sync_execute() member function instead.")
+        HPX_FORCEINLINE decltype(auto)
+        operator()(Executor&& exec, F&& f, Shape const& shape, Ts&&... ts) const
+        {
+            return hpx::functional::tag_invoke_ns::tag_invoke(
+                bulk_sync_execute_t{}, HPX_FORWARD(Executor, exec),
+                HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
+        }
+
         // Fallback: non-integral shape
         template <executor_any Executor, typename F, typename Shape,
             typename... Ts>
             requires(!std::integral<Shape> &&
                 !detail::has_bulk_sync_execute_member<Executor, F, Shape,
-                    Ts...>)
+                    Ts...> &&
+                !hpx::functional::is_tag_invocable_v<bulk_sync_execute_t,
+                    Executor &&, F &&, Shape const&, Ts && ...>)
         HPX_FORCEINLINE decltype(auto) operator()(
             Executor&& exec, F&& f, Shape const& shape, Ts&&... ts) const
         {
@@ -428,6 +524,26 @@ namespace hpx::parallel::execution {
                     HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
         }
 
+        // Deprecated: ADL tag_invoke backwards compatibility
+        template <typename Executor, typename F, typename Shape, typename... Ts>
+            requires(!std::integral<Shape> &&
+                !detail::has_bulk_async_execute_member<Executor, F, Shape,
+                    Ts...> &&
+                !hpx::traits::is_bulk_two_way_executor_v<
+                    std::decay_t<Executor>> &&
+                hpx::functional::is_tag_invocable_v<bulk_async_execute_t,
+                    Executor &&, F &&, Shape const&, Ts && ...>)
+        HPX_DEPRECATED_V(2, 0,
+            "tag_invoke overloads for bulk_async_execute are deprecated. "
+            "Define a .bulk_async_execute() member function instead.")
+        HPX_FORCEINLINE decltype(auto)
+        operator()(Executor&& exec, F&& f, Shape const& shape, Ts&&... ts) const
+        {
+            return hpx::functional::tag_invoke_ns::tag_invoke(
+                bulk_async_execute_t{}, HPX_FORWARD(Executor, exec),
+                HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
+        }
+
         // Fallback: non-integral shape, not bulk_two_way_executor
         template <executor_any Executor, typename F, typename Shape,
             typename... Ts>
@@ -435,7 +551,9 @@ namespace hpx::parallel::execution {
                 !detail::has_bulk_async_execute_member<Executor, F, Shape,
                     Ts...> &&
                 !hpx::traits::is_bulk_two_way_executor_v<
-                    std::decay_t<Executor>>)
+                    std::decay_t<Executor>> &&
+                !hpx::functional::is_tag_invocable_v<bulk_async_execute_t,
+                    Executor &&, F &&, Shape const&, Ts && ...>)
         HPX_FORCEINLINE decltype(auto) operator()(
             Executor&& exec, F&& f, Shape const& shape, Ts&&... ts) const
         {
@@ -509,12 +627,35 @@ namespace hpx::parallel::execution {
                     HPX_FORWARD(Future, predecessor), HPX_FORWARD(Ts, ts)...);
         }
 
+        // Deprecated: ADL tag_invoke backwards compatibility
+        template <typename Executor, typename F, typename Shape,
+            typename Future, typename... Ts>
+            requires(!std::integral<Shape> &&
+                !detail::has_bulk_then_execute_member<Executor, F, Shape,
+                    Future, Ts...> &&
+                hpx::functional::is_tag_invocable_v<bulk_then_execute_t,
+                    Executor &&, F &&, Shape const&, Future &&, Ts && ...>)
+        HPX_DEPRECATED_V(2, 0,
+            "tag_invoke overloads for bulk_then_execute are deprecated. "
+            "Define a .bulk_then_execute() member function instead.")
+        HPX_FORCEINLINE decltype(auto)
+        operator()(Executor&& exec, F&& f, Shape const& shape,
+            Future&& predecessor, Ts&&... ts) const
+        {
+            return hpx::functional::tag_invoke_ns::tag_invoke(
+                bulk_then_execute_t{}, HPX_FORWARD(Executor, exec),
+                HPX_FORWARD(F, f), shape, HPX_FORWARD(Future, predecessor),
+                HPX_FORWARD(Ts, ts)...);
+        }
+
         // Fallback: non-integral shape
         template <executor_any Executor, typename F, typename Shape,
             typename Future, typename... Ts>
             requires(!std::integral<Shape> &&
                 !detail::has_bulk_then_execute_member<Executor, F, Shape,
-                    Future, Ts...>)
+                    Future, Ts...> &&
+                !hpx::functional::is_tag_invocable_v<bulk_then_execute_t,
+                    Executor &&, F &&, Shape const&, Future &&, Ts && ...>)
         HPX_FORCEINLINE decltype(auto) operator()(Executor&& exec, F&& f,
             Shape const& shape, Future&& predecessor, Ts&&... ts) const
         {
@@ -571,9 +712,27 @@ namespace hpx::parallel::execution {
                 .async_invoke(HPX_FORWARD(F, f), HPX_FORWARD(Fs, fs)...);
         }
 
+        // Deprecated: ADL tag_invoke backwards compatibility
+        template <typename Executor, typename F, typename... Fs>
+            requires(!detail::has_async_invoke_member<Executor, F, Fs...> &&
+                hpx::functional::is_tag_invocable_v<async_invoke_t, Executor &&,
+                    F &&, Fs && ...>)
+        HPX_DEPRECATED_V(2, 0,
+            "tag_invoke overloads for async_invoke are deprecated. "
+            "Define an .async_invoke() member function instead.")
+        HPX_FORCEINLINE decltype(auto)
+        operator()(Executor&& exec, F&& f, Fs&&... fs) const
+        {
+            return hpx::functional::tag_invoke_ns::tag_invoke(async_invoke_t{},
+                HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f),
+                HPX_FORWARD(Fs, fs)...);
+        }
+
         // Fallback: use fn_helper
         template <executor_any Executor, typename F, typename... Fs>
             requires(!detail::has_async_invoke_member<Executor, F, Fs...> &&
+                !hpx::functional::is_tag_invocable_v<async_invoke_t,
+                    Executor &&, F &&, Fs && ...> &&
                 std::invocable<F> && (std::invocable<Fs> && ...))
         HPX_FORCEINLINE decltype(auto) operator()(
             Executor&& exec, F&& f, Fs&&... fs) const
@@ -617,9 +776,27 @@ namespace hpx::parallel::execution {
                 .sync_invoke(HPX_FORWARD(F, f), HPX_FORWARD(Fs, fs)...);
         }
 
+        // Deprecated: ADL tag_invoke backwards compatibility
+        template <typename Executor, typename F, typename... Fs>
+            requires(!detail::has_sync_invoke_member<Executor, F, Fs...> &&
+                hpx::functional::is_tag_invocable_v<sync_invoke_t, Executor &&,
+                    F &&, Fs && ...>)
+        HPX_DEPRECATED_V(2, 0,
+            "tag_invoke overloads for sync_invoke are deprecated. "
+            "Define a .sync_invoke() member function instead.")
+        HPX_FORCEINLINE decltype(auto)
+        operator()(Executor&& exec, F&& f, Fs&&... fs) const
+        {
+            return hpx::functional::tag_invoke_ns::tag_invoke(sync_invoke_t{},
+                HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f),
+                HPX_FORWARD(Fs, fs)...);
+        }
+
         // Fallback: use fn_helper
         template <executor_any Executor, typename F, typename... Fs>
             requires(!detail::has_sync_invoke_member<Executor, F, Fs...> &&
+                !hpx::functional::is_tag_invocable_v<sync_invoke_t, Executor &&,
+                    F &&, Fs && ...> &&
                 std::invocable<F> && (std::invocable<Fs> && ...))
         HPX_FORCEINLINE decltype(auto) operator()(
             Executor&& exec, F&& f, Fs&&... fs) const

--- a/libs/core/execution_base/include/hpx/execution_base/execution.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/execution.hpp
@@ -512,7 +512,10 @@ namespace hpx::parallel::execution {
             requires(!std::integral<Shape> &&
                 !detail::has_bulk_async_execute_member<Executor, F, Shape,
                     Ts...> &&
-                hpx::traits::is_bulk_two_way_executor_v<std::decay_t<Executor>>)
+                hpx::traits::is_bulk_two_way_executor_v<
+                    std::decay_t<Executor>> &&
+                !hpx::functional::is_tag_invocable_v<bulk_async_execute_t,
+                    Executor &&, F &&, Shape const&, Ts && ...>)
         HPX_FORCEINLINE auto operator()(
             Executor&& exec, F&& f, Shape const& shape, Ts&&... ts) const
             -> decltype(HPX_FORWARD(Executor, exec)
@@ -529,8 +532,6 @@ namespace hpx::parallel::execution {
             requires(!std::integral<Shape> &&
                 !detail::has_bulk_async_execute_member<Executor, F, Shape,
                     Ts...> &&
-                !hpx::traits::is_bulk_two_way_executor_v<
-                    std::decay_t<Executor>> &&
                 hpx::functional::is_tag_invocable_v<bulk_async_execute_t,
                     Executor &&, F &&, Shape const&, Ts && ...>)
         HPX_DEPRECATED_V(2, 0,

--- a/libs/core/execution_base/tests/include/algorithm_test_utils.hpp
+++ b/libs/core/execution_base/tests/include/algorithm_test_utils.hpp
@@ -10,7 +10,6 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/execution_base.hpp>
-#include <hpx/modules/tag_invoke.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <atomic>
@@ -523,17 +522,17 @@ struct custom_sender_descriptor_tag
 {
 };
 
-struct custom_sender_tag_invoke
+struct custom_sender_overload
 {
     using is_sender = void;
     using sender_concept = hpx::execution::experimental::sender_t;
 
     [[no_unique_address]] custom_sender_descriptor_tag __desc_tag{};
-    std::atomic<bool>& tag_invoke_overload_called;
+    std::atomic<bool>& overload_called;
 
-    explicit custom_sender_tag_invoke(
-        std::atomic<bool>& tag_invoke_overload_called_) noexcept
-      : tag_invoke_overload_called(tag_invoke_overload_called_)
+    explicit custom_sender_overload(
+        std::atomic<bool>& overload_called_) noexcept
+      : overload_called(overload_called_)
     {
     }
 
@@ -571,14 +570,14 @@ struct custom_sender
     [[no_unique_address]] custom_sender_descriptor_tag __desc_tag{};
     std::atomic<bool>& start_called;
     std::atomic<bool>& connect_called;
-    std::atomic<bool>& tag_invoke_overload_called;
+    std::atomic<bool>& overload_called;
 
     custom_sender(std::atomic<bool>& start_called_,
         std::atomic<bool>& connect_called_,
-        std::atomic<bool>& tag_invoke_overload_called_) noexcept
+        std::atomic<bool>& overload_called_) noexcept
       : start_called(start_called_)
       , connect_called(connect_called_)
-      , tag_invoke_overload_called(tag_invoke_overload_called_)
+      , overload_called(overload_called_)
     {
     }
 
@@ -623,17 +622,16 @@ struct custom_sender_multi_tuple
     [[no_unique_address]] custom_sender_descriptor_tag __desc_tag{};
     std::atomic<bool>& start_called;
     std::atomic<bool>& connect_called;
-    std::atomic<bool>& tag_invoke_overload_called;
+    std::atomic<bool>& overload_called;
 
     bool expect_set_value = true;
 
     custom_sender_multi_tuple(std::atomic<bool>& start_called_,
-        std::atomic<bool>& connect_called_,
-        std::atomic<bool>& tag_invoke_overload_called_,
+        std::atomic<bool>& connect_called_, std::atomic<bool>& overload_called_,
         bool expect_set_value_ = true) noexcept
       : start_called(start_called_)
       , connect_called(connect_called_)
-      , tag_invoke_overload_called(tag_invoke_overload_called_)
+      , overload_called(overload_called_)
       , expect_set_value(expect_set_value_)
     {
     }
@@ -692,16 +690,16 @@ struct custom_typed_sender
 
     std::atomic<bool>& start_called;
     std::atomic<bool>& connect_called;
-    std::atomic<bool>& tag_invoke_overload_called;
+    std::atomic<bool>& overload_called;
 
     template <typename U>
     custom_typed_sender(U&& x_, std::atomic<bool>& start_called_,
         std::atomic<bool>& connect_called_,
-        std::atomic<bool>& tag_invoke_overload_called_) noexcept
+        std::atomic<bool>& overload_called_) noexcept
       : x(std::forward<U>(x_))
       , start_called(start_called_)
       , connect_called(connect_called_)
-      , tag_invoke_overload_called(tag_invoke_overload_called_)
+      , overload_called(overload_called_)
     {
     }
 
@@ -751,7 +749,7 @@ struct custom_sender2 : custom_sender
 template <typename T>
 struct custom_type
 {
-    std::atomic<bool>& tag_invoke_overload_called;
+    std::atomic<bool>& overload_called;
     std::decay_t<T> x;
 };
 
@@ -795,15 +793,14 @@ struct example_scheduler_template
 
     std::atomic<bool>& schedule_called;
     std::atomic<bool>& execute_called;
-    std::atomic<bool>& tag_invoke_overload_called;
+    std::atomic<bool>& overload_called;
 
     // NOLINTNEXTLINE(bugprone-crtp-constructor-accessibility)
     example_scheduler_template(std::atomic<bool>& schedule_called,
-        std::atomic<bool>& execute_called,
-        std::atomic<bool>& tag_invoke_overload_called)
+        std::atomic<bool>& execute_called, std::atomic<bool>& overload_called)
       : schedule_called(schedule_called)
       , execute_called(execute_called)
-      , tag_invoke_overload_called(tag_invoke_overload_called)
+      , overload_called(overload_called)
     {
     }
 
@@ -876,7 +873,7 @@ struct example_scheduler_template
     example_scheduler_template(example_scheduler_template<D> const& other)
       : schedule_called(other.schedule_called)
       , execute_called(other.execute_called)
-      , tag_invoke_overload_called(other.tag_invoke_overload_called)
+      , overload_called(other.overload_called)
     {
     }
 };
@@ -897,8 +894,7 @@ namespace tag_namespace {
         template <typename Sender>
         auto operator()(Sender&& sender) const
         {
-            return hpx::functional::tag_invoke(
-                *this, std::forward<Sender>(sender));
+            return adl_invoke(*this, std::forward<Sender>(sender));
         }
 
         struct wrapper
@@ -910,7 +906,7 @@ namespace tag_namespace {
         // sure this is a worse match than the one in my_namespace by requiring
         // a conversion.
         template <typename Sender>
-        friend void tag_invoke(wrapper, Sender&&)
+        friend void adl_invoke(wrapper, Sender&&)
         {
         }
     } my_tag{};
@@ -1015,7 +1011,7 @@ namespace my_namespace {
     // sure this is a better match than the one in tag_namespace so that if this
     // one is visible it is chosen. It should not be visible.
     template <typename Sender>
-    void tag_invoke(tag_namespace::my_tag_t, Sender&&)
+    void adl_invoke(tag_namespace::my_tag_t, Sender&&)
     {
         static_assert(sizeof(Sender) == 0);
     }
@@ -1023,8 +1019,8 @@ namespace my_namespace {
 
 // This test function expects a type that has my_namespace::my_type as a
 // template argument. If template arguments are correctly hidden from ADL the
-// friend tag_invoke overload in my_tag_t will be chosen. If template arguments
-// are not hidden the unconstrained tag_invoke overload in my_namespace will be
+// friend adl_invoke overload in my_tag_t will be chosen. If template arguments
+// are not hidden the unconstrained adl_invoke overload in my_namespace will be
 // chosen instead.
 template <typename Sender>
 void test_adl_isolation(Sender&& sender)

--- a/libs/core/execution_base/tests/unit/basic_schedule.cpp
+++ b/libs/core/execution_base/tests/unit/basic_schedule.cpp
@@ -15,8 +15,8 @@
 
 namespace ex = hpx::execution::experimental;
 
-static std::size_t friend_tag_invoke_schedule_calls = 0;
-static std::size_t tag_invoke_schedule_calls = 0;
+static std::size_t member_schedule_calls = 0;
+static std::size_t free_schedule_calls = 0;
 
 struct dummy_scheduler
 {
@@ -68,7 +68,7 @@ struct scheduler_1
 
     sender_1 schedule() const noexcept
     {
-        ++friend_tag_invoke_schedule_calls;
+        ++member_schedule_calls;
         return {};
     }
 
@@ -89,7 +89,7 @@ struct scheduler_2
 
     sender_2 schedule() const noexcept
     {
-        ++tag_invoke_schedule_calls;
+        ++free_schedule_calls;
         return {};
     }
 
@@ -118,14 +118,14 @@ int main()
     scheduler_1 s1;
     auto snd1 = ex::schedule(s1);
     HPX_UNUSED(snd1);
-    HPX_TEST_EQ(friend_tag_invoke_schedule_calls, std::size_t(1));
-    HPX_TEST_EQ(tag_invoke_schedule_calls, std::size_t(0));
+    HPX_TEST_EQ(member_schedule_calls, std::size_t(1));
+    HPX_TEST_EQ(free_schedule_calls, std::size_t(0));
 
     scheduler_2 s2;
     auto snd2 = ex::schedule(s2);
     HPX_UNUSED(snd2);
-    HPX_TEST_EQ(friend_tag_invoke_schedule_calls, std::size_t(1));
-    HPX_TEST_EQ(tag_invoke_schedule_calls, std::size_t(1));
+    HPX_TEST_EQ(member_schedule_calls, std::size_t(1));
+    HPX_TEST_EQ(free_schedule_calls, std::size_t(1));
 
     static_assert(std::is_same_v<ex::schedule_result_t<scheduler_1>,
                       example_sender_template<scheduler_1>>,

--- a/libs/core/execution_base/tests/unit/basic_sender.cpp
+++ b/libs/core/execution_base/tests/unit/basic_sender.cpp
@@ -17,7 +17,7 @@
 namespace ex = hpx::execution::experimental;
 
 static std::size_t member_connect_calls = 0;
-static std::size_t free_connect_calls = 0;
+static std::size_t member_connect_calls_2 = 0;
 
 struct non_sender_1
 {
@@ -180,7 +180,7 @@ struct sender_2
 
     operation_state connect(example_receiver& r) && noexcept
     {
-        ++free_connect_calls;
+        ++member_connect_calls_2;
         return {{}, r};
     }
 };
@@ -331,7 +331,7 @@ int main()
         ex::start(os);
         HPX_TEST_EQ(r1.i, 4711);
         HPX_TEST_EQ(member_connect_calls, std::size_t(1));
-        HPX_TEST_EQ(free_connect_calls, std::size_t(0));
+        HPX_TEST_EQ(member_connect_calls_2, std::size_t(0));
     }
 
     {
@@ -340,7 +340,7 @@ int main()
         ex::start(os);
         HPX_TEST_EQ(r2.i, 4711);
         HPX_TEST_EQ(member_connect_calls, std::size_t(1));
-        HPX_TEST_EQ(free_connect_calls, std::size_t(1));
+        HPX_TEST_EQ(member_connect_calls_2, std::size_t(1));
     }
 
     {
@@ -349,7 +349,7 @@ int main()
         ex::start(os);
         HPX_TEST_EQ(r3.i, 4711);
         HPX_TEST_EQ(member_connect_calls, std::size_t(2));
-        HPX_TEST_EQ(free_connect_calls, std::size_t(1));
+        HPX_TEST_EQ(member_connect_calls_2, std::size_t(1));
     }
 
     return hpx::util::report_errors();

--- a/libs/core/execution_base/tests/unit/basic_sender.cpp
+++ b/libs/core/execution_base/tests/unit/basic_sender.cpp
@@ -16,8 +16,8 @@
 
 namespace ex = hpx::execution::experimental;
 
-static std::size_t friend_tag_invoke_connect_calls = 0;
-static std::size_t tag_invoke_connect_calls = 0;
+static std::size_t member_connect_calls = 0;
+static std::size_t free_connect_calls = 0;
 
 struct non_sender_1
 {
@@ -148,7 +148,7 @@ struct sender_1
 
     operation_state connect(example_receiver& r) && noexcept
     {
-        ++friend_tag_invoke_connect_calls;
+        ++member_connect_calls;
         return {{}, r};
     }
 };
@@ -180,7 +180,7 @@ struct sender_2
 
     operation_state connect(example_receiver& r) && noexcept
     {
-        ++tag_invoke_connect_calls;
+        ++free_connect_calls;
         return {{}, r};
     }
 };
@@ -212,7 +212,7 @@ struct sender_3
 
     operation_state connect(example_receiver& r) && noexcept
     {
-        ++friend_tag_invoke_connect_calls;
+        ++member_connect_calls;
         return {{}, r};
     }
 };
@@ -330,8 +330,8 @@ int main()
         auto os = ex::connect(sender_1{}, r1);
         ex::start(os);
         HPX_TEST_EQ(r1.i, 4711);
-        HPX_TEST_EQ(friend_tag_invoke_connect_calls, std::size_t(1));
-        HPX_TEST_EQ(tag_invoke_connect_calls, std::size_t(0));
+        HPX_TEST_EQ(member_connect_calls, std::size_t(1));
+        HPX_TEST_EQ(free_connect_calls, std::size_t(0));
     }
 
     {
@@ -339,8 +339,8 @@ int main()
         auto os = ex::connect(sender_2{}, r2);
         ex::start(os);
         HPX_TEST_EQ(r2.i, 4711);
-        HPX_TEST_EQ(friend_tag_invoke_connect_calls, std::size_t(1));
-        HPX_TEST_EQ(tag_invoke_connect_calls, std::size_t(1));
+        HPX_TEST_EQ(member_connect_calls, std::size_t(1));
+        HPX_TEST_EQ(free_connect_calls, std::size_t(1));
     }
 
     {
@@ -348,8 +348,8 @@ int main()
         auto os = ex::connect(sender_3{}, r3);
         ex::start(os);
         HPX_TEST_EQ(r3.i, 4711);
-        HPX_TEST_EQ(friend_tag_invoke_connect_calls, std::size_t(2));
-        HPX_TEST_EQ(tag_invoke_connect_calls, std::size_t(1));
+        HPX_TEST_EQ(member_connect_calls, std::size_t(2));
+        HPX_TEST_EQ(free_connect_calls, std::size_t(1));
     }
 
     return hpx::util::report_errors();

--- a/libs/core/executors/CMakeLists.txt
+++ b/libs/core/executors/CMakeLists.txt
@@ -140,7 +140,6 @@ add_hpx_module(
     hpx_resource_partitioner
     hpx_serialization
     hpx_synchronization
-    hpx_tag_invoke
     hpx_timing
     hpx_threading
     hpx_threading_base

--- a/libs/core/executors/tests/unit/annotating_executor.cpp
+++ b/libs/core/executors/tests/unit/annotating_executor.cpp
@@ -380,7 +380,7 @@ void test_bulk_then(Executor&& executor)
 template <typename ExPolicy>
 void test_post_policy([[maybe_unused]] ExPolicy&& policy)
 {
-// GCC V8 and below don't properly find the policy tag_invoke overloads
+// GCC V8 and below don't properly find the policy overloads
 #if !defined(HPX_GCC_VERSION) || HPX_GCC_VERSION >= 90000
     std::string desc("test_post_policy");
     auto p = hpx::execution::experimental::with_annotation(policy, desc);

--- a/libs/core/futures/CMakeLists.txt
+++ b/libs/core/futures/CMakeLists.txt
@@ -89,7 +89,6 @@ add_hpx_module(
     hpx_memory
     hpx_serialization
     hpx_synchronization
-    hpx_tag_invoke
     hpx_timing
     hpx_threading_base
     hpx_thread_support

--- a/libs/core/include_local/CMakeLists.txt
+++ b/libs/core/include_local/CMakeLists.txt
@@ -113,7 +113,6 @@ add_hpx_module(
     hpx_runtime_local
     hpx_string_util
     hpx_synchronization
-    hpx_tag_invoke
     hpx_threading
     hpx_threading_base
     hpx_thread_support

--- a/libs/core/iterator_support/CMakeLists.txt
+++ b/libs/core/iterator_support/CMakeLists.txt
@@ -53,7 +53,6 @@ add_hpx_module(
     hpx_datastructures
     hpx_functional
     hpx_serialization
-    hpx_tag_invoke
     hpx_type_support
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/pack_traversal/CMakeLists.txt
+++ b/libs/core/pack_traversal/CMakeLists.txt
@@ -40,7 +40,6 @@ add_hpx_module(
     hpx_futures
     hpx_iterator_support
     hpx_memory
-    hpx_tag_invoke
     hpx_type_support
     hpx_util
   CMAKE_SUBDIRS examples tests

--- a/libs/core/properties/include/hpx/properties/property.hpp
+++ b/libs/core/properties/include/hpx/properties/property.hpp
@@ -14,12 +14,8 @@
 
 namespace hpx::experimental {
 
-    // TODO(): prefer_t no longer dispatches through tag_invoke.
-    //   Before: prefer(tag, obj, prop) could be customized by defining
-    //     tag_invoke(prefer_t, tag, obj, prop) for a type.
-    //   Now: prefer(tag, obj, prop) simply calls tag(obj, prop) if possible,
-    //     else returns obj unchanged. To customize behavior, customize tag
-    //     itself (i.e. define tag_invoke(tag, obj, prop)).
+    // prefer(tag, obj, prop) calls tag(obj, prop) if invocable, else
+    // returns obj unchanged.
     HPX_CXX_CORE_EXPORT inline constexpr struct prefer_t
     {
         // call tag(tn...) when invocable

--- a/libs/core/runtime_local/CMakeLists.txt
+++ b/libs/core/runtime_local/CMakeLists.txt
@@ -127,7 +127,6 @@ add_hpx_module(
     hpx_serialization
     hpx_static_reinit
     hpx_synchronization
-    hpx_tag_invoke
     hpx_threading
     hpx_threading_base
     hpx_threadmanager

--- a/libs/core/synchronization/CMakeLists.txt
+++ b/libs/core/synchronization/CMakeLists.txt
@@ -88,7 +88,6 @@ add_hpx_module(
     hpx_lock_registration
     hpx_logging
     hpx_memory
-    hpx_tag_invoke
     hpx_threading_base
     hpx_thread_support
     hpx_timing

--- a/libs/core/thread_pools/CMakeLists.txt
+++ b/libs/core/thread_pools/CMakeLists.txt
@@ -50,7 +50,6 @@ add_hpx_module(
     hpx_functional
     hpx_logging
     hpx_schedulers
-    hpx_tag_invoke
     hpx_threading_base
     hpx_tracing
     hpx_topology

--- a/libs/core/threading/CMakeLists.txt
+++ b/libs/core/threading/CMakeLists.txt
@@ -31,7 +31,6 @@ add_hpx_module(
     hpx_lock_registration
     hpx_memory
     hpx_synchronization
-    hpx_tag_invoke
     hpx_threading_base
     hpx_thread_support
     hpx_timing

--- a/libs/core/threading_base/CMakeLists.txt
+++ b/libs/core/threading_base/CMakeLists.txt
@@ -139,7 +139,6 @@ add_hpx_module(
     hpx_lock_registration
     hpx_logging
     hpx_memory
-    hpx_tag_invoke
     hpx_thread_support
     hpx_timing
     hpx_topology

--- a/libs/core/thrust/CMakeLists.txt
+++ b/libs/core/thrust/CMakeLists.txt
@@ -39,7 +39,6 @@ add_hpx_module(
     hpx_executors
     hpx_functional
     hpx_futures
-    hpx_tag_invoke
     hpx_threading_base
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/timed_execution/CMakeLists.txt
+++ b/libs/core/timed_execution/CMakeLists.txt
@@ -35,7 +35,6 @@ add_hpx_module(
     hpx_execution_base
     hpx_executors
     hpx_futures
-    hpx_tag_invoke
     hpx_threading
     hpx_timing
     hpx_topology

--- a/libs/core/topology/CMakeLists.txt
+++ b/libs/core/topology/CMakeLists.txt
@@ -64,7 +64,6 @@ add_hpx_module(
     hpx_errors
     hpx_format
     hpx_logging
-    hpx_tag_invoke
     hpx_type_support
     hpx_util
   DEPENDENCIES Hwloc::hwloc

--- a/libs/full/async_distributed/include/hpx/async_distributed/trigger.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/trigger.hpp
@@ -10,6 +10,7 @@
 #include <hpx/config.hpp>
 #include <hpx/async_distributed/continuation_fwd.hpp>
 #include <hpx/modules/functional.hpp>
+#include <hpx/modules/tag_invoke.hpp>
 #include <hpx/modules/type_support.hpp>
 
 #include <exception>

--- a/libs/full/async_distributed/include/hpx/async_distributed/trigger.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/trigger.hpp
@@ -10,7 +10,6 @@
 #include <hpx/config.hpp>
 #include <hpx/async_distributed/continuation_fwd.hpp>
 #include <hpx/modules/functional.hpp>
-#include <hpx/modules/tag_invoke.hpp>
 #include <hpx/modules/type_support.hpp>
 
 #include <exception>

--- a/libs/full/collectives/include/hpx/collectives/exclusive_scan.hpp
+++ b/libs/full/collectives/include/hpx/collectives/exclusive_scan.hpp
@@ -280,7 +280,6 @@ namespace hpx { namespace collectives {
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/futures.hpp>
-#include <hpx/modules/tag_invoke.hpp>
 #include <hpx/modules/type_support.hpp>
 
 #include <hpx/collectives/argument_types.hpp>

--- a/libs/full/collectives/include/hpx/collectives/inclusive_scan.hpp
+++ b/libs/full/collectives/include/hpx/collectives/inclusive_scan.hpp
@@ -223,7 +223,6 @@ namespace hpx { namespace collectives {
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/futures.hpp>
-#include <hpx/modules/tag_invoke.hpp>
 #include <hpx/modules/type_support.hpp>
 
 #include <hpx/collectives/argument_types.hpp>


### PR DESCRIPTION
Fixes #

## Proposed Changes

  -
  -
  -

## Any background context you want to provide?

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
