### PR TITLE
async_distributed: add C++26 reflection overloads for sync, post, async_cb, post_cb

### DIFF
--- a/libs/full/async_distributed/include/hpx/async_distributed/async_callback.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/async_callback.hpp
@@ -268,4 +268,31 @@ namespace hpx {
         return detail::async_cb_dispatch<std::decay_t<F>>::call(
             HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
     }
+#if defined(HPX_HAVE_CXX26_REFLECTION)
+    /// \brief Reflection-based async_cb overload.
+    ///
+    /// Allows calling hpx::async_cb<^^func>(target, callback, ...) directly
+    /// without defining an explicit action type. Internally constructs
+    /// reflect_action<F> and delegates to the existing async_cb machinery.
+    ///
+    /// \tparam F        A std::meta::info reflection of a free function.
+    /// \tparam Target   id_type, client, or distribution policy.
+    /// \tparam Callback Callback type invoked on completion.
+    /// \tparam Ts       Additional arguments to pass to the function.
+    // clang-format off
+    HPX_CXX_EXPORT template <std::meta::info F, typename Target,
+        typename Callback, typename... Ts>
+        requires(std::meta::is_namespace_member(F) && std::meta::is_function(F) &&
+            (std::is_same_v<std::decay_t<Target>, hpx::id_type> ||
+                hpx::traits::is_client_v<std::decay_t<Target>> ||
+                hpx::traits::is_distribution_policy_v<std::decay_t<Target>>))
+    HPX_FORCEINLINE auto async_cb(
+        Target&& target, Callback&& cb, Ts&&... ts)
+    // clang-format on
+    {
+        return hpx::async_cb(hpx::actions::reflect_action<F>{},
+            HPX_FORWARD(Target, target), HPX_FORWARD(Callback, cb),
+            HPX_FORWARD(Ts, ts)...);
+    }
+#endif    // HPX_HAVE_CXX26_REFLECTION
 }    // namespace hpx

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/post_callback.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/post_callback.hpp
@@ -500,4 +500,31 @@ namespace hpx {
     {
         return hpx::post_c_cb<Action>(HPX_FORWARD(Ts, ts)...);
     }
+#if defined(HPX_HAVE_CXX26_REFLECTION)
+    /// \brief Reflection-based post_cb overload.
+    ///
+    /// Allows calling hpx::post_cb<^^func>(target, callback, ...) directly
+    /// without defining an explicit action type. Internally constructs
+    /// reflect_action<F> and delegates to the existing post_cb machinery.
+    ///
+    /// \tparam F        A std::meta::info reflection of a free function.
+    /// \tparam Target   id_type or distribution policy.
+    /// \tparam Callback Callback type invoked on completion.
+    /// \tparam Ts       Additional arguments to pass to the function.
+    // clang-format off
+    HPX_CXX_EXPORT template <std::meta::info F, typename Target,
+        typename Callback, typename... Ts>
+        requires(std::meta::is_namespace_member(F) &&
+            std::meta::is_function(F) &&
+            (std::is_same_v<std::decay_t<Target>, hpx::id_type> ||
+                hpx::traits::is_distribution_policy_v<std::decay_t<Target>>))
+    HPX_FORCEINLINE bool post_cb(
+        Target&& target, Callback&& cb, Ts&&... ts)
+    // clang-format on
+    {
+        return hpx::post_cb(hpx::actions::reflect_action<F>{},
+            HPX_FORWARD(Target, target), HPX_FORWARD(Callback, cb),
+            HPX_FORWARD(Ts, ts)...);
+    }
+#endif    // HPX_HAVE_CXX26_REFLECTION
 }    // namespace hpx

--- a/libs/full/async_distributed/include/hpx/async_distributed/post.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/post.hpp
@@ -62,3 +62,33 @@ namespace hpx::detail {
 }    // namespace hpx::detail
 
 #endif
