### PR TITLE
Adding helper simplifying to launch a connecting locality

### DIFF
--- a/components/process/CMakeLists.txt
+++ b/components/process/CMakeLists.txt
@@ -108,7 +108,9 @@ else()
   )
 endif()
 
-set(process_sources server/child_component.cpp process.cpp)
+set(process_sources server/child_component.cpp launch_connecting_locality.cpp
+                    process.cpp
+)
 
 if(WIN32)
   set(process_sources

--- a/components/process/include/hpx/components/process/process.hpp
+++ b/components/process/include/hpx/components/process/process.hpp
@@ -12,8 +12,12 @@
 
 #include <hpx/components/process/child.hpp>
 
+#include <cstdint>
+#include <optional>
+#include <string>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 namespace hpx::components::process {
 
@@ -23,4 +27,59 @@ namespace hpx::components::process {
     {
         return hpx::new_<child>(id, HPX_FORWARD(Ts, ts)...);
     }
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// \brief Launch an executable as a new HPX locality that connects to the
+    ///        currently running (bootstrap) locality via TCP.
+    ///
+    /// This function spawns \p to_launch as a child process configured to join
+    /// the calling HPX runtime as an additional, connecting locality. It forces
+    /// the TCP parcelport for bootstrapping, forwards AGAS server address/port
+    /// information from the current runtime's configuration, lets the operating
+    /// system pick an ephemeral parcel port for the new locality, and blocks
+    /// the caller until the spawned locality signals that it has finished
+    /// starting up (via a named latch derived from the executable name and,
+    /// optionally,
+    /// \p spawn_id).
+    ///
+    /// \param to_launch  Path to the executable to launch as the connecting
+    ///                    locality.
+    /// \param outer_args Additional command-line arguments appended after the
+    ///                    mandatory HPX bootstrap arguments
+    ///                    (`--hpx:ignore-batch-env`,
+    ///                    `--hpx:ini=hpx.parcel.tcp.priority=1000`,
+    ///                    `--hpx:ini=hpx.parcel.bootstrap=tcp`). Defaults to an
+    ///                    empty list.
+    /// \param outer_env  Additional environment variable entries in
+    ///                    `"NAME=value"` form (or just `"NAME"` to set an empty
+    ///                    value) that are merged into (and override) the
+    ///                    inherited environment before launching the child
+    ///                    process. Defaults to an empty list.
+    /// \param spawn_id   Optional identifier used to disambiguate the startup
+    ///                    latch name when multiple instances of the same
+    ///                    executable are launched concurrently. When present,
+    ///                    the latch name is `"<exe-stem>/<spawn_id>"`;
+    ///                    otherwise it is just `"<exe-stem>"`.
+    ///
+    /// \returns A \c child object representing the launched connecting-locality
+    ///          process, once it has signaled startup completion.
+    ///
+    /// \throws hpx::exception (or a derived type) if the child process could
+    ///         not be started (\c process::throw_on_error() is used).
+    ///
+    /// \note The following environment variables are set (overriding any
+    ///       inherited values) before launching:
+    ///       - `HPX_AGAS_SERVER_ADDRESS` / `HPX_AGAS_SERVER_PORT` ? taken from
+    ///         the current runtime's `hpx.agas.address` / `hpx.agas.port`
+    ///         configuration entries.
+    ///       - `HPX_PARCEL_SERVER_ADDRESS` ? same address as the AGAS server.
+    ///       - `HPX_PARCEL_SERVER_PORT` ? set to `"0"` so the OS assigns an
+    ///         ephemeral port.
+    ///       - `HPX_ON_STARTUP_WAIT_ON_LATCH` ? the startup latch name
+    ///         described above, used to synchronize with the caller.
+    HPX_PROCESS_EXPORT child launch_connecting_locality(
+        std::string const& to_launch,
+        std::vector<std::string> const& outer_args = {},
+        std::vector<std::string> const& outer_env = {},
+        std::optional<std::uint64_t> spawn_id = nullopt);
 }    // namespace hpx::components::process

--- a/components/process/src/launch_connecting_locality.cpp
+++ b/components/process/src/launch_connecting_locality.cpp
@@ -1,0 +1,152 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/modules/filesystem.hpp>
+#include <hpx/modules/runtime_distributed.hpp>
+#include <hpx/modules/runtime_local.hpp>
+
+#include <hpx/components/process/child.hpp>
+#include <hpx/components/process/process.hpp>
+#include <hpx/components/process/util/initializers.hpp>
+
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace {
+
+    ///////////////////////////////////////////////////////////////////////////////
+    int get_arraylen(char** arr)
+    {
+        int count = 0;
+        if (nullptr != arr)
+        {
+            while (nullptr != arr[count])
+                ++count;    // simply count the strings
+        }
+        return count;
+    }
+
+    std::vector<std::string> get_environment()
+    {
+        std::vector<std::string> env;
+#if defined(HPX_WINDOWS)
+        int const len = get_arraylen(_environ);
+        std::copy(&_environ[0], &_environ[len], std::back_inserter(env));
+#elif defined(linux) || defined(__linux) || defined(__linux__) ||              \
+    defined(__AIX__) || defined(__APPLE__) || defined(__FreeBSD__)
+        int const len = get_arraylen(environ);
+        std::copy(&environ[0], &environ[len], std::back_inserter(env));
+#else
+#error "Don't know, how to access the execution environment on this platform"
+#endif
+        return env;
+    }
+
+    // Replace any inherited entry for the given name. The environment is handed to
+    // execve verbatim and getenv returns the first match, so appending alone would
+    // leave an inherited entry shadowing the value set here.
+    void set_env_var(std::vector<std::string>& env, std::string const& name,
+        std::string const& value)
+    {
+        std::string const prefix = name + "=";
+
+        env.erase(std::ranges::remove_if(env,
+                      [&prefix](std::string const& entry) {
+                          return entry.starts_with(prefix);
+                      })
+                      .begin(),
+            env.end());
+
+        env.push_back(prefix + value);
+    }
+
+}    // namespace
+
+namespace hpx::components::process {
+
+    // Launch the given executable as a connecting HPX locality
+    child launch_connecting_locality(std::string const& to_launch,
+        std::vector<std::string> const& outer_args,
+        std::vector<std::string> const& outer_env,
+        std::optional<std::uint64_t> spawn_id)
+    {
+        hpx::filesystem::path const exe(to_launch);
+
+        std::vector<std::string> args;
+        args.emplace_back(hpx::filesystem::to_string(exe));
+        args.emplace_back("--hpx:ignore-batch-env");
+        args.emplace_back("--hpx:run-hpx-main");
+
+        // Force use of the TCP parcelport, which is the one that binds a port.
+        args.emplace_back("--hpx:ini=hpx.parcel.tcp.priority=1000");
+        args.emplace_back("--hpx:ini=hpx.parcel.bootstrap=tcp");
+
+        // optionally pass additional arguments
+        args.insert(args.end(), outer_args.begin(), outer_args.end());
+
+        std::string const address =
+            hpx::get_config_entry("hpx.agas.address", HPX_INITIAL_IP_ADDRESS);
+
+        std::vector<std::string> env = get_environment();
+
+        // optionally pass additional environment entries first
+        std::ranges::for_each(outer_env, [&](std::string const& e) {
+            if (std::size_t const pos = e.find('='); pos != std::string::npos)
+            {
+                set_env_var(env, e.substr(0, pos), e.substr(pos + 1));
+            }
+            else
+            {
+                set_env_var(env, e, "");
+            }
+        });
+
+        // Apply launcher-managed values last.
+        set_env_var(env, "HPX_AGAS_SERVER_ADDRESS", address);
+        set_env_var(env, "HPX_AGAS_SERVER_PORT",
+            hpx::get_config_entry(
+                "hpx.agas.port", std::to_string(HPX_INITIAL_IP_PORT)));
+
+        // Hand the launched locality port 0 and let the operating system pick.
+        // it registered.
+        set_env_var(env, "HPX_PARCEL_SERVER_ADDRESS", address);
+        set_env_var(env, "HPX_PARCEL_SERVER_PORT", "0");
+
+        std::string stem(hpx::filesystem::to_string(exe.stem()));
+        if (spawn_id.has_value())
+        {
+            stem += "/" + std::to_string(*spawn_id);
+        }
+        else
+        {
+            // Ensure every launch without an explicit spawn_id still gets a
+            // unique latch name, avoiding collisions between concurrent
+            // launches of the same executable.
+            static std::atomic<std::uint64_t> next_launch_id{0};
+            stem += "/" + std::to_string(next_launch_id++);
+        }
+        set_env_var(env, "HPX_ON_STARTUP_WAIT_ON_LATCH", stem);
+
+        // clang-format off
+        process::child c = process::execute(hpx::find_here(),
+            process::run_exe(hpx::filesystem::to_string(to_launch)),
+            process::set_args(args),
+            process::set_env(env),
+            process::start_in_dir(
+                hpx::filesystem::to_string(exe.parent_path())),
+            process::throw_on_error(),
+            process::wait_on_latch(stem));
+        // clang-format on
+
+        return c;
+    }
+}    // namespace hpx::components::process

--- a/components/process/tests/unit/CMakeLists.txt
+++ b/components/process/tests/unit/CMakeLists.txt
@@ -1,5 +1,49 @@
-# Copyright (c) 2019 The STE||AR-Group
+# Copyright (c) 2019-2026 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests)
+
+if(HPX_WITH_NETWORKING AND HPX_WITH_PARCELPORT_TCP)
+
+  set(tests ${tests} launch_connecting_locality)
+  set(folder_name "Tests/Unit/Components/Process")
+
+  # add executable needed for the launch_connecting_locality test
+  add_hpx_executable(
+    worker_connecting_locality INTERNAL_FLAGS
+    SOURCES worker_connecting_locality.cpp
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER ${folder_name}
+  )
+
+  set(launch_connecting_locality_FLAGS DEPENDENCIES process_component)
+  set(launch_connecting_locality_PARAMETERS
+      RUN_SERIAL --launch=$<TARGET_FILE:worker_connecting_locality>
+      # Force use of the TCP parcelport
+      --hpx:ini=hpx.parcel.tcp.priority=1000 --hpx:ini=hpx.parcel.bootstrap=tcp
+  )
+
+  foreach(test ${tests})
+    set(sources ${test}.cpp)
+    source_group("Source Files" FILES ${sources})
+    set(folder_name "Tests/Unit/Components/Process")
+
+    add_hpx_executable(
+      ${test}_test INTERNAL_FLAGS
+      SOURCES ${sources} ${${test}_FLAGS}
+      EXCLUDE_FROM_ALL
+      HPX_PREFIX ${HPX_BUILD_PREFIX}
+      FOLDER ${folder_name}
+    )
+    add_hpx_unit_test("components.process" ${test} ${${test}_PARAMETERS})
+  endforeach()
+
+  add_hpx_pseudo_dependencies(
+    tests.unit.components.process.launch_connecting_locality
+    worker_connecting_locality
+  )
+endif()

--- a/components/process/tests/unit/launch_connecting_locality.cpp
+++ b/components/process/tests/unit/launch_connecting_locality.cpp
@@ -1,0 +1,93 @@
+//  Copyright (c) 2026 The STE||AR-Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// This test verifies that hpx::components::process::launch_connecting_locality
+// can be used to launch a new locality that connects back to this (bootstrap)
+// locality, and that it is properly removed from AGAS again once it
+// disconnects.
+
+#include <hpx/config.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/process.hpp>
+#include <hpx/modules/filesystem.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <chrono>
+#include <cstddef>
+#include <string>
+#include <vector>
+
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    namespace process = hpx::components::process;
+    namespace fs = hpx::filesystem;
+
+    // find where the HPX core libraries are located
+    fs::path base_dir = hpx::util::find_prefix();
+    base_dir /= "bin";
+
+    fs::path exe =
+        base_dir / "worker_connecting_locality" HPX_EXECUTABLE_EXTENSION;
+
+    if (vm.count("launch"))
+        exe = vm["launch"].as<std::string>();
+
+    std::size_t const before = hpx::find_all_localities().size();
+
+    // Launch the worker as a connecting locality; this blocks (via an
+    // internally-managed startup latch) until the worker has connected back.
+    process::child c =
+        process::launch_connecting_locality(hpx::filesystem::to_string(exe));
+
+    c.wait();
+    HPX_TEST(c);
+
+    // the launched executable should have connected back as a new locality
+    HPX_TEST(hpx::find_all_localities().size() > before);
+
+    // wait for the worker to exit, it disconnects and returns 0
+    int const exit_code = c.wait_for_exit(hpx::launch::sync);
+    HPX_TEST_EQ(exit_code, 0);
+
+    // disconnect() on the worker side deregisters it from AGAS, but that is
+    // not synchronously reflected here, so poll (bounded) until it is.
+    for (std::size_t i = 0; i != 100; ++i)
+    {
+        if (hpx::find_all_localities().size() == before)
+            break;
+        hpx::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    HPX_TEST_EQ(hpx::find_all_localities().size(), before);
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("launch,l", value<std::string>(),
+        "the worker executable that will be launched and connect back");
+
+    std::vector<std::string> const cfg = {
+        "hpx.expect_connecting_localities!=1"};
+
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::init(argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}
+
+#endif

--- a/components/process/tests/unit/worker_connecting_locality.cpp
+++ b/components/process/tests/unit/worker_connecting_locality.cpp
@@ -1,0 +1,32 @@
+//  Copyright (c) 2026 The STE||AR-Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Helper for the launch_connecting_locality unit test. This executable connects
+// to the running test as a new locality and disconnects gracefully.
+
+#include <hpx/config.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+
+int hpx_main()
+{
+    hpx::disconnect();
+    return 0;
+}
+
+int main(int argc, char* argv[])
+{
+    // Note: this uses runtime_mode::connect to instruct this locality to
+    // connect to the existing HPX application.
+    hpx::init_params init_args;
+    init_args.mode = hpx::runtime_mode::connect;
+
+    return hpx::init(argc, argv, init_args);
+}
+
+#endif

--- a/components/supervision_dispatch/examples/late_component_launcher.cpp
+++ b/components/supervision_dispatch/examples/late_component_launcher.cpp
@@ -101,37 +101,6 @@ namespace {
     using set_message_action =
         late_component::server::test_server::set_message_action;
 
-    // Copies this process's current environment, exactly as launch_process.cpp
-    // and os_assigned_parcelport_port_7406.cpp do, so it can be handed to
-    // process::set_env() with a few HPX_* entries appended for the spawned
-    // worker below.
-    inline int get_arraylen(char** arr)
-    {
-        int count = 0;
-        if (nullptr != arr)
-        {
-            while (nullptr != arr[count])
-                ++count;
-        }
-        return count;
-    }
-
-    std::vector<std::string> get_environment()
-    {
-        std::vector<std::string> env;
-#if defined(HPX_WINDOWS)
-        int len = get_arraylen(_environ);
-        std::copy(&_environ[0], &_environ[len], std::back_inserter(env));
-#elif defined(linux) || defined(__linux) || defined(__linux__) ||              \
-    defined(__AIX__) || defined(__APPLE__) || defined(__FreeBSD__)
-        int len = get_arraylen(environ);
-        std::copy(&environ[0], &environ[len], std::back_inserter(env));
-#else
-#error "Don't know, how to access the execution environment on this platform"
-#endif
-        return env;
-    }
-
     // ========================================================================
     // Task 4a: spawn_worker()/worker_slot/task scaffolding.
     // ========================================================================
@@ -184,8 +153,8 @@ namespace {
     // Assumes success throughout (see the "Explicit non-goals" paragraph in the
     // file comment above): a process launch failure here is not handled and
     // simply propagates out of this function.
-    worker_slot spawn_worker(
-        hpx::supervision::registry const& handle, bool use_failing_variant)
+    worker_slot spawn_worker(hpx::supervision::registry const& handle,
+        bool const use_failing_variant)
     {
         namespace process = hpx::components::process;
         namespace fs = hpx::filesystem;
@@ -206,45 +175,13 @@ namespace {
                     "late_component_worker" HPX_EXECUTABLE_EXTENSION);
 
         std::vector<std::string> args;
-        args.push_back(fs::to_string(exe));
-        args.push_back("--hpx:ignore-batch-env");
         args.push_back("--hpx:threads=1");
-
-        // Force use of the TCP parcelport, mirroring launch_process.cpp/
-        // os_assigned_parcelport_port_7406.cpp.
-        args.push_back("--hpx:ini=hpx.parcel.tcp.priority=1000");
-        args.push_back("--hpx:ini=hpx.parcel.bootstrap=tcp");
-
-        std::vector<std::string> env = get_environment();
-
-        std::string const address =
-            hpx::get_config_entry("hpx.agas.address", HPX_INITIAL_IP_ADDRESS);
-
-        env.push_back("HPX_AGAS_SERVER_ADDRESS=" + address);
-        env.push_back("HPX_AGAS_SERVER_PORT=" +
-            hpx::get_config_entry(
-                "hpx.agas.port", std::to_string(HPX_INITIAL_IP_PORT)));
-
-        // Let the operating system choose the parcelport port (mirroring
-        // os_assigned_parcelport_port_7406.cpp) rather than tracking
-        // previously-used ports ourselves -- every respawn needs a fresh,
-        // unused port, and an unbounded number of respawns can happen over this
-        // root's lifetime.
-        env.push_back("HPX_PARCEL_SERVER_ADDRESS=" + address);
-        env.push_back("HPX_PARCEL_SERVER_PORT=0");
-
-        std::string const latch_name =
-            "late_component_launcher/spawn/" + std::to_string(spawn_id);
-        env.push_back("HPX_ON_STARTUP_WAIT_ON_LATCH=" + latch_name);
 
         std::vector<hpx::id_type> const localities_before =
             hpx::find_remote_localities();
 
-        process::child c = process::execute(hpx::find_here(),
-            process::run_exe(fs::to_string(exe)), process::set_args(args),
-            process::set_env(env),
-            process::start_in_dir(fs::to_string(base_dir)),
-            process::throw_on_error(), process::wait_on_latch(latch_name));
+        process::child c =
+            process::launch_connecting_locality(fs::to_string(exe), args, {}, spawn_id);
 
         // Waits for the spawned locality to actually connect back.
         c.wait();
@@ -311,9 +248,9 @@ namespace {
         // finalize() (see late_component_failing_worker.cpp) - so the
         // fencing/retry/respawn path below is actually exercised rather than
         // only ever taking the success path.
-        worker_slots.push_back(
+        worker_slots.emplace_back(
             spawn_worker(handle, /* use_failing_variant */ false));
-        worker_slots.push_back(
+        worker_slots.emplace_back(
             spawn_worker(handle, /* use_failing_variant */ true));
 
         std::deque<task> queue;
@@ -429,7 +366,7 @@ int hpx_main()
     return hpx::finalize();
 }
 
-int main(int argc, char* argv[])
+int main(int const argc, char* argv[])
 {
     // Mirrors launch_process.cpp: this locality expects other localities (the
     // workers spawned by spawn_worker() above) to dynamically connect to it


### PR DESCRIPTION
## Summary

Adds a reusable **connecting-locality launcher** to the `process` component, extracting duplicated boilerplate for spawning HPX localities that connect back to a running (bootstrap) locality, and integrates it into the supervision-dispatch worker-spawn example.

### Changes

**New API — `hpx::components::process::launch_connecting_locality`**
(`components/process/include/hpx/components/process/process.hpp`,
`components/process/src/launch_connecting_locality.cpp`)
- New exported function that launches an executable as a new connecting HPX locality via TCP.
- Automatically:
  - Forces the TCP parcelport for bootstrapping (`--hpx:ignore-batch-env`, `hpx.parcel.tcp.priority=1000`, `hpx.parcel.bootstrap=tcp`).
  - Forwards AGAS server address/port from the current runtime's configuration.
  - Lets the OS assign an ephemeral parcel port for the new locality (`HPX_PARCEL_SERVER_PORT=0`).
  - Sets `HPX_ON_STARTUP_WAIT_ON_LATCH` and blocks until the child signals startup completion.
- Accepts optional extra CLI args (`outer_args`), extra environment entries (`outer_env`), and an optional `spawn_id` used to disambiguate the startup-latch name for concurrent launches of the same executable.
- Throws on launch failure (`process::throw_on_error()`).

**Build wiring**
(`components/process/CMakeLists.txt`)
- Adds `launch_connecting_locality.cpp` to `process_sources`.

**Worker integration**
(`components/supervision_dispatch/examples/late_component_launcher.cpp`)
- Replaces the hand-rolled environment-copy helpers (`get_arraylen`, `get_environment`) and manual `process::execute(...)` setup in `spawn_worker()` with a single call to `process::launch_connecting_locality(...)`.
- Minor cleanups: `bool const use_failing_variant`, `worker_slots.emplace_back(...)` instead of `push_back`, `int const argc` in `main`.

**Test coverage**
(`components/process/tests/unit/launch_connecting_locality.cpp`,
`components/process/tests/unit/worker_connecting_locality.cpp`,
`components/process/tests/unit/CMakeLists.txt`)
- New unit test exercising `launch_connecting_locality` directly.
- New worker-side test binary used as the connecting-locality target, verifying locality registration and clean removal.
- CMake wiring to build/register the new test targets.

### Notes for reviewers
- This is largely a refactor (extract-and-reuse) of previously duplicated launch logic in `late_component_launcher.cpp`, now centralized behind a documented, tested API in the `process` component.
- Behavior of the worker-spawn flow in the supervision-dispatch example should be unchanged; only the implementation path differs.

