### PR TITLE
Fix cpp-dependencies parser crash by removing quotes in comments

### DIFF
--- a/libs/full/async_distributed/tests/unit/CMakeLists.txt
+++ b/libs/full/async_distributed/tests/unit/CMakeLists.txt
@@ -70,8 +70,8 @@ if(HPX_WITH_COMPILE_ONLY_TESTS)
   # Verifies that the managed_component_dtor_policy specialization for
   # promise_lco correctly resolves to managed_object_is_lifetime_controlled.
   # Without the 'void' second template argument fix this static_assert fails
-  # (clang: "too few template arguments for class template
-  # 'managed_component_dtor_policy'").
+  # with clang reporting too few template arguments for class template
+  # managed_component_dtor_policy.
   set(compile_tests promise_lco_dtor_policy)
 
   foreach(compile_test ${compile_tests})


### PR DESCRIPTION
Fixes #

## Proposed Changes

- removed brackets () and quotes "" in comments from CMakeLists.txt to avoid crashing the CI pipeline 

## Any background context you want to provide?
so the cpp-dependencies workflow has a naive parser bug. if we look at the ReadCmakelist function in Input.cpp of the tomtom tool , it checks if the first character of a line is # to ignore comments. but since our comment was indented, the first character was actually ' ' (a space), so it read the comment as normal code.

then the quote-stripping logic messed up because of the " spanning multiple lines. it ended up deleting the closing bracket ) but kept the opening one (. this desynced the parenLevel counter and caused it to core dump with Assertion 'parenLevel == 0 ...' failed

i tested locally by building docker and running the CI container based on the file in `.github/workflows/check-circular-deps.yml` 

```bash
docker run --rm -v $(pwd):/workspace -w /workspace stellargroup/build_env:17 bash -c " \
  cpp-dependencies \
    --dir libs \
    --ignore \$(find libs -type d -wholename '*/include_compatibility' | cut -d'/' -f2-) \
    --graph-cycles /tmp/circular_deps.dot \
  && cat /tmp/circular_deps.dot"
```
```output
No files specified to ignore?
digraph dependencies {
}
```

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