+
+#if defined(HPX_HAVE_CXX26_REFLECTION)
+#include <hpx/actions_base/reflect_action.hpp>
+
+namespace hpx {
+
+    /// \brief Reflection-based post overload.
+    ///
+    /// Allows calling hpx::post<^^func>(target, ...) directly without
+    /// defining an explicit action type. Internally constructs
+    /// reflect_action<F> and delegates to the existing post machinery.
+    ///
+    /// \tparam F      A std::meta::info reflection of a free function.
+    /// \tparam Target id_type, client, or distribution policy.
+    /// \tparam Ts     Additional arguments to pass to the function.
+    // clang-format off
+    HPX_CXX_EXPORT template <std::meta::info F, typename Target, typename... Ts>
+        requires(std::meta::is_namespace_member(F) && std::meta::is_function(F) &&
+            (std::is_same_v<std::decay_t<Target>, hpx::id_type> ||
+                hpx::traits::is_client_v<std::decay_t<Target>> ||
+                hpx::traits::is_distribution_policy_v<std::decay_t<Target>>))
+    HPX_FORCEINLINE bool post(Target&& target, Ts&&... ts)
+    // clang-format on
+    {
+        return hpx::post(hpx::actions::reflect_action<F>{},
+            HPX_FORWARD(Target, target), HPX_FORWARD(Ts, ts)...);
+    }
+
+}    // namespace hpx
+#endif    // HPX_HAVE_CXX26_REFLECTION

--- a/libs/full/async_distributed/include/hpx/async_distributed/sync.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/sync.hpp
@@ -185,6 +185,29 @@ namespace hpx {
         return detail::sync_action_dispatch<Action, std::decay_t<F>>::call(
             HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
     }
+#if defined(HPX_HAVE_CXX26_REFLECTION)
+    /// \brief Reflection-based sync overload.
+    ///
+    /// Allows calling hpx::sync<^^func>(target, ...) directly without
+    /// defining an explicit action type. Internally constructs
+    /// reflect_action<F> and delegates to the existing sync machinery.
+    ///
+    /// \tparam F      A std::meta::info reflection of a free function.
+    /// \tparam Target id_type, client, or distribution policy.
+    /// \tparam Ts     Additional arguments to pass to the function.
+    // clang-format off
+    HPX_CXX_EXPORT template <std::meta::info F, typename Target, typename... Ts>
+        requires(std::meta::is_namespace_member(F) && std::meta::is_function(F) &&
+            (std::is_same_v<std::decay_t<Target>, hpx::id_type> ||
+                hpx::traits::is_client_v<std::decay_t<Target>> ||
+                hpx::traits::is_distribution_policy_v<std::decay_t<Target>>))
+    HPX_FORCEINLINE auto sync(Target&& target, Ts&&... ts)
+    // clang-format on
+    {
+        return hpx::sync<hpx::actions::reflect_action<F>>(
+            HPX_FORWARD(Target, target), HPX_FORWARD(Ts, ts)...);
+    }
+#endif    // HPX_HAVE_CXX26_REFLECTION
 }    // namespace hpx
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary

Adds reflection-based overloads of `hpx::sync<^^func>`, `hpx::post<^^func>`,
`hpx::async_cb<^^func>`, and `hpx::post_cb<^^func>` following the same
pattern as `hpx::async<^^func>` from #7376.

## Before / After

```cpp
// Before (explicit action type):
hpx::sync<my_action>(target, args...);
hpx::post(my_action{}, target, args...);
hpx::async_cb<my_action>(target, cb, args...);
hpx::post_cb<my_action>(target, cb, args...);

// After (C++26 reflection):
hpx::sync<^^my_function>(target, args...);
hpx::post<^^my_function>(target, args...);
hpx::async_cb<^^my_function>(target, cb, args...);
hpx::post_cb<^^my_function>(target, cb, args...);
```

## Design

All four overloads follow the exact same pattern as `hpx::async<^^func>`:
- Constrained with `requires(std::meta::is_namespace_member(F) && std::meta::is_function(F))`
- Forward to existing machinery via `reflect_action<F>{}`
- Guarded by `HPX_HAVE_CXX26_REFLECTION`

## Related

Requested by @hkaiser. Completes the reflection API for all distributed dispatch variants.
Builds on #7298, #7376.