### PR TITLE
fix(execution_base): complete P2300 compliance and fix set_stopped crash for any_sender

### DIFF
--- a/libs/core/execution/tests/unit/algorithm_when_all_vector.cpp
+++ b/libs/core/execution/tests/unit/algorithm_when_all_vector.cpp
@@ -154,7 +154,7 @@ int main()
 
         check_value_types<hpx::variant<hpx::tuple<std::vector<int>>>>(s);
         check_error_types<hpx::variant<std::exception_ptr>>(s);
-        check_sends_stopped<false>(s);
+        check_sends_stopped<true>(s);
 
         auto f = [](std::vector<int> v) {
             HPX_TEST_EQ(v.size(), std::size_t(3));
@@ -181,7 +181,7 @@ int main()
 
         check_value_types<hpx::variant<hpx::tuple<std::vector<double>>>>(s);
         check_error_types<hpx::variant<std::exception_ptr>>(s);
-        check_sends_stopped<false>(s);
+        check_sends_stopped<true>(s);
 
         auto f = [](std::vector<double> v) {
             HPX_TEST_EQ(v.size(), std::size_t(3));
@@ -245,7 +245,7 @@ int main()
 
         check_value_types<hpx::variant<hpx::tuple<>>>(s);
         check_error_types<hpx::variant<std::exception_ptr>>(s);
-        check_sends_stopped<false>(s);
+        check_sends_stopped<true>(s);
 
         auto f = []() {};
         auto r = callback_receiver<decltype(f)>{f, set_value_called};
@@ -267,7 +267,7 @@ int main()
 
         check_value_types<hpx::variant<hpx::tuple<>>>(s);
         check_error_types<hpx::variant<std::exception_ptr>>(s);
-        check_sends_stopped<false>(s);
+        check_sends_stopped<true>(s);
 
         auto f = []() {};
         auto r = callback_receiver<decltype(f)>{f, set_value_called};
@@ -294,7 +294,7 @@ int main()
         check_value_types<hpx::variant<
             hpx::tuple<std::vector<custom_type_non_default_constructible>>>>(s);
         check_error_types<hpx::variant<std::exception_ptr>>(s);
-        check_sends_stopped<false>(s);
+        check_sends_stopped<true>(s);
 
         auto f = [](std::vector<custom_type_non_default_constructible> v) {
             HPX_TEST_EQ(v.size(), std::size_t(3));
@@ -328,7 +328,7 @@ int main()
             std::vector<custom_type_non_default_constructible_non_copyable>>>>(
             s);
         check_error_types<hpx::variant<std::exception_ptr>>(s);
-        check_sends_stopped<false>(s);
+        check_sends_stopped<true>(s);
 
         auto f =
             [](std::vector<custom_type_non_default_constructible_non_copyable>
@@ -372,7 +372,7 @@ int main()
         check_value_types<
             hpx::variant<hpx::tuple<std::vector<double>, std::vector<int>>>>(s);
         check_error_types<hpx::variant<std::exception_ptr>>(s);
-        check_sends_stopped<false>(s);
+        check_sends_stopped<true>(s);
 
         auto f = [](std::vector<double> v1, std::vector<int> v3) {
             HPX_TEST_EQ(v1.size(), std::size_t(3));
@@ -444,7 +444,7 @@ int main()
 
         check_value_types<hpx::variant<hpx::tuple<std::vector<double>>>>(s);
         check_error_types<hpx::variant<std::exception_ptr>>(s);
-        check_sends_stopped<false>(s);
+        check_sends_stopped<true>(s);
 
         auto r = error_callback_receiver<check_exception_ptr>{
             check_exception_ptr{}, set_error_called};
@@ -467,7 +467,7 @@ int main()
 
         check_value_types<hpx::variant<hpx::tuple<std::vector<double>>>>(s);
         check_error_types<hpx::variant<std::exception_ptr>>(s);
-        check_sends_stopped<false>(s);
+        check_sends_stopped<true>(s);
 
         auto r = error_callback_receiver<check_exception_ptr>{
             check_exception_ptr{}, set_error_called};
@@ -490,7 +490,7 @@ int main()
 
         check_value_types<hpx::variant<hpx::tuple<std::vector<double>>>>(s);
         check_error_types<hpx::variant<std::exception_ptr>>(s);
-        check_sends_stopped<false>(s);
+        check_sends_stopped<true>(s);
 
         auto r = error_callback_receiver<check_exception_ptr>{
             check_exception_ptr{}, set_error_called};
@@ -513,7 +513,7 @@ int main()
 
         check_value_types<hpx::variant<hpx::tuple<std::vector<double>>>>(s);
         check_error_types<hpx::variant<std::exception_ptr>>(s);
-        check_sends_stopped<false>(s);
+        check_sends_stopped<true>(s);
 
         auto r = error_callback_receiver<check_exception_ptr>{
             check_exception_ptr{}, set_error_called};

--- a/libs/core/execution_base/include/hpx/execution_base/any_sender.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/any_sender.hpp
@@ -774,8 +774,9 @@ namespace hpx::execution::experimental {
 
         template <typename Self, typename... Env>
         static consteval auto get_completion_signatures() noexcept
-            -> hpx::execution::experimental::completion_signatures<
-                set_value_t(Ts...), set_error_t(std::exception_ptr)>
+            -> hpx::execution::experimental::completion_signatures<set_value_t(
+                                                                       Ts...),
+                set_error_t(std::exception_ptr), set_stopped_t()>
         {
             return {};
         }
@@ -852,8 +853,9 @@ namespace hpx::execution::experimental {
 
         template <typename Self, typename... Env>
         static consteval auto get_completion_signatures() noexcept
-            -> hpx::execution::experimental::completion_signatures<
-                set_value_t(Ts...), set_error_t(std::exception_ptr)>
+            -> hpx::execution::experimental::completion_signatures<set_value_t(
+                                                                       Ts...),
+                set_error_t(std::exception_ptr), set_stopped_t()>
         {
             return {};
         }

--- a/libs/core/execution_base/include/hpx/execution_base/any_sender.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/any_sender.hpp
@@ -473,7 +473,7 @@ namespace hpx::execution::experimental::detail {
 
         void set_stopped() && noexcept override
         {
-            HPX_UNREACHABLE;
+            hpx::execution::experimental::set_stopped(HPX_MOVE(receiver));
         }
     };
 
@@ -772,10 +772,14 @@ namespace hpx::execution::experimental {
         unique_any_sender& operator=(unique_any_sender&&) = default;
         unique_any_sender& operator=(unique_any_sender const&) = delete;
 
-        // TODO: Remove this
-        using completion_signatures =
-            hpx::execution::experimental::completion_signatures<
-                set_value_t(Ts...), set_error_t(std::exception_ptr)>;
+        template <typename Self, typename... Env>
+        static consteval auto get_completion_signatures() noexcept
+            -> hpx::execution::experimental::completion_signatures<set_value_t(
+                                                                       Ts...),
+                set_error_t(std::exception_ptr), set_stopped_t()>
+        {
+            return {};
+        }
 
         template <typename R>
         detail::any_operation_state connect(R&& r) &&
@@ -847,10 +851,14 @@ namespace hpx::execution::experimental {
         any_sender& operator=(any_sender&&) = default;
         any_sender& operator=(any_sender const&) = default;
 
-        // TODO: Remove this
-        using completion_signatures =
-            hpx::execution::experimental::completion_signatures<
-                set_value_t(Ts...), set_error_t(std::exception_ptr)>;
+        template <typename Self, typename... Env>
+        static consteval auto get_completion_signatures() noexcept
+            -> hpx::execution::experimental::completion_signatures<set_value_t(
+                                                                       Ts...),
+                set_error_t(std::exception_ptr), set_stopped_t()>
+        {
+            return {};
+        }
 
         template <typename R>
         detail::any_operation_state connect(R&& r) &

--- a/libs/core/execution_base/include/hpx/execution_base/any_sender.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/any_sender.hpp
@@ -774,9 +774,8 @@ namespace hpx::execution::experimental {
 
         template <typename Self, typename... Env>
         static consteval auto get_completion_signatures() noexcept
-            -> hpx::execution::experimental::completion_signatures<set_value_t(
-                                                                       Ts...),
-                set_error_t(std::exception_ptr), set_stopped_t()>
+            -> hpx::execution::experimental::completion_signatures<
+                set_value_t(Ts...), set_error_t(std::exception_ptr)>
         {
             return {};
         }
@@ -853,9 +852,8 @@ namespace hpx::execution::experimental {
 
         template <typename Self, typename... Env>
         static consteval auto get_completion_signatures() noexcept
-            -> hpx::execution::experimental::completion_signatures<set_value_t(
-                                                                       Ts...),
-                set_error_t(std::exception_ptr), set_stopped_t()>
+            -> hpx::execution::experimental::completion_signatures<
+                set_value_t(Ts...), set_error_t(std::exception_ptr)>
         {
             return {};
         }

--- a/libs/core/execution_base/tests/unit/any_sender.cpp
+++ b/libs/core/execution_base/tests/unit/any_sender.cpp
@@ -277,7 +277,7 @@ void test_any_sender(F&& f, Ts&&... ts)
 
     check_value_types<hpx::variant<hpx::tuple<Ts...>>>(as2);
     check_error_types<hpx::variant<std::exception_ptr>>(as2);
-    check_sends_stopped<true>(as2);
+    check_sends_stopped<false>(as2);
 
     // We should be able to connect both as1 and as2 multiple times; set_value
     // should always be called
@@ -367,7 +367,7 @@ void test_unique_any_sender(F&& f, Ts&&... ts)
 
     check_value_types<hpx::variant<hpx::tuple<Ts...>>>(as1);
     check_error_types<hpx::variant<std::exception_ptr>>(as1);
-    check_sends_stopped<true>(as1);
+    check_sends_stopped<false>(as1);
 
     auto as2 = std::move(as1);
 
@@ -376,7 +376,7 @@ void test_unique_any_sender(F&& f, Ts&&... ts)
 
     check_value_types<hpx::variant<hpx::tuple<Ts...>>>(as2);
     check_error_types<hpx::variant<std::exception_ptr>>(as2);
-    check_sends_stopped<true>(as2);
+    check_sends_stopped<false>(as2);
 
     // We expect set_value to be called here
     {
@@ -551,37 +551,6 @@ struct wait_globals
     }
 } waiter{};
 
-void test_any_sender_set_stopped()
-{
-    stopped_sender_with_value_type s;
-
-    ex::any_sender<> as{std::move(s)};
-
-    // Connect and start: should call set_stopped on the receiver
-    {
-        std::atomic<bool> set_stopped_called{false};
-        auto os = ex::connect(
-            std::move(as), expect_stopped_receiver{set_stopped_called});
-        ex::start(os);
-        HPX_TEST(set_stopped_called);
-    }
-}
-
-void test_unique_any_sender_set_stopped()
-{
-    stopped_sender_with_value_type s;
-
-    ex::unique_any_sender<> as{std::move(s)};
-
-    // Connect and start: should call set_stopped on the receiver
-    {
-        std::atomic<bool> set_stopped_called{false};
-        auto os = ex::connect(
-            std::move(as), expect_stopped_receiver{set_stopped_called});
-        ex::start(os);
-        HPX_TEST(set_stopped_called);
-    }
-}
 
 void test_globals()
 {
@@ -674,10 +643,6 @@ int main()
     // Failure paths
     test_any_sender_set_error();
     test_unique_any_sender_set_error();
-
-    // Stopped paths
-    test_any_sender_set_stopped();
-    test_unique_any_sender_set_stopped();
 
     // Test use of *any_* in globals
     test_globals();

--- a/libs/core/execution_base/tests/unit/any_sender.cpp
+++ b/libs/core/execution_base/tests/unit/any_sender.cpp
@@ -277,7 +277,7 @@ void test_any_sender(F&& f, Ts&&... ts)
 
     check_value_types<hpx::variant<hpx::tuple<Ts...>>>(as2);
     check_error_types<hpx::variant<std::exception_ptr>>(as2);
-    check_sends_stopped<false>(as2);
+    check_sends_stopped<true>(as2);
 
     // We should be able to connect both as1 and as2 multiple times; set_value
     // should always be called
@@ -367,7 +367,7 @@ void test_unique_any_sender(F&& f, Ts&&... ts)
 
     check_value_types<hpx::variant<hpx::tuple<Ts...>>>(as1);
     check_error_types<hpx::variant<std::exception_ptr>>(as1);
-    check_sends_stopped<false>(as1);
+    check_sends_stopped<true>(as1);
 
     auto as2 = std::move(as1);
 
@@ -376,7 +376,7 @@ void test_unique_any_sender(F&& f, Ts&&... ts)
 
     check_value_types<hpx::variant<hpx::tuple<Ts...>>>(as2);
     check_error_types<hpx::variant<std::exception_ptr>>(as2);
-    check_sends_stopped<false>(as2);
+    check_sends_stopped<true>(as2);
 
     // We expect set_value to be called here
     {
@@ -551,6 +551,37 @@ struct wait_globals
     }
 } waiter{};
 
+void test_any_sender_set_stopped()
+{
+    stopped_sender_with_value_type s;
+
+    ex::any_sender<> as{std::move(s)};
+
+    // Connect and start: should call set_stopped on the receiver
+    {
+        std::atomic<bool> set_stopped_called{false};
+        auto os = ex::connect(
+            std::move(as), expect_stopped_receiver{set_stopped_called});
+        ex::start(os);
+        HPX_TEST(set_stopped_called);
+    }
+}
+
+void test_unique_any_sender_set_stopped()
+{
+    stopped_sender_with_value_type s;
+
+    ex::unique_any_sender<> as{std::move(s)};
+
+    // Connect and start: should call set_stopped on the receiver
+    {
+        std::atomic<bool> set_stopped_called{false};
+        auto os = ex::connect(
+            std::move(as), expect_stopped_receiver{set_stopped_called});
+        ex::start(os);
+        HPX_TEST(set_stopped_called);
+    }
+}
 
 void test_globals()
 {
@@ -643,6 +674,10 @@ int main()
     // Failure paths
     test_any_sender_set_error();
     test_unique_any_sender_set_error();
+
+    // Stopped paths
+    test_any_sender_set_stopped();
+    test_unique_any_sender_set_stopped();
 
     // Test use of *any_* in globals
     test_globals();

--- a/libs/core/execution_base/tests/unit/any_sender.cpp
+++ b/libs/core/execution_base/tests/unit/any_sender.cpp
@@ -277,7 +277,7 @@ void test_any_sender(F&& f, Ts&&... ts)
 
     check_value_types<hpx::variant<hpx::tuple<Ts...>>>(as2);
     check_error_types<hpx::variant<std::exception_ptr>>(as2);
-    check_sends_stopped<false>(as2);
+    check_sends_stopped<true>(as2);
 
     // We should be able to connect both as1 and as2 multiple times; set_value
     // should always be called
@@ -367,7 +367,7 @@ void test_unique_any_sender(F&& f, Ts&&... ts)
 
     check_value_types<hpx::variant<hpx::tuple<Ts...>>>(as1);
     check_error_types<hpx::variant<std::exception_ptr>>(as1);
-    check_sends_stopped<false>(as1);
+    check_sends_stopped<true>(as1);
 
     auto as2 = std::move(as1);
 
@@ -376,7 +376,7 @@ void test_unique_any_sender(F&& f, Ts&&... ts)
 
     check_value_types<hpx::variant<hpx::tuple<Ts...>>>(as2);
     check_error_types<hpx::variant<std::exception_ptr>>(as2);
-    check_sends_stopped<false>(as2);
+    check_sends_stopped<true>(as2);
 
     // We expect set_value to be called here
     {
@@ -551,6 +551,38 @@ struct wait_globals
     }
 } waiter{};
 
+void test_any_sender_set_stopped()
+{
+    stopped_sender_with_value_type s;
+
+    ex::any_sender<> as{std::move(s)};
+
+    // Connect and start: should call set_stopped on the receiver
+    {
+        std::atomic<bool> set_stopped_called{false};
+        auto os = ex::connect(
+            std::move(as), expect_stopped_receiver{set_stopped_called});
+        ex::start(os);
+        HPX_TEST(set_stopped_called);
+    }
+}
+
+void test_unique_any_sender_set_stopped()
+{
+    stopped_sender_with_value_type s;
+
+    ex::unique_any_sender<> as{std::move(s)};
+
+    // Connect and start: should call set_stopped on the receiver
+    {
+        std::atomic<bool> set_stopped_called{false};
+        auto os = ex::connect(
+            std::move(as), expect_stopped_receiver{set_stopped_called});
+        ex::start(os);
+        HPX_TEST(set_stopped_called);
+    }
+}
+
 void test_globals()
 {
     global_unique_any_sender =
@@ -642,6 +674,10 @@ int main()
     // Failure paths
     test_any_sender_set_error();
     test_unique_any_sender_set_error();
+
+    // Stopped paths
+    test_any_sender_set_stopped();
+    test_unique_any_sender_set_stopped();
 
     // Test use of *any_* in globals
     test_globals();


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - **Migrated completion signatures:** Replaced the deprecated `completion_signatures` member typedef (and removed the associated `TODO: Remove this` comments) in `any_sender` and `unique_any_sender` with a P2300-compliant `get_completion_signatures()` implementation.
  - **Fixed `set_stopped` abort:** Replaced `HPX_UNREACHABLE` in `any_receiver_impl::set_stopped()` with `hpx::execution::experimental::set_stopped(HPX_MOVE(receiver))`.
  - **Added `set_stopped_t`:** Updated the advertised signatures to properly include `set_stopped_t` alongside `set_value_t` and `set_error_t`.
  - **Added test coverage:** Added `test_any_sender_set_stopped()` and `test_unique_any_sender_set_stopped()` to `any_sender.cpp` to verify that cancellation is safely forwarded through the type-erasure layer.

## Any background context you want to provide?

Previously, any sender that signaled cancellation (`set_stopped`) through the `any_sender` type-erasure layer would crash the program at runtime because the receiver implementation explicitly hit `HPX_UNREACHABLE`. Furthermore, the sender was relying on a legacy signature discovery path. 

This PR resolves a real correctness bug for cancellation channels and brings HPX's `any_sender` into full P2300 stdexec compliance, paying off two explicit tech-debt TODOs in the process.

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [x] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.