### PR TITLE
Feat/remove copy sender

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/algorithms/copy.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/copy.hpp
@@ -552,10 +552,9 @@ namespace hpx::parallel {
 
             template <typename ExPolicy, typename FwdIter1, typename FwdIter2,
                 typename FwdIter3, typename Pred, typename Proj = hpx::identity>
-            static typename util::detail::algorithm_result<ExPolicy,
-                util::in_out_result<FwdIter1, FwdIter3>>::type
-            parallel(ExPolicy&& policy, FwdIter1 first, FwdIter2 last,
-                FwdIter3 dest, Pred&& pred, Proj&& proj /* = Proj()*/)
+            static decltype(auto) parallel(ExPolicy&& policy, FwdIter1 first,
+                FwdIter2 last, FwdIter3 dest, Pred&& pred,
+                Proj&& proj /* = Proj()*/)
             {
                 typedef hpx::util::zip_iterator<FwdIter1, bool*> zip_iterator;
                 typedef util::detail::algorithm_result<ExPolicy,
@@ -564,10 +563,15 @@ namespace hpx::parallel {
                 typedef typename std::iterator_traits<FwdIter1>::difference_type
                     difference_type;
 
-                if (first == last)
+                if constexpr (!hpx::execution_policy_has_scheduler_executor_v<
+                                  ExPolicy>)
                 {
-                    return result::get(util::in_out_result<FwdIter1, FwdIter3>{
-                        HPX_MOVE(first), HPX_MOVE(dest)});
+                    if (first == last)
+                    {
+                        return result::get(
+                            util::in_out_result<FwdIter1, FwdIter3>{
+                                HPX_MOVE(first), HPX_MOVE(dest)});
+                    }
                 }
 
                 difference_type count = detail::distance(first, last);

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/remove_copy.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/remove_copy.hpp
@@ -269,10 +269,12 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/tag_dispatch.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/handle_local_exceptions.hpp>
 #include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/result_types.hpp>
 
 #include <algorithm>
+#include <exception>
 #include <iterator>
 #include <type_traits>
 #include <utility>
@@ -444,9 +446,7 @@ namespace hpx {
             )
         // clang-format on
         // clang-format off
-        static typename parallel::util::detail::algorithm_result<ExPolicy,
-            FwdIter2>::type
-        invoke_default(ExPolicy&& policy,
+        static decltype(auto) invoke_default(ExPolicy&& policy,
             FwdIter1 first, FwdIter1 last, FwdIter2 dest, Pred pred)
         // clang-format on
         {
@@ -456,12 +456,41 @@ namespace hpx {
             static_assert(std::forward_iterator<FwdIter2>,
                 "Required at least forward iterator.");
 
-            auto&& res = hpx::parallel::detail::remove_copy_if<
-                hpx::parallel::util::in_out_result<FwdIter1, FwdIter2>>()
-                             .call(HPX_FORWARD(ExPolicy, policy), first, last,
-                                 dest, HPX_MOVE(pred), hpx::identity_v);
+            constexpr bool has_scheduler_executor =
+                hpx::execution_policy_has_scheduler_executor_v<ExPolicy>;
 
-            return hpx::parallel::util::get_second_element(HPX_MOVE(res));
+            if constexpr (has_scheduler_executor)
+            {
+                using result_handler =
+                    hpx::parallel::util::detail::algorithm_result<ExPolicy,
+                        hpx::parallel::util::in_out_result<FwdIter1, FwdIter2>>;
+
+                return hpx::parallel::util::get_second_element(
+                    result_handler::get(hpx::parallel::execution::async_execute(
+                        policy.executor(),
+                        [first, last, dest, pred = HPX_MOVE(pred)]() mutable {
+                            try
+                            {
+                                return hpx::parallel::detail::
+                                    sequential_remove_copy_if(first, last, dest,
+                                        HPX_MOVE(pred), hpx::identity_v);
+                            }
+                            catch (...)
+                            {
+                                hpx::parallel::util::detail::
+                                    handle_local_exceptions<ExPolicy>::call(
+                                        std::current_exception());
+                            }
+                        })));
+            }
+            else
+            {
+                return hpx::parallel::util::get_second_element(
+                    hpx::parallel::detail::remove_copy_if<hpx::parallel::util::
+                            in_out_result<FwdIter1, FwdIter2>>()
+                        .call(HPX_FORWARD(ExPolicy, policy), first, last, dest,
+                            HPX_MOVE(pred), hpx::identity_v));
+            }
         }
     } remove_copy_if{};
 
@@ -505,9 +534,7 @@ namespace hpx {
             )
         // clang-format on
         // clang-format off
-        static typename parallel::util::detail::algorithm_result<ExPolicy,
-            FwdIter2>::type
-        invoke_default(ExPolicy&& policy,
+        static decltype(auto) invoke_default(ExPolicy&& policy,
             FwdIter1 first, FwdIter1 last, FwdIter2 dest, T const& value)
         // clang-format on
         {

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/remove_copy.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/remove_copy.hpp
@@ -269,12 +269,10 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/detail/tag_dispatch.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
-#include <hpx/parallel/util/detail/handle_local_exceptions.hpp>
 #include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/result_types.hpp>
 
 #include <algorithm>
-#include <exception>
 #include <iterator>
 #include <type_traits>
 #include <utility>
@@ -380,10 +378,8 @@ namespace hpx::parallel {
 
             template <typename ExPolicy, typename FwdIter1, typename Sent,
                 typename FwdIter2, typename F, typename Proj>
-            static typename util::detail::algorithm_result<ExPolicy,
-                util::in_out_result<FwdIter1, FwdIter2>>::type
-            parallel(ExPolicy&& policy, FwdIter1 first, Sent last,
-                FwdIter2 dest, F&& f, Proj&& proj)
+            static decltype(auto) parallel(ExPolicy&& policy, FwdIter1 first,
+                Sent last, FwdIter2 dest, F&& f, Proj&& proj)
             {
                 return copy_if<IterPair>().call(
                     HPX_FORWARD(ExPolicy, policy), first, last, dest,
@@ -456,41 +452,11 @@ namespace hpx {
             static_assert(std::forward_iterator<FwdIter2>,
                 "Required at least forward iterator.");
 
-            constexpr bool has_scheduler_executor =
-                hpx::execution_policy_has_scheduler_executor_v<ExPolicy>;
-
-            if constexpr (has_scheduler_executor)
-            {
-                using result_handler =
-                    hpx::parallel::util::detail::algorithm_result<ExPolicy,
-                        hpx::parallel::util::in_out_result<FwdIter1, FwdIter2>>;
-
-                return hpx::parallel::util::get_second_element(
-                    result_handler::get(hpx::parallel::execution::async_execute(
-                        policy.executor(),
-                        [first, last, dest, pred = HPX_MOVE(pred)]() mutable {
-                            try
-                            {
-                                return hpx::parallel::detail::
-                                    sequential_remove_copy_if(first, last, dest,
-                                        HPX_MOVE(pred), hpx::identity_v);
-                            }
-                            catch (...)
-                            {
-                                hpx::parallel::util::detail::
-                                    handle_local_exceptions<ExPolicy>::call(
-                                        std::current_exception());
-                            }
-                        })));
-            }
-            else
-            {
-                return hpx::parallel::util::get_second_element(
-                    hpx::parallel::detail::remove_copy_if<hpx::parallel::util::
-                            in_out_result<FwdIter1, FwdIter2>>()
-                        .call(HPX_FORWARD(ExPolicy, policy), first, last, dest,
-                            HPX_MOVE(pred), hpx::identity_v));
-            }
+            return hpx::parallel::util::get_second_element(
+                hpx::parallel::detail::remove_copy_if<
+                    hpx::parallel::util::in_out_result<FwdIter1, FwdIter2>>()
+                    .call(HPX_FORWARD(ExPolicy, policy), first, last, dest,
+                        HPX_MOVE(pred), hpx::identity_v));
         }
     } remove_copy_if{};
 

--- a/libs/core/algorithms/include/hpx/parallel/util/scan_partitioner.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/scan_partitioner.hpp
@@ -384,6 +384,7 @@ namespace hpx::parallel::util {
                                             HPX_INVOKE(f4,
                                                 HPX_MOVE(scan_results),
                                                 HPX_MOVE(data));
+                                            return;
                                         }
                                         else
                                         {

--- a/libs/core/algorithms/include/hpx/parallel/util/scan_partitioner.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/scan_partitioner.hpp
@@ -12,6 +12,7 @@
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/modules/async_combinators.hpp>
+#include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/parallel/util/detail/chunk_size.hpp>
@@ -27,6 +28,8 @@
 #include <cstddef>
 #include <exception>
 #include <list>
+#include <memory>
+#include <optional>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -226,6 +229,186 @@ namespace hpx::parallel::util {
                     });
             }
         };
+
+        ///////////////////////////////////////////////////////////////////////
+        // Scheduler executors return senders instead of futures. Run both
+        // parallel scan phases as bulk sender operations and calculate the
+        // inter-partition prefixes between them.
+        HPX_CXX_CORE_EXPORT template <typename ExPolicy, typename R,
+            typename Result1, typename Result2>
+        struct scan_scheduler_partitioner
+        {
+            using handle_local_exceptions =
+                detail::handle_local_exceptions<ExPolicy>;
+
+            static std::exception_ptr transform_exception(
+                std::exception_ptr error) noexcept
+            {
+                try
+                {
+                    handle_local_exceptions::call(error);
+                }
+                catch (...)
+                {
+                    return std::current_exception();
+                }
+
+                HPX_UNREACHABLE;
+            }
+
+            template <typename FwdIter>
+            using chunk_type = hpx::tuple<std::size_t, FwdIter, std::size_t>;
+
+            template <typename FwdIter>
+            using final_chunk_type = hpx::tuple<FwdIter, std::size_t, Result1>;
+
+            template <typename ExPolicy_, typename FwdIter, typename T,
+                typename F1, typename F2, typename F3, typename F4>
+            static decltype(auto) call(ExPolicy_&& policy, FwdIter first,
+                std::size_t count, T&& init, F1&& f1, F2&& f2, F3&& f3, F4&& f4)
+            {
+                using parameters_type =
+                    typename std::decay_t<ExPolicy_>::executor_parameters_type;
+                using executor_type =
+                    typename std::decay_t<ExPolicy_>::executor_type;
+                using scoped_executor_parameters =
+                    detail::scoped_executor_parameters_ref<parameters_type,
+                        executor_type>;
+
+                scoped_executor_parameters scoped_params(
+                    policy.parameters(), policy.executor());
+
+                std::size_t cores = 1;
+                auto shape = [&]() {
+                    if constexpr (hpx::execution::experimental::
+                                      extract_has_variable_chunk_size_v<
+                                          parameters_type>)
+                    {
+                        return detail::get_bulk_iteration_shape_variable(
+                            policy, first, count, cores);
+                    }
+                    else
+                    {
+                        return detail::get_bulk_iteration_shape(
+                            policy, first, count, cores);
+                    }
+                }();
+
+                std::vector<chunk_type<FwdIter>> chunks;
+                chunks.reserve(hpx::util::size(shape));
+                for (auto const& chunk : shape)
+                {
+                    chunks.emplace_back(
+                        chunks.size(), hpx::get<0>(chunk), hpx::get<1>(chunk));
+                }
+
+                namespace ex = hpx::execution::experimental;
+
+                auto partial_results =
+                    std::make_shared<std::vector<std::optional<Result1>>>(
+                        chunks.size());
+                auto exec = policy.executor();
+                auto first_step = execution::bulk_async_execute(
+                    exec,
+                    [f1 = HPX_FORWARD(F1, f1), partial_results](
+                        chunk_type<FwdIter> const& chunk) mutable {
+                        auto f1_copy = f1;
+                        (*partial_results)[hpx::get<0>(chunk)].emplace(
+                            HPX_INVOKE(f1_copy, hpx::get<1>(chunk),
+                                hpx::get<2>(chunk)));
+                    },
+                    chunks);
+                auto first_step_with_errors = ex::let_error(
+                    HPX_MOVE(first_step), [](std::exception_ptr error) {
+                        return ex::just_error(transform_exception(error));
+                    });
+
+                scoped_params.mark_end_of_scheduling();
+
+                return ex::let_value(HPX_MOVE(first_step_with_errors),
+                    [exec = HPX_MOVE(exec), chunks = HPX_MOVE(chunks),
+                        partial_results = HPX_MOVE(partial_results),
+                        init = HPX_FORWARD(T, init), f2 = HPX_FORWARD(F2, f2),
+                        f3 = HPX_FORWARD(F3, f3),
+                        f4 = HPX_FORWARD(F4, f4)]() mutable {
+                        try
+                        {
+                            std::vector<Result1> scan_results;
+                            scan_results.reserve(partial_results->size() + 1);
+
+                            Result1 result = HPX_MOVE(init);
+                            scan_results.push_back(result);
+                            for (auto& partial_result : *partial_results)
+                            {
+                                HPX_ASSERT(partial_result.has_value());
+                                result =
+                                    HPX_INVOKE(f2, result, *partial_result);
+                                scan_results.push_back(result);
+                            }
+
+                            std::vector<final_chunk_type<FwdIter>> final_chunks;
+                            final_chunks.reserve(chunks.size());
+                            for (std::size_t i = 0; i != chunks.size(); ++i)
+                            {
+                                final_chunks.emplace_back(
+                                    hpx::get<1>(chunks[i]),
+                                    hpx::get<2>(chunks[i]), scan_results[i]);
+                            }
+
+                            auto final_step = execution::bulk_async_execute(
+                                exec,
+                                [f3 = HPX_MOVE(f3)](
+                                    final_chunk_type<FwdIter> const&
+                                        chunk) mutable {
+                                    auto f3_copy = f3;
+                                    HPX_INVOKE(f3_copy, hpx::get<0>(chunk),
+                                        hpx::get<1>(chunk), hpx::get<2>(chunk));
+                                },
+                                final_chunks);
+                            auto final_step_with_errors =
+                                ex::let_error(HPX_MOVE(final_step),
+                                    [](std::exception_ptr error) {
+                                        return ex::just_error(
+                                            transform_exception(error));
+                                    });
+
+                            return ex::then(HPX_MOVE(final_step_with_errors),
+                                [f4 = HPX_MOVE(f4),
+                                    scan_results =
+                                        HPX_MOVE(scan_results)]() mutable -> R {
+                                    try
+                                    {
+                                        std::vector<hpx::future<Result2>> data;
+                                        if constexpr (std::is_void_v<R>)
+                                        {
+                                            HPX_INVOKE(f4,
+                                                HPX_MOVE(scan_results),
+                                                HPX_MOVE(data));
+                                        }
+                                        else
+                                        {
+                                            return HPX_INVOKE(f4,
+                                                HPX_MOVE(scan_results),
+                                                HPX_MOVE(data));
+                                        }
+                                    }
+                                    catch (...)
+                                    {
+                                        handle_local_exceptions::call(
+                                            std::current_exception());
+                                    }
+                                    HPX_UNREACHABLE;
+                                });
+                        }
+                        catch (...)
+                        {
+                            handle_local_exceptions::call(
+                                std::current_exception());
+                        }
+                        HPX_UNREACHABLE;
+                    });
+            }
+        };
     }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
@@ -236,10 +419,14 @@ namespace hpx::parallel::util {
     HPX_CXX_CORE_EXPORT template <typename ExPolicy, typename R = void,
         typename Result1 = R, typename Result2 = void>
     struct scan_partitioner
-      : detail::select_partitioner<std::decay_t<ExPolicy>,
-            detail::scan_static_partitioner,
-            detail::scan_task_static_partitioner>::template apply<R, Result1,
-            Result2>
+      : std::conditional_t<
+            hpx::execution_policy_has_scheduler_executor_v<ExPolicy>,
+            detail::scan_scheduler_partitioner<std::decay_t<ExPolicy>, R,
+                Result1, Result2>,
+            typename detail::select_partitioner<std::decay_t<ExPolicy>,
+                detail::scan_static_partitioner,
+                detail::scan_task_static_partitioner>::template apply<R,
+                Result1, Result2>>
     {
     };
 }    // namespace hpx::parallel::util

--- a/libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt
@@ -202,6 +202,8 @@ set(sender_tests
     none_of_sender
     partial_sort_sender
     reduce_sender
+    remove_copy_if_sender
+    remove_copy_sender
     remove_sender
     remove_if_sender
     replace_sender

--- a/libs/core/algorithms/tests/unit/algorithms/remove_copy_if_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/remove_copy_if_sender.cpp
@@ -1,0 +1,233 @@
+//  Copyright (c) 2026 Pratyksh Gupta
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/algorithm.hpp>
+#include <hpx/execution.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <exception>
+#include <iterator>
+#include <new>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "test_utils.hpp"
+
+namespace ex = hpx::execution::experimental;
+namespace tt = hpx::this_thread::experimental;
+
+template <typename LnPolicy, typename ExPolicy, typename IteratorTag>
+void test_remove_copy_if_scheduler(
+    LnPolicy ln_policy, ExPolicy&& ex_policy, IteratorTag)
+{
+    static_assert(!hpx::is_async_execution_policy_v<ExPolicy>);
+
+    using base_iterator = std::vector<int>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+    using scheduler_type = ex::thread_pool_policy_scheduler<LnPolicy>;
+
+    std::vector<int> input{1, 2, 3, 4, 5, 6};
+    std::vector<int> output(input.size(), -1);
+    auto exec = ex::explicit_scheduler_executor(scheduler_type(ln_policy));
+
+    auto result = hpx::remove_copy_if(ex_policy.on(exec),
+        iterator(input.begin()), iterator(input.end()), output.begin(),
+        [](int value) { return value % 2 == 0; });
+    static_assert(std::is_same_v<decltype(result), base_iterator>);
+
+    HPX_TEST(result == output.begin() + 3);
+    std::vector<int> const expected{1, 3, 5};
+    HPX_TEST(std::equal(expected.begin(), expected.end(), output.begin()));
+    HPX_TEST(std::all_of(
+        result, output.end(), [](int value) { return value == -1; }));
+}
+
+template <typename LnPolicy, typename ExPolicy, typename IteratorTag>
+void test_remove_copy_if_sender_case(LnPolicy ln_policy, ExPolicy&& ex_policy,
+    IteratorTag, std::vector<int> input, std::vector<int> const& expected)
+{
+    static_assert(hpx::is_async_execution_policy_v<ExPolicy>);
+
+    using base_iterator = std::vector<int>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+    using scheduler_type = ex::thread_pool_policy_scheduler<LnPolicy>;
+
+    std::vector<int> output(input.size(), -1);
+    auto exec = ex::explicit_scheduler_executor(scheduler_type(ln_policy));
+
+    auto sender =
+        ex::just(iterator(input.begin()), iterator(input.end()), output.begin(),
+            [](int value) { return value % 2 == 0; }) |
+        hpx::remove_copy_if(ex_policy.on(exec));
+    static_assert(ex::is_sender_v<decltype(sender)>);
+
+    auto result = tt::sync_wait(std::move(sender));
+    HPX_TEST(result.has_value());
+    if (!result.has_value())
+    {
+        return;
+    }
+
+    auto const output_end = hpx::get<0>(*result);
+    HPX_TEST(output_end ==
+        output.begin() + static_cast<std::ptrdiff_t>(expected.size()));
+    HPX_TEST(std::equal(expected.begin(), expected.end(), output.begin()));
+    HPX_TEST(std::all_of(
+        output_end, output.end(), [](int value) { return value == -1; }));
+}
+
+template <typename LnPolicy, typename ExPolicy, typename IteratorTag>
+void test_remove_copy_if_sender(
+    LnPolicy ln_policy, ExPolicy&& ex_policy, IteratorTag)
+{
+    test_remove_copy_if_sender_case(
+        ln_policy, ex_policy, IteratorTag{}, {1, 2, 3, 4, 5, 6}, {1, 3, 5});
+    test_remove_copy_if_sender_case(
+        ln_policy, ex_policy, IteratorTag{}, {}, {});
+    test_remove_copy_if_sender_case(
+        ln_policy, ex_policy, IteratorTag{}, {2, 4, 6}, {});
+    test_remove_copy_if_sender_case(
+        ln_policy, ex_policy, IteratorTag{}, {1, 3, 5}, {1, 3, 5});
+}
+
+template <typename Exception, typename LnPolicy, typename ExPolicy,
+    typename IteratorTag>
+void test_remove_copy_if_sender_exception(
+    LnPolicy ln_policy, ExPolicy&& ex_policy, IteratorTag)
+{
+    static_assert(hpx::is_async_execution_policy_v<ExPolicy>);
+
+    using base_iterator = std::vector<int>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+    using scheduler_type = ex::thread_pool_policy_scheduler<LnPolicy>;
+
+    std::vector<int> input{1, 2, 3, 4};
+    std::vector<int> output(input.size());
+    auto exec = ex::explicit_scheduler_executor(scheduler_type(ln_policy));
+
+    bool caught_expected_exception = false;
+    try
+    {
+        tt::sync_wait(
+            ex::just(iterator(input.begin()), iterator(input.end()),
+                output.begin(),
+                [](int) -> bool {
+                    if constexpr (std::is_same_v<Exception, std::runtime_error>)
+                    {
+                        throw std::runtime_error("test");
+                    }
+                    else
+                    {
+                        throw std::bad_alloc();
+                    }
+                }) |
+            hpx::remove_copy_if(ex_policy.on(exec)));
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& errors)
+    {
+        if constexpr (std::is_same_v<Exception, std::runtime_error>)
+        {
+            test::test_num_exceptions<ExPolicy, IteratorTag>::call(
+                ex_policy, errors);
+
+            bool all_exceptions_expected = errors.begin() != errors.end();
+            for (std::exception_ptr const& error : errors)
+            {
+                bool is_expected_exception = false;
+                try
+                {
+                    std::rethrow_exception(error);
+                }
+                catch (std::runtime_error const&)
+                {
+                    is_expected_exception = true;
+                }
+                catch (...)
+                {
+                    is_expected_exception = false;
+                }
+                all_exceptions_expected =
+                    all_exceptions_expected && is_expected_exception;
+            }
+            HPX_TEST(all_exceptions_expected);
+            caught_expected_exception = all_exceptions_expected;
+        }
+        else
+        {
+            HPX_TEST(false);
+        }
+    }
+    catch (Exception const&)
+    {
+        if constexpr (std::is_same_v<Exception, std::bad_alloc>)
+        {
+            caught_expected_exception = true;
+        }
+        else
+        {
+            HPX_TEST(false);
+        }
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_expected_exception);
+}
+
+template <typename IteratorTag>
+void remove_copy_if_sender_test()
+{
+    using namespace hpx::execution;
+
+    test_remove_copy_if_scheduler(hpx::launch::sync, seq, IteratorTag{});
+    test_remove_copy_if_scheduler(hpx::launch::sync, unseq, IteratorTag{});
+    test_remove_copy_if_scheduler(hpx::launch::async, par, IteratorTag{});
+    test_remove_copy_if_scheduler(hpx::launch::async, par_unseq, IteratorTag{});
+
+    test_remove_copy_if_sender(hpx::launch::sync, seq(task), IteratorTag{});
+    test_remove_copy_if_sender(hpx::launch::sync, unseq(task), IteratorTag{});
+    test_remove_copy_if_sender(hpx::launch::async, par(task), IteratorTag{});
+    test_remove_copy_if_sender(
+        hpx::launch::async, par_unseq(task), IteratorTag{});
+
+    test_remove_copy_if_sender_exception<std::runtime_error>(
+        hpx::launch::sync, seq(task), IteratorTag{});
+    test_remove_copy_if_sender_exception<std::runtime_error>(
+        hpx::launch::async, par(task), IteratorTag{});
+    test_remove_copy_if_sender_exception<std::bad_alloc>(
+        hpx::launch::sync, seq(task), IteratorTag{});
+    test_remove_copy_if_sender_exception<std::bad_alloc>(
+        hpx::launch::async, par(task), IteratorTag{});
+}
+
+int hpx_main()
+{
+    remove_copy_if_sender_test<std::forward_iterator_tag>();
+    remove_copy_if_sender_test<std::random_access_iterator_tag>();
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    hpx::local::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/algorithms/tests/unit/algorithms/remove_copy_if_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/remove_copy_if_sender.cpp
@@ -155,7 +155,10 @@ void test_remove_copy_if_sender_parallel()
     }
 
     HPX_TEST(hpx::get<0>(*result) == output.end());
-    HPX_TEST(max_active_count.load(std::memory_order_relaxed) > 1);
+    if (hpx::get_os_thread_count() > 1)
+    {
+        HPX_TEST(max_active_count.load(std::memory_order_relaxed) > 1);
+    }
 }
 
 template <typename Exception, typename LnPolicy, typename ExPolicy,

--- a/libs/core/algorithms/tests/unit/algorithms/remove_copy_if_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/remove_copy_if_sender.cpp
@@ -8,8 +8,11 @@
 #include <hpx/execution.hpp>
 #include <hpx/init.hpp>
 #include <hpx/modules/testing.hpp>
+#include <hpx/modules/threading.hpp>
 
 #include <algorithm>
+#include <atomic>
+#include <chrono>
 #include <cstddef>
 #include <exception>
 #include <iterator>
@@ -24,6 +27,26 @@
 
 namespace ex = hpx::execution::experimental;
 namespace tt = hpx::this_thread::experimental;
+
+void record_concurrency(std::atomic<std::size_t>& active_count,
+    std::atomic<std::size_t>& max_active_count,
+    std::atomic<std::size_t>& invocation_count)
+{
+    std::size_t const active =
+        active_count.fetch_add(1, std::memory_order_relaxed) + 1;
+    std::size_t previous_max = max_active_count.load(std::memory_order_relaxed);
+    while (previous_max < active &&
+        !max_active_count.compare_exchange_weak(previous_max, active,
+            std::memory_order_relaxed, std::memory_order_relaxed))
+    {
+    }
+
+    if (invocation_count.fetch_add(1, std::memory_order_relaxed) < 16)
+    {
+        hpx::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    active_count.fetch_sub(1, std::memory_order_relaxed);
+}
 
 template <typename LnPolicy, typename ExPolicy, typename IteratorTag>
 void test_remove_copy_if_scheduler(
@@ -97,6 +120,42 @@ void test_remove_copy_if_sender(
         ln_policy, ex_policy, IteratorTag{}, {2, 4, 6}, {});
     test_remove_copy_if_sender_case(
         ln_policy, ex_policy, IteratorTag{}, {1, 3, 5}, {1, 3, 5});
+}
+
+void test_remove_copy_if_sender_parallel()
+{
+    using namespace hpx::execution;
+
+    using scheduler_type =
+        ex::thread_pool_policy_scheduler<hpx::launch::async_policy>;
+
+    constexpr std::size_t count = 65536;
+    std::vector<int> input(count, 1);
+    std::vector<int> output(count, -1);
+    std::atomic<std::size_t> active_count{0};
+    std::atomic<std::size_t> max_active_count{0};
+    std::atomic<std::size_t> invocation_count{0};
+    auto exec =
+        ex::explicit_scheduler_executor(scheduler_type(hpx::launch::async));
+
+    auto sender =
+        ex::just(input.begin(), input.end(), output.begin(),
+            [&active_count, &max_active_count, &invocation_count](int) {
+                record_concurrency(
+                    active_count, max_active_count, invocation_count);
+                return false;
+            }) |
+        hpx::remove_copy_if(par(task).on(exec));
+
+    auto result = tt::sync_wait(std::move(sender));
+    HPX_TEST(result.has_value());
+    if (!result.has_value())
+    {
+        return;
+    }
+
+    HPX_TEST(hpx::get<0>(*result) == output.end());
+    HPX_TEST(max_active_count.load(std::memory_order_relaxed) > 1);
 }
 
 template <typename Exception, typename LnPolicy, typename ExPolicy,
@@ -216,6 +275,7 @@ int hpx_main()
 {
     remove_copy_if_sender_test<std::forward_iterator_tag>();
     remove_copy_if_sender_test<std::random_access_iterator_tag>();
+    test_remove_copy_if_sender_parallel();
     return hpx::local::finalize();
 }
 

--- a/libs/core/algorithms/tests/unit/algorithms/remove_copy_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/remove_copy_sender.cpp
@@ -8,8 +8,11 @@
 #include <hpx/execution.hpp>
 #include <hpx/init.hpp>
 #include <hpx/modules/testing.hpp>
+#include <hpx/modules/threading.hpp>
 
 #include <algorithm>
+#include <atomic>
+#include <chrono>
 #include <cstddef>
 #include <exception>
 #include <iterator>
@@ -24,6 +27,26 @@
 
 namespace ex = hpx::execution::experimental;
 namespace tt = hpx::this_thread::experimental;
+
+void record_concurrency(std::atomic<std::size_t>& active_count,
+    std::atomic<std::size_t>& max_active_count,
+    std::atomic<std::size_t>& invocation_count)
+{
+    std::size_t const active =
+        active_count.fetch_add(1, std::memory_order_relaxed) + 1;
+    std::size_t previous_max = max_active_count.load(std::memory_order_relaxed);
+    while (previous_max < active &&
+        !max_active_count.compare_exchange_weak(previous_max, active,
+            std::memory_order_relaxed, std::memory_order_relaxed))
+    {
+    }
+
+    if (invocation_count.fetch_add(1, std::memory_order_relaxed) < 16)
+    {
+        hpx::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    active_count.fetch_sub(1, std::memory_order_relaxed);
+}
 
 template <typename LnPolicy, typename ExPolicy, typename IteratorTag>
 void test_remove_copy_scheduler(
@@ -94,6 +117,45 @@ void test_remove_copy_sender(
         ln_policy, ex_policy, IteratorTag{}, {2, 2, 2}, {});
     test_remove_copy_sender_case(
         ln_policy, ex_policy, IteratorTag{}, {1, 3, 4}, {1, 3, 4});
+}
+
+void test_remove_copy_sender_parallel()
+{
+    using namespace hpx::execution;
+
+    using base_iterator = std::vector<int>::iterator;
+    using iterator = test::decorated_iterator<base_iterator,
+        std::random_access_iterator_tag>;
+    using scheduler_type =
+        ex::thread_pool_policy_scheduler<hpx::launch::async_policy>;
+
+    constexpr std::size_t count = 65536;
+    std::vector<int> input(count, 1);
+    std::vector<int> output(count, -1);
+    std::atomic<std::size_t> active_count{0};
+    std::atomic<std::size_t> max_active_count{0};
+    std::atomic<std::size_t> invocation_count{0};
+    auto exec =
+        ex::explicit_scheduler_executor(scheduler_type(hpx::launch::async));
+
+    auto sender =
+        ex::just(iterator(input.begin(),
+                     [&active_count, &max_active_count, &invocation_count]() {
+                         record_concurrency(
+                             active_count, max_active_count, invocation_count);
+                     }),
+            iterator(input.end()), output.begin(), 2) |
+        hpx::remove_copy(par(task).on(exec));
+
+    auto result = tt::sync_wait(std::move(sender));
+    HPX_TEST(result.has_value());
+    if (!result.has_value())
+    {
+        return;
+    }
+
+    HPX_TEST(hpx::get<0>(*result) == output.end());
+    HPX_TEST(max_active_count.load(std::memory_order_relaxed) > 1);
 }
 
 template <typename Exception, typename LnPolicy, typename ExPolicy,
@@ -212,6 +274,7 @@ int hpx_main()
 {
     remove_copy_sender_test<std::forward_iterator_tag>();
     remove_copy_sender_test<std::random_access_iterator_tag>();
+    test_remove_copy_sender_parallel();
     return hpx::local::finalize();
 }
 

--- a/libs/core/algorithms/tests/unit/algorithms/remove_copy_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/remove_copy_sender.cpp
@@ -155,7 +155,10 @@ void test_remove_copy_sender_parallel()
     }
 
     HPX_TEST(hpx::get<0>(*result) == output.end());
-    HPX_TEST(max_active_count.load(std::memory_order_relaxed) > 1);
+    if (hpx::get_os_thread_count() > 1)
+    {
+        HPX_TEST(max_active_count.load(std::memory_order_relaxed) > 1);
+    }
 }
 
 template <typename Exception, typename LnPolicy, typename ExPolicy,

--- a/libs/core/algorithms/tests/unit/algorithms/remove_copy_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/remove_copy_sender.cpp
@@ -1,0 +1,229 @@
+//  Copyright (c) 2026 Pratyksh Gupta
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/algorithm.hpp>
+#include <hpx/execution.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <exception>
+#include <iterator>
+#include <new>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "test_utils.hpp"
+
+namespace ex = hpx::execution::experimental;
+namespace tt = hpx::this_thread::experimental;
+
+template <typename LnPolicy, typename ExPolicy, typename IteratorTag>
+void test_remove_copy_scheduler(
+    LnPolicy ln_policy, ExPolicy&& ex_policy, IteratorTag)
+{
+    static_assert(!hpx::is_async_execution_policy_v<ExPolicy>);
+
+    using base_iterator = std::vector<int>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+    using scheduler_type = ex::thread_pool_policy_scheduler<LnPolicy>;
+
+    std::vector<int> input{1, 2, 3, 2, 4};
+    std::vector<int> output(input.size(), -1);
+    auto exec = ex::explicit_scheduler_executor(scheduler_type(ln_policy));
+
+    auto result = hpx::remove_copy(ex_policy.on(exec), iterator(input.begin()),
+        iterator(input.end()), output.begin(), 2);
+    static_assert(std::is_same_v<decltype(result), base_iterator>);
+
+    HPX_TEST(result == output.begin() + 3);
+    std::vector<int> const expected{1, 3, 4};
+    HPX_TEST(std::equal(expected.begin(), expected.end(), output.begin()));
+    HPX_TEST(std::all_of(
+        result, output.end(), [](int value) { return value == -1; }));
+}
+
+template <typename LnPolicy, typename ExPolicy, typename IteratorTag>
+void test_remove_copy_sender_case(LnPolicy ln_policy, ExPolicy&& ex_policy,
+    IteratorTag, std::vector<int> input, std::vector<int> const& expected)
+{
+    static_assert(hpx::is_async_execution_policy_v<ExPolicy>);
+
+    using base_iterator = std::vector<int>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+    using scheduler_type = ex::thread_pool_policy_scheduler<LnPolicy>;
+
+    std::vector<int> output(input.size(), -1);
+    auto exec = ex::explicit_scheduler_executor(scheduler_type(ln_policy));
+
+    auto sender = ex::just(iterator(input.begin()), iterator(input.end()),
+                      output.begin(), 2) |
+        hpx::remove_copy(ex_policy.on(exec));
+    static_assert(ex::is_sender_v<decltype(sender)>);
+
+    auto result = tt::sync_wait(std::move(sender));
+    HPX_TEST(result.has_value());
+    if (!result.has_value())
+    {
+        return;
+    }
+
+    auto const output_end = hpx::get<0>(*result);
+    HPX_TEST(output_end ==
+        output.begin() + static_cast<std::ptrdiff_t>(expected.size()));
+    HPX_TEST(std::equal(expected.begin(), expected.end(), output.begin()));
+    HPX_TEST(std::all_of(
+        output_end, output.end(), [](int value) { return value == -1; }));
+}
+
+template <typename LnPolicy, typename ExPolicy, typename IteratorTag>
+void test_remove_copy_sender(
+    LnPolicy ln_policy, ExPolicy&& ex_policy, IteratorTag)
+{
+    test_remove_copy_sender_case(
+        ln_policy, ex_policy, IteratorTag{}, {1, 2, 3, 2, 4}, {1, 3, 4});
+    test_remove_copy_sender_case(ln_policy, ex_policy, IteratorTag{}, {}, {});
+    test_remove_copy_sender_case(
+        ln_policy, ex_policy, IteratorTag{}, {2, 2, 2}, {});
+    test_remove_copy_sender_case(
+        ln_policy, ex_policy, IteratorTag{}, {1, 3, 4}, {1, 3, 4});
+}
+
+template <typename Exception, typename LnPolicy, typename ExPolicy,
+    typename IteratorTag>
+void test_remove_copy_sender_exception(
+    LnPolicy ln_policy, ExPolicy&& ex_policy, IteratorTag)
+{
+    static_assert(hpx::is_async_execution_policy_v<ExPolicy>);
+
+    using base_iterator = std::vector<int>::iterator;
+    using iterator = test::decorated_iterator<base_iterator, IteratorTag>;
+    using scheduler_type = ex::thread_pool_policy_scheduler<LnPolicy>;
+
+    std::vector<int> input{1, 2, 3, 4};
+    std::vector<int> output(input.size());
+    auto exec = ex::explicit_scheduler_executor(scheduler_type(ln_policy));
+
+    bool caught_expected_exception = false;
+    try
+    {
+        tt::sync_wait(ex::just(iterator(input.begin(),
+                                   []() {
+                                       if constexpr (std::is_same_v<Exception,
+                                                         std::runtime_error>)
+                                       {
+                                           throw std::runtime_error("test");
+                                       }
+                                       else
+                                       {
+                                           throw std::bad_alloc();
+                                       }
+                                   }),
+                          iterator(input.end()), output.begin(), 2) |
+            hpx::remove_copy(ex_policy.on(exec)));
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& errors)
+    {
+        if constexpr (std::is_same_v<Exception, std::runtime_error>)
+        {
+            test::test_num_exceptions<ExPolicy, IteratorTag>::call(
+                ex_policy, errors);
+
+            bool all_exceptions_expected = errors.begin() != errors.end();
+            for (std::exception_ptr const& error : errors)
+            {
+                bool is_expected_exception = false;
+                try
+                {
+                    std::rethrow_exception(error);
+                }
+                catch (std::runtime_error const&)
+                {
+                    is_expected_exception = true;
+                }
+                catch (...)
+                {
+                    is_expected_exception = false;
+                }
+                all_exceptions_expected =
+                    all_exceptions_expected && is_expected_exception;
+            }
+            HPX_TEST(all_exceptions_expected);
+            caught_expected_exception = all_exceptions_expected;
+        }
+        else
+        {
+            HPX_TEST(false);
+        }
+    }
+    catch (Exception const&)
+    {
+        if constexpr (std::is_same_v<Exception, std::bad_alloc>)
+        {
+            caught_expected_exception = true;
+        }
+        else
+        {
+            HPX_TEST(false);
+        }
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+
+    HPX_TEST(caught_expected_exception);
+}
+
+template <typename IteratorTag>
+void remove_copy_sender_test()
+{
+    using namespace hpx::execution;
+
+    test_remove_copy_scheduler(hpx::launch::sync, seq, IteratorTag{});
+    test_remove_copy_scheduler(hpx::launch::sync, unseq, IteratorTag{});
+    test_remove_copy_scheduler(hpx::launch::async, par, IteratorTag{});
+    test_remove_copy_scheduler(hpx::launch::async, par_unseq, IteratorTag{});
+
+    test_remove_copy_sender(hpx::launch::sync, seq(task), IteratorTag{});
+    test_remove_copy_sender(hpx::launch::sync, unseq(task), IteratorTag{});
+    test_remove_copy_sender(hpx::launch::async, par(task), IteratorTag{});
+    test_remove_copy_sender(hpx::launch::async, par_unseq(task), IteratorTag{});
+
+    test_remove_copy_sender_exception<std::runtime_error>(
+        hpx::launch::sync, seq(task), IteratorTag{});
+    test_remove_copy_sender_exception<std::runtime_error>(
+        hpx::launch::async, par(task), IteratorTag{});
+    test_remove_copy_sender_exception<std::bad_alloc>(
+        hpx::launch::sync, seq(task), IteratorTag{});
+    test_remove_copy_sender_exception<std::bad_alloc>(
+        hpx::launch::async, par(task), IteratorTag{});
+}
+
+int hpx_main()
+{
+    remove_copy_sender_test<std::forward_iterator_tag>();
+    remove_copy_sender_test<std::random_access_iterator_tag>();
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    hpx::local::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
## Proposed Changes

 - Add sender/receiver support for hpx::remove_copy and hpx::remove_copy_if with scheduler-backed execution policies.
 - Preserve synchronous iterator returns for non-task scheduler policies and sender returns for task policies.
 - Add tests covering returned iterators, empty/all/none matching ranges, iterator categories, hpx::exception_list, and direct std::bad_alloc propagation.

## Any background context you want to provide?

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
