### PR TITLE
Refactor run_on_all reduction algorithm to use P2300 sender/receiver

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/run_on_all.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/run_on_all.hpp
@@ -20,6 +20,7 @@
 #include <hpx/parallel/algorithms/for_loop_reduction.hpp>
 
 #include <cstddef>
+#include <exception>
 #include <memory>
 #include <tuple>
 #include <type_traits>

--- a/libs/core/algorithms/include/hpx/parallel/run_on_all.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/run_on_all.hpp
@@ -161,10 +161,10 @@ namespace hpx::experimental {
                     {
                         HPX_INVOKE(cleanup_error);
                     }
+                    // NOLINTNEXTLINE(bugprone-empty-catch)
                     catch (...)
                     {
-                        // Suppress secondary exceptions during cleanup to
-                        // strictly preserve the primary bulk execution error
+                        // silently swallow secondary exceptions during cleanup
                     }
                     return ex::just_error(HPX_MOVE(ep));
                 }) |

--- a/libs/core/algorithms/include/hpx/parallel/run_on_all.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/run_on_all.hpp
@@ -35,21 +35,16 @@ namespace hpx::experimental {
         decltype(auto) run_on_all(
             ExPolicy&& policy, F&& f, Reductions&&... reductions)
         {
-            // force using index_queue scheduler with given amount of threads
-            hpx::threads::thread_schedule_hint hint;
-            hint.sharing_mode(
-                hpx::threads::thread_sharing_hint::do_not_share_function);
-
             auto cores =
                 hpx::execution::experimental::processing_units_count(policy);
 
-            // Create executor with proper configuration
-            auto exec =
+            // Create scheduler with proper core count configuration
+            auto sched =
                 hpx::execution::experimental::with_processing_units_count(
-                    hpx::execution::parallel_executor(
-                        hpx::threads::thread_priority::bound,
-                        hpx::threads::thread_stacksize::default_, hint),
+                    hpx::execution::experimental::thread_pool_scheduler{},
                     cores);
+
+            namespace ex = hpx::execution::experimental;
 
             // Execute based on policy type
             if constexpr (hpx::is_async_execution_policy_v<ExPolicy>)
@@ -63,22 +58,25 @@ namespace hpx::experimental {
                 std::apply(
                     [&](auto&... r) { (r.init_iteration(0, 0), ...); }, *sp);
 
-                // Create a lambda that captures all reductions
-                auto task = [sp, f = HPX_FORWARD(F, f)](std::size_t i) {
+                // 1. Extract lambdas into variables BEFORE the pipeline to prevent
+                // Clang 22 template instantiation crashes (exit code 139).
+                auto bulk_task = [sp, f = HPX_FORWARD(F, f)](std::size_t i) {
                     std::apply(
                         [&](auto&... r) { f(r.iteration_value(i)...); }, *sp);
                 };
 
-                auto fut = hpx::parallel::execution::bulk_async_execute(
-                    HPX_MOVE(exec), HPX_MOVE(task), cores);
-
-                // Return a future that performs cleanup after all tasks
-                // complete
-                return fut.then([sp = HPX_MOVE(sp)](auto&& fut_inner) mutable {
+                auto cleanup_task = [sp = HPX_MOVE(sp)]() mutable {
                     std::apply(
                         [](auto&... r) { (r.exit_iteration(0), ...); }, *sp);
-                    return fut_inner.get();
-                });
+                };
+
+                // 2. Build the graph
+                auto s = ex::schedule(sched) |
+                    ex::bulk(cores, HPX_MOVE(bulk_task)) |
+                    ex::then(HPX_MOVE(cleanup_task));
+
+                // 3. Adapt the return type to a future
+                return ex::make_future(HPX_MOVE(s));
             }
             else
             {
@@ -89,18 +87,25 @@ namespace hpx::experimental {
                 std::apply([](auto&... r) { (r.init_iteration(0, 0), ...); },
                     all_reductions);
 
-                // Create a lambda that captures all reductions
-                auto task = [&all_reductions, &f](std::size_t i) {
+                // 1. Extract lambdas into variables BEFORE the pipeline to prevent
+                // Clang 22 template instantiation crashes (exit code 139).
+                auto bulk_task = [&all_reductions, &f](std::size_t i) {
                     std::apply([&](auto&... r) { f(r.iteration_value(i)...); },
                         all_reductions);
                 };
 
-                hpx::parallel::execution::bulk_sync_execute(
-                    HPX_MOVE(exec), HPX_MOVE(task), cores);
+                auto cleanup_task = [&all_reductions]() {
+                    std::apply([](auto&... r) { (r.exit_iteration(0), ...); },
+                        all_reductions);
+                };
 
-                // Clean up reductions
-                std::apply([](auto&... r) { (r.exit_iteration(0), ...); },
-                    all_reductions);
+                // 2. Build the graph
+                auto s = ex::schedule(sched) |
+                    ex::bulk(cores, HPX_MOVE(bulk_task)) |
+                    ex::then(HPX_MOVE(cleanup_task));
+
+                // 3. Adapt for void return (Synchronous blocking)
+                hpx::this_thread::experimental::sync_wait(HPX_MOVE(s));
             }
         }
 

--- a/libs/core/algorithms/include/hpx/parallel/run_on_all.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/run_on_all.hpp
@@ -81,7 +81,16 @@ namespace hpx::experimental {
                     ex::bulk(cores, HPX_MOVE(bulk_task)) |
                     ex::let_error([cleanup_error = HPX_MOVE(cleanup_error)](
                                       std::exception_ptr ep) mutable {
-                        HPX_INVOKE(cleanup_error);
+                        try
+                        {
+                            HPX_INVOKE(cleanup_error);
+                        }
+                        catch (...)
+                        {
+                            // Suppress secondary exceptions during cleanup to
+                            // strictly preserve the primary bulk execution
+                            // error
+                        }
                         return ex::just_error(HPX_MOVE(ep));
                     }) |
                     ex::then(HPX_MOVE(cleanup_task));
@@ -120,7 +129,16 @@ namespace hpx::experimental {
                     ex::bulk(cores, HPX_MOVE(bulk_task)) |
                     ex::let_error([cleanup_error = HPX_MOVE(cleanup_error)](
                                       std::exception_ptr ep) mutable {
-                        HPX_INVOKE(cleanup_error);
+                        try
+                        {
+                            HPX_INVOKE(cleanup_error);
+                        }
+                        catch (...)
+                        {
+                            // Suppress secondary exceptions during cleanup to
+                            // strictly preserve the primary bulk execution
+                            // error
+                        }
                         return ex::just_error(HPX_MOVE(ep));
                     }) |
                     ex::then(HPX_MOVE(cleanup_task));

--- a/libs/core/algorithms/include/hpx/parallel/run_on_all.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/run_on_all.hpp
@@ -35,17 +35,21 @@ namespace hpx::experimental {
         decltype(auto) run_on_all(
             ExPolicy&& policy, F&& f, Reductions&&... reductions)
         {
+            // force using index_queue scheduler with given amount of threads
+            hpx::threads::thread_schedule_hint hint;
+            hint.sharing_mode(
+                hpx::threads::thread_sharing_hint::do_not_share_function);
+
             auto cores =
                 hpx::execution::experimental::processing_units_count(policy);
 
-            // Create scheduler with proper core count configuration and priority
-            auto sched = hpx::execution::experimental::with_priority(
+            // Create executor with proper configuration
+            auto exec =
                 hpx::execution::experimental::with_processing_units_count(
-                    hpx::execution::experimental::thread_pool_scheduler{},
-                    cores),
-                hpx::execution::experimental::get_priority(policy));
-
-            namespace ex = hpx::execution::experimental;
+                    hpx::execution::parallel_executor(
+                        hpx::threads::thread_priority::bound,
+                        hpx::threads::thread_stacksize::default_, hint),
+                    cores);
 
             // Execute based on policy type
             if constexpr (hpx::is_async_execution_policy_v<ExPolicy>)
@@ -59,44 +63,22 @@ namespace hpx::experimental {
                 std::apply(
                     [&](auto&... r) { (r.init_iteration(0, 0), ...); }, *sp);
 
-                // Extract lambdas before pipeline composition. This prevents a
-                // Clang 22 template-instantiation crash (exit code 139).
-                auto bulk_task = [sp, f = HPX_FORWARD(F, f)](std::size_t i) {
+                // Create a lambda that captures all reductions
+                auto task = [sp, f = HPX_FORWARD(F, f)](std::size_t i) {
                     std::apply(
                         [&](auto&... r) { f(r.iteration_value(i)...); }, *sp);
                 };
 
-                auto cleanup_task = [sp]() mutable {
+                auto fut = hpx::parallel::execution::bulk_async_execute(
+                    HPX_MOVE(exec), HPX_MOVE(task), cores);
+
+                // Return a future that performs cleanup after all tasks
+                // complete
+                return fut.then([sp = HPX_MOVE(sp)](auto&& fut_inner) mutable {
                     std::apply(
                         [](auto&... r) { (r.exit_iteration(0), ...); }, *sp);
-                };
-
-                auto cleanup_error = [sp]() mutable {
-                    std::apply(
-                        [](auto&... r) { (r.exit_iteration(0), ...); }, *sp);
-                };
-
-                // 2. Build the graph
-                auto s = ex::schedule(sched) |
-                    ex::bulk(cores, HPX_MOVE(bulk_task)) |
-                    ex::let_error([cleanup_error = HPX_MOVE(cleanup_error)](
-                                      std::exception_ptr ep) mutable {
-                        try
-                        {
-                            HPX_INVOKE(cleanup_error);
-                        }
-                        catch (...)
-                        {
-                            // Suppress secondary exceptions during cleanup to
-                            // strictly preserve the primary bulk execution
-                            // error
-                        }
-                        return ex::just_error(HPX_MOVE(ep));
-                    }) |
-                    ex::then(HPX_MOVE(cleanup_task));
-
-                // 3. Adapt the return type to a future
-                return ex::make_future(HPX_MOVE(s));
+                    return fut_inner.get();
+                });
             }
             else
             {
@@ -107,44 +89,18 @@ namespace hpx::experimental {
                 std::apply([](auto&... r) { (r.init_iteration(0, 0), ...); },
                     all_reductions);
 
-                // Extract lambdas before pipeline composition. This prevents a
-                // Clang 22 template-instantiation crash (exit code 139).
-                auto bulk_task = [&all_reductions, &f](std::size_t i) {
+                // Create a lambda that captures all reductions
+                auto task = [&all_reductions, &f](std::size_t i) {
                     std::apply([&](auto&... r) { f(r.iteration_value(i)...); },
                         all_reductions);
                 };
 
-                auto cleanup_task = [&all_reductions]() {
-                    std::apply([](auto&... r) { (r.exit_iteration(0), ...); },
-                        all_reductions);
-                };
+                hpx::parallel::execution::bulk_sync_execute(
+                    HPX_MOVE(exec), HPX_MOVE(task), cores);
 
-                auto cleanup_error = [&all_reductions]() {
-                    std::apply([](auto&... r) { (r.exit_iteration(0), ...); },
-                        all_reductions);
-                };
-
-                // 2. Build the graph
-                auto s = ex::schedule(sched) |
-                    ex::bulk(cores, HPX_MOVE(bulk_task)) |
-                    ex::let_error([cleanup_error = HPX_MOVE(cleanup_error)](
-                                      std::exception_ptr ep) mutable {
-                        try
-                        {
-                            HPX_INVOKE(cleanup_error);
-                        }
-                        catch (...)
-                        {
-                            // Suppress secondary exceptions during cleanup to
-                            // strictly preserve the primary bulk execution
-                            // error
-                        }
-                        return ex::just_error(HPX_MOVE(ep));
-                    }) |
-                    ex::then(HPX_MOVE(cleanup_task));
-
-                // 3. Adapt for void return (Synchronous blocking)
-                hpx::this_thread::experimental::sync_wait(HPX_MOVE(s));
+                // Clean up reductions
+                std::apply([](auto&... r) { (r.exit_iteration(0), ...); },
+                    all_reductions);
             }
         }
 
@@ -158,6 +114,68 @@ namespace hpx::experimental {
 
             return run_on_all(
                 HPX_FORWARD(ExPolicy, policy), HPX_MOVE(f), std::get<Is>(t)...);
+        }
+
+        HPX_CXX_CORE_EXPORT template <typename Scheduler, typename F,
+            typename... Reductions>
+        decltype(auto) run_on_all_sched(
+            Scheduler&& sched, F&& f, Reductions&&... reductions)
+        {
+            auto cores = hpx::execution::experimental::processing_units_count(
+                hpx::execution::experimental::thread_pool_scheduler{});
+
+            namespace ex = hpx::execution::experimental;
+
+            auto all_reductions =
+                std::make_tuple(HPX_FORWARD(Reductions, reductions)...);
+            auto sp = std::make_shared<decltype(all_reductions)>(
+                HPX_MOVE(all_reductions));
+
+            std::apply([&](auto&... r) { (r.init_iteration(0, 0), ...); }, *sp);
+
+            // Extract lambdas before pipeline composition. This prevents a
+            // Clang 22 template-instantiation crash (exit code 139).
+            auto bulk_task = [sp, f = HPX_FORWARD(F, f)](std::size_t i) {
+                std::apply(
+                    [&](auto&... r) { f(r.iteration_value(i)...); }, *sp);
+            };
+
+            auto cleanup_task = [sp]() mutable {
+                std::apply([](auto&... r) { (r.exit_iteration(0), ...); }, *sp);
+            };
+
+            auto cleanup_error = [sp]() mutable {
+                std::apply([](auto&... r) { (r.exit_iteration(0), ...); }, *sp);
+            };
+
+            return ex::schedule(HPX_FORWARD(Scheduler, sched)) |
+                ex::bulk(cores, HPX_MOVE(bulk_task)) |
+                ex::let_error([cleanup_error = HPX_MOVE(cleanup_error)](
+                                  std::exception_ptr ep) mutable {
+                    try
+                    {
+                        HPX_INVOKE(cleanup_error);
+                    }
+                    catch (...)
+                    {
+                        // Suppress secondary exceptions during cleanup to
+                        // strictly preserve the primary bulk execution error
+                    }
+                    return ex::just_error(HPX_MOVE(ep));
+                }) |
+                ex::then(HPX_MOVE(cleanup_task));
+        }
+
+        HPX_CXX_CORE_EXPORT template <typename Scheduler, std::size_t... Is,
+            typename... Ts>
+        decltype(auto) run_on_all_sched(
+            Scheduler&& sched, hpx::util::index_pack<Is...>, Ts&&... ts)
+        {
+            auto&& t = std::forward_as_tuple(HPX_FORWARD(Ts, ts)...);
+            auto f = std::get<sizeof...(Ts) - 1>(t);
+
+            return run_on_all_sched(
+                HPX_FORWARD(Scheduler, sched), HPX_MOVE(f), std::get<Is>(t)...);
         }
     }    // namespace detail
     /// \endcond
@@ -185,6 +203,30 @@ namespace hpx::experimental {
     }
 
     /// Run a function on all available worker threads with reduction support
+    /// using the given P2300 scheduler
+    ///
+    /// \tparam Scheduler The scheduler type
+    /// \tparam T         The first type in a list of reduction types and the
+    ///                   function type to invoke (last argument)
+    /// \tparam Ts        The list of reduction types and the function type to
+    ///                   invoke (last argument)
+    /// \param sched      The scheduler to use
+    /// \param t          The first in a list of reductions and the function to
+    ///                   invoke (last argument)
+    /// \param ts         The list of reductions and the function to invoke (last
+    ///                   argument)
+    HPX_CXX_CORE_EXPORT template <typename Scheduler, typename T,
+        typename... Ts>
+        requires(hpx::execution::experimental::is_scheduler_v<
+            std::decay_t<Scheduler>>)
+    decltype(auto) run_on_all(Scheduler&& sched, T&& t, Ts&&... ts)
+    {
+        return detail::run_on_all_sched(HPX_FORWARD(Scheduler, sched),
+            hpx::util::make_index_pack_t<sizeof...(Ts)>(), HPX_FORWARD(T, t),
+            HPX_FORWARD(Ts, ts)...);
+    }
+
+    /// Run a function on all available worker threads with reduction support
     /// using the \a hpx::execution::par execution policy
     ///
     /// \tparam T        The first type in a list of reduction types and the
@@ -196,7 +238,8 @@ namespace hpx::experimental {
     /// \param ts        The list of reductions and the function to invoke (last
     ///                  argument)
     HPX_CXX_CORE_EXPORT template <typename T, typename... Ts>
-        requires(!hpx::is_execution_policy_v<T>)
+        requires(!hpx::is_execution_policy_v<T> &&
+            !hpx::execution::experimental::is_scheduler_v<std::decay_t<T>>)
     decltype(auto) run_on_all(T&& t, Ts&&... ts)
     {
         return detail::run_on_all(hpx::execution::par,

--- a/libs/core/algorithms/include/hpx/parallel/run_on_all.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/run_on_all.hpp
@@ -38,11 +38,12 @@ namespace hpx::experimental {
             auto cores =
                 hpx::execution::experimental::processing_units_count(policy);
 
-            // Create scheduler with proper core count configuration
-            auto sched =
+            // Create scheduler with proper core count configuration and priority
+            auto sched = hpx::execution::experimental::with_priority(
                 hpx::execution::experimental::with_processing_units_count(
                     hpx::execution::experimental::thread_pool_scheduler{},
-                    cores);
+                    cores),
+                hpx::execution::experimental::get_priority(policy));
 
             namespace ex = hpx::execution::experimental;
 
@@ -58,14 +59,19 @@ namespace hpx::experimental {
                 std::apply(
                     [&](auto&... r) { (r.init_iteration(0, 0), ...); }, *sp);
 
-                // 1. Extract lambdas into variables BEFORE the pipeline to prevent
-                // Clang 22 template instantiation crashes (exit code 139).
+                // Extract lambdas before pipeline composition. This prevents a
+                // Clang 22 template-instantiation crash (exit code 139).
                 auto bulk_task = [sp, f = HPX_FORWARD(F, f)](std::size_t i) {
                     std::apply(
                         [&](auto&... r) { f(r.iteration_value(i)...); }, *sp);
                 };
 
-                auto cleanup_task = [sp = HPX_MOVE(sp)]() mutable {
+                auto cleanup_task = [sp]() mutable {
+                    std::apply(
+                        [](auto&... r) { (r.exit_iteration(0), ...); }, *sp);
+                };
+
+                auto cleanup_error = [sp]() mutable {
                     std::apply(
                         [](auto&... r) { (r.exit_iteration(0), ...); }, *sp);
                 };
@@ -73,6 +79,11 @@ namespace hpx::experimental {
                 // 2. Build the graph
                 auto s = ex::schedule(sched) |
                     ex::bulk(cores, HPX_MOVE(bulk_task)) |
+                    ex::let_error([cleanup_error = HPX_MOVE(cleanup_error)](
+                                      std::exception_ptr ep) mutable {
+                        HPX_INVOKE(cleanup_error);
+                        return ex::just_error(HPX_MOVE(ep));
+                    }) |
                     ex::then(HPX_MOVE(cleanup_task));
 
                 // 3. Adapt the return type to a future
@@ -87,8 +98,8 @@ namespace hpx::experimental {
                 std::apply([](auto&... r) { (r.init_iteration(0, 0), ...); },
                     all_reductions);
 
-                // 1. Extract lambdas into variables BEFORE the pipeline to prevent
-                // Clang 22 template instantiation crashes (exit code 139).
+                // Extract lambdas before pipeline composition. This prevents a
+                // Clang 22 template-instantiation crash (exit code 139).
                 auto bulk_task = [&all_reductions, &f](std::size_t i) {
                     std::apply([&](auto&... r) { f(r.iteration_value(i)...); },
                         all_reductions);
@@ -99,9 +110,19 @@ namespace hpx::experimental {
                         all_reductions);
                 };
 
+                auto cleanup_error = [&all_reductions]() {
+                    std::apply([](auto&... r) { (r.exit_iteration(0), ...); },
+                        all_reductions);
+                };
+
                 // 2. Build the graph
                 auto s = ex::schedule(sched) |
                     ex::bulk(cores, HPX_MOVE(bulk_task)) |
+                    ex::let_error([cleanup_error = HPX_MOVE(cleanup_error)](
+                                      std::exception_ptr ep) mutable {
+                        HPX_INVOKE(cleanup_error);
+                        return ex::just_error(HPX_MOVE(ep));
+                    }) |
                     ex::then(HPX_MOVE(cleanup_task));
 
                 // 3. Adapt for void return (Synchronous blocking)

--- a/libs/core/algorithms/include/hpx/parallel/run_on_all.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/run_on_all.hpp
@@ -118,11 +118,16 @@ namespace hpx::experimental {
 
         HPX_CXX_CORE_EXPORT template <typename Scheduler, typename F,
             typename... Reductions>
+        // clang-format off
+            requires (
+                hpx::execution::experimental::is_scheduler_v<std::decay_t<Scheduler>>
+            )
+        // clang-format on
         decltype(auto) run_on_all_sched(
             Scheduler&& sched, F&& f, Reductions&&... reductions)
         {
-            auto cores = hpx::execution::experimental::processing_units_count(
-                hpx::execution::experimental::thread_pool_scheduler{});
+            auto cores =
+                hpx::execution::experimental::processing_units_count(sched);
 
             namespace ex = hpx::execution::experimental;
 

--- a/libs/core/algorithms/include/hpx/parallel/task_group.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/task_group.hpp
@@ -26,6 +26,8 @@
 
 #include <atomic>
 #include <exception>
+#include <functional>
+#include <memory>
 #include <type_traits>
 #include <utility>
 
@@ -122,25 +124,32 @@ namespace hpx::experimental {
 
             namespace ex = hpx::execution::experimental;
 
+            auto state = std::make_shared<std::function<void()>>(
+                [this]() { latch_.count_down(1); });
+
             // Workaround for Clang compiler crash (exit code 139):
             // Extract lambda body into a separate function to reduce template AST depth
-            auto task = [this, f = HPX_FORWARD(F, f),
+            auto task = [this, state, f = HPX_FORWARD(F, f),
                             ... ts = HPX_FORWARD(Ts, ts)]() mutable {
                 hpx::detail::try_catch_exception_ptr(
                     [&]() { HPX_INVOKE(f, ts...); },
                     [this](
                         std::exception_ptr e) { add_exception(HPX_MOVE(e)); });
+                HPX_INVOKE(*state);
             };
 
-            auto on_exit =
-                hpx::experimental::scope_exit([this] { latch_.count_down(1); });
+            auto sender = ex::schedule(HPX_FORWARD(Scheduler, sched)) |
+                ex::then(HPX_MOVE(task)) |
+                ex::let_error([this, state](std::exception_ptr e) mutable {
+                    add_exception(HPX_MOVE(e));
+                    // Manually invoke the latch countdown if the scheduler failed
+                    HPX_INVOKE(*state);
+                    // Convert the error channel to a value channel to satisfy start_detached
+                    return ex::just();
+                });
 
-            ex::start_detached(ex::schedule(HPX_FORWARD(Scheduler, sched)) |
-                ex::then([this, on_exit = HPX_MOVE(on_exit),
-                             task = HPX_MOVE(task)]() mutable {
-                    auto _(HPX_MOVE(on_exit));
-                    HPX_INVOKE(task);
-                }));
+            // Start the sender but don't wait for it to complete
+            ex::start_detached(HPX_MOVE(sender));
         }
 
         /// \brief Adds a task to compute \c f() and returns immediately.

--- a/libs/core/algorithms/include/hpx/parallel/task_group.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/task_group.hpp
@@ -34,6 +34,18 @@
 /// Top-level namespace
 namespace hpx::experimental {
 
+    namespace detail {
+        template <typename Executor>
+        inline constexpr bool is_task_group_executor_v =
+            hpx::traits::is_executor_any_v<std::decay_t<Executor>>;
+
+        template <typename Scheduler>
+        inline constexpr bool is_task_group_scheduler_v =
+            hpx::execution::experimental::is_scheduler_v<
+                std::decay_t<Scheduler>> &&
+            !is_task_group_executor_v<Scheduler>;
+    }    // namespace detail
+
     /// A \c task_group represents concurrent execution of a group of tasks.
     /// Tasks can be dynamically added to the group while it is executing.
     HPX_CXX_CORE_EXPORT class task_group
@@ -66,32 +78,13 @@ namespace hpx::experimental {
         template <typename Executor, typename F, typename... Ts>
         // clang-format off
             requires (
-                hpx::traits::is_executor_any_v<std::decay_t<Executor>>
+                detail::is_task_group_executor_v<Executor>
             )
         // clang-format on
         void run(Executor&& exec, F&& f, Ts&&... ts)
         {
-            // make sure exceptions don't leave the latch in the wrong state
-            if (latch_.reset_if_needed_and_count_up(1, 1))
-            {
-                has_arrived_.store(false, std::memory_order_release);
-            }
-
-            auto on_exit =
-                hpx::experimental::scope_exit([this] { latch_.count_down(1); });
-
             hpx::parallel::execution::post(HPX_FORWARD(Executor, exec),
-                [this, on_exit = HPX_MOVE(on_exit), f = HPX_FORWARD(F, f),
-                    ... ts = HPX_FORWARD(Ts, ts)]() mutable {
-                    // latch needs to be released before the lambda exits
-                    auto _(HPX_MOVE(on_exit));
-
-                    hpx::detail::try_catch_exception_ptr(
-                        [&]() { HPX_INVOKE(f, ts...); },
-                        [this](std::exception_ptr e) {
-                            add_exception(HPX_MOVE(e));
-                        });
-                });
+                wrap_task(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...));
         }
 
         /// \brief Adds a task to compute \c f() and returns immediately.
@@ -109,44 +102,24 @@ namespace hpx::experimental {
         template <typename Scheduler, typename F, typename... Ts>
         // clang-format off
             requires (
-                hpx::execution::experimental::is_scheduler_v<
-                    std::decay_t<Scheduler>> &&
-                !hpx::traits::is_executor_any_v<std::decay_t<Scheduler>>
+                detail::is_task_group_scheduler_v<Scheduler>
             )
         // clang-format on
         void run(Scheduler&& sched, F&& f, Ts&&... ts)
         {
-            // make sure exceptions don't leave the latch in the wrong state
-            if (latch_.reset_if_needed_and_count_up(1, 1))
-            {
-                has_arrived_.store(false, std::memory_order_release);
-            }
-
             namespace ex = hpx::execution::experimental;
 
-            auto state = std::make_shared<std::function<void()>>(
-                [this]() { latch_.count_down(1); });
-
-            // Workaround for Clang compiler crash (exit code 139):
-            // Extract lambda body into a separate function to reduce template AST depth
-            auto task = [this, state, f = HPX_FORWARD(F, f),
-                            ... ts = HPX_FORWARD(Ts, ts)]() mutable {
-                hpx::detail::try_catch_exception_ptr(
-                    [&]() { HPX_INVOKE(f, ts...); },
-                    [this](
-                        std::exception_ptr e) { add_exception(HPX_MOVE(e)); });
-                HPX_INVOKE(*state);
-            };
+            // Extract the lambda into a separate variable to prevent AST depth crashes on Clang compilers during complex template instantiations.
+            auto task = wrap_task(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
 
             auto sender = ex::schedule(HPX_FORWARD(Scheduler, sched)) |
                 ex::then(HPX_MOVE(task)) |
-                ex::let_error([this, state](std::exception_ptr e) mutable {
+                ex::let_error([this](std::exception_ptr e) mutable {
                     add_exception(HPX_MOVE(e));
-                    // Manually invoke the latch countdown if the scheduler failed
-                    HPX_INVOKE(*state);
                     // Convert the error channel to a value channel to satisfy start_detached
                     return ex::just();
-                });
+                }) |
+                ex::let_stopped([]() { return ex::just(); });
 
             // Start the sender but don't wait for it to complete
             ex::start_detached(HPX_MOVE(sender));
@@ -164,8 +137,8 @@ namespace hpx::experimental {
         template <typename F, typename... Ts>
         // clang-format off
             requires (
-                !hpx::traits::is_executor_any_v<std::decay_t<F>> &&
-                !hpx::execution::experimental::is_scheduler_v<std::decay_t<F>>
+                !detail::is_task_group_executor_v<F> &&
+                !detail::is_task_group_scheduler_v<F>
             )
         // clang-format on
         void run(F&& f, Ts&&... ts)
@@ -179,6 +152,31 @@ namespace hpx::experimental {
 
         /// \brief Adds an exception to this \c task_group
         HPX_CORE_EXPORT void add_exception(std::exception_ptr p);
+
+    private:
+        template <typename F, typename... Ts>
+        auto wrap_task(F&& f, Ts&&... ts)
+        {
+            // make sure exceptions don't leave the latch in the wrong state
+            if (latch_.reset_if_needed_and_count_up(1, 1))
+            {
+                has_arrived_.store(false, std::memory_order_release);
+            }
+
+            auto on_exit =
+                hpx::experimental::scope_exit([this] { latch_.count_down(1); });
+
+            return [this, on_exit = HPX_MOVE(on_exit), f = HPX_FORWARD(F, f),
+                       ... ts = HPX_FORWARD(Ts, ts)]() mutable {
+                // latch needs to be released before the lambda exits
+                auto _(HPX_MOVE(on_exit));
+
+                hpx::detail::try_catch_exception_ptr(
+                    [&]() { HPX_INVOKE(f, ts...); },
+                    [this](
+                        std::exception_ptr e) { add_exception(HPX_MOVE(e)); });
+            };
+        }
 
     private:
         friend class serialization::access;

--- a/libs/core/algorithms/include/hpx/parallel/task_group.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/task_group.hpp
@@ -14,6 +14,7 @@
 #include <hpx/modules/concepts.hpp>
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/modules/execution.hpp>
 #include <hpx/modules/execution_base.hpp>
 
 #include <hpx/modules/executors.hpp>
@@ -121,22 +122,25 @@ namespace hpx::experimental {
 
             namespace ex = hpx::execution::experimental;
 
+            // Workaround for Clang compiler crash (exit code 139):
+            // Extract lambda body into a separate function to reduce template AST depth
+            auto task = [this, f = HPX_FORWARD(F, f),
+                            ... ts = HPX_FORWARD(Ts, ts)]() mutable {
+                hpx::detail::try_catch_exception_ptr(
+                    [&]() { HPX_INVOKE(f, ts...); },
+                    [this](
+                        std::exception_ptr e) { add_exception(HPX_MOVE(e)); });
+            };
+
             auto on_exit =
                 hpx::experimental::scope_exit([this] { latch_.count_down(1); });
 
             ex::start_detached(ex::schedule(HPX_FORWARD(Scheduler, sched)) |
-                ex::then(
-                    [this, on_exit = HPX_MOVE(on_exit), f = HPX_FORWARD(F, f),
-                        ... ts = HPX_FORWARD(Ts, ts)]() mutable {
-                        // latch needs to be released before the lambda exits
-                        auto _(HPX_MOVE(on_exit));
-
-                        hpx::detail::try_catch_exception_ptr(
-                            [&]() { HPX_INVOKE(f, ts...); },
-                            [this](std::exception_ptr e) {
-                                add_exception(HPX_MOVE(e));
-                            });
-                    }));
+                ex::then([this, on_exit = HPX_MOVE(on_exit),
+                             task = HPX_MOVE(task)]() mutable {
+                    auto _(HPX_MOVE(on_exit));
+                    HPX_INVOKE(task);
+                }));
         }
 
         /// \brief Adds a task to compute \c f() and returns immediately.

--- a/libs/core/algorithms/include/hpx/parallel/task_group.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/task_group.hpp
@@ -112,6 +112,8 @@ namespace hpx::experimental {
             // Extract the lambda into a separate variable to prevent AST depth crashes on Clang compilers during complex template instantiations.
             auto task = wrap_task(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
 
+            auto stopped_handler = []() { return ex::just(); };
+
             auto sender = ex::schedule(HPX_FORWARD(Scheduler, sched)) |
                 ex::then(HPX_MOVE(task)) |
                 ex::let_error([this](std::exception_ptr e) mutable {
@@ -119,7 +121,7 @@ namespace hpx::experimental {
                     // Convert the error channel to a value channel to satisfy start_detached
                     return ex::just();
                 }) |
-                ex::let_stopped([]() { return ex::just(); });
+                ex::let_stopped(HPX_MOVE(stopped_handler));
 
             // Start the sender but don't wait for it to complete
             ex::start_detached(HPX_MOVE(sender));

--- a/libs/core/algorithms/include/hpx/parallel/task_group.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/task_group.hpp
@@ -15,6 +15,10 @@
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/execution_base.hpp>
+
+#include <hpx/execution_base/sender.hpp>
+#include <hpx/execution_base/stdexec_forward.hpp>
+#include <hpx/execution_base/traits/is_executor.hpp>
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/futures.hpp>
@@ -92,6 +96,54 @@ namespace hpx::experimental {
 
         /// \brief Adds a task to compute \c f() and returns immediately.
         ///
+        /// \tparam Scheduler The type of the P2300 scheduler to dispatch on.
+        /// \tparam F         The type of the user defined function to invoke.
+        /// \tparam Ts        The type of additional arguments used to invoke \c f().
+        ///
+        /// \param sched      The P2300 scheduler to use for dispatching the
+        ///                   task.
+        /// \param f          The user defined function to invoke inside the task
+        ///                   group.
+        /// \param ts         Additional arguments to use to invoke \c f().
+
+        template <typename Scheduler, typename F, typename... Ts>
+        // clang-format off
+            requires (
+                hpx::execution::experimental::is_scheduler_v<
+                    std::decay_t<Scheduler>> &&
+                !hpx::traits::is_executor_any_v<std::decay_t<Scheduler>>
+            )
+        // clang-format on
+        void run(Scheduler&& sched, F&& f, Ts&&... ts)
+        {
+            // make sure exceptions don't leave the latch in the wrong state
+            if (latch_.reset_if_needed_and_count_up(1, 1))
+            {
+                has_arrived_.store(false, std::memory_order_release);
+            }
+
+            namespace ex = hpx::execution::experimental;
+
+            auto on_exit =
+                hpx::experimental::scope_exit([this] { latch_.count_down(1); });
+
+            ex::start_detached(ex::schedule(HPX_FORWARD(Scheduler, sched)) |
+                ex::then(
+                    [this, on_exit = HPX_MOVE(on_exit), f = HPX_FORWARD(F, f),
+                        ... ts = HPX_FORWARD(Ts, ts)]() mutable {
+                        // latch needs to be released before the lambda exits
+                        auto _(HPX_MOVE(on_exit));
+
+                        hpx::detail::try_catch_exception_ptr(
+                            [&]() { HPX_INVOKE(f, ts...); },
+                            [this](std::exception_ptr e) {
+                                add_exception(HPX_MOVE(e));
+                            });
+                    }));
+        }
+
+        /// \brief Adds a task to compute \c f() and returns immediately.
+        ///
         /// \tparam F  The type of the user defined function to invoke.
         /// \tparam Ts The type of additional arguments used to invoke \c f().
         ///
@@ -102,7 +154,9 @@ namespace hpx::experimental {
         template <typename F, typename... Ts>
         // clang-format off
             requires (
-                !hpx::traits::is_executor_any_v<std::decay_t<F>>
+                !hpx::traits::is_executor_any_v<std::decay_t<F>> &&
+                !hpx::execution::experimental::is_scheduler_v<
+                    std::decay_t<F>>
             )
         // clang-format on
         void run(F&& f, Ts&&... ts)

--- a/libs/core/algorithms/include/hpx/parallel/task_group.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/task_group.hpp
@@ -156,8 +156,7 @@ namespace hpx::experimental {
         // clang-format off
             requires (
                 !hpx::traits::is_executor_any_v<std::decay_t<F>> &&
-                !hpx::execution::experimental::is_scheduler_v<
-                    std::decay_t<F>>
+                !hpx::execution::experimental::is_scheduler_v<std::decay_t<F>>
             )
         // clang-format on
         void run(F&& f, Ts&&... ts)

--- a/libs/core/algorithms/include/hpx/parallel/task_group.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/task_group.hpp
@@ -16,9 +16,6 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/execution_base.hpp>
 
-#include <hpx/execution_base/sender.hpp>
-#include <hpx/execution_base/stdexec_forward.hpp>
-#include <hpx/execution_base/traits/is_executor.hpp>
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/futures.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/task_group.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/task_group.hpp
@@ -34,18 +34,6 @@
 /// Top-level namespace
 namespace hpx::experimental {
 
-    namespace detail {
-        template <typename Executor>
-        inline constexpr bool is_task_group_executor_v =
-            hpx::traits::is_executor_any_v<std::decay_t<Executor>>;
-
-        template <typename Scheduler>
-        inline constexpr bool is_task_group_scheduler_v =
-            hpx::execution::experimental::is_scheduler_v<
-                std::decay_t<Scheduler>> &&
-            !is_task_group_executor_v<Scheduler>;
-    }    // namespace detail
-
     /// A \c task_group represents concurrent execution of a group of tasks.
     /// Tasks can be dynamically added to the group while it is executing.
     HPX_CXX_CORE_EXPORT class task_group
@@ -78,7 +66,7 @@ namespace hpx::experimental {
         template <typename Executor, typename F, typename... Ts>
         // clang-format off
             requires (
-                detail::is_task_group_executor_v<Executor>
+                hpx::traits::is_executor_any_v<std::decay_t<Executor>>
             )
         // clang-format on
         void run(Executor&& exec, F&& f, Ts&&... ts)
@@ -102,7 +90,9 @@ namespace hpx::experimental {
         template <typename Scheduler, typename F, typename... Ts>
         // clang-format off
             requires (
-                detail::is_task_group_scheduler_v<Scheduler>
+                hpx::execution::experimental::is_scheduler_v<
+                    std::decay_t<Scheduler>> &&
+                !hpx::traits::is_executor_any_v<std::decay_t<Scheduler>>
             )
         // clang-format on
         void run(Scheduler&& sched, F&& f, Ts&&... ts)
@@ -113,14 +103,25 @@ namespace hpx::experimental {
             // crashes on Clang compilers during complex template instantiations.
             auto task = wrap_task(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
 
-            auto stopped_handler = []() { return ex::just(); };
+            auto stopped_handler = []() {
+                // Note: This silently discards cancellation signals. If the scheduler
+                // signals 'stopped' (e.g., the pool is shutting down), this pipeline
+                // converts it to just() with no call to add_exception. This is an
+                // explicit semantic choice: a cancelled task will silently vanish
+                // and not appear in the exception_list.
+                return ex::just();
+            };
 
             auto sender = ex::schedule(HPX_FORWARD(Scheduler, sched)) |
                 ex::then(HPX_MOVE(task)) |
                 ex::let_error([this](std::exception_ptr e) mutable {
+                    // Note: The wrap_task inner lambda already wraps the user callable
+                    // in try_catch_exception_ptr and reports user-task failures via
+                    // add_exception. Therefore, this let_error acts solely as a safety
+                    // net for scheduler-level errors (e.g., if schedule() itself fails).
+                    // We convert this error channel to a value channel via ex::just()
+                    // to satisfy start_detached.
                     add_exception(HPX_MOVE(e));
-                    // Convert the error channel to a value channel to satisfy
-                    // start_detached
                     return ex::just();
                 }) |
                 ex::let_stopped(HPX_MOVE(stopped_handler));
@@ -141,8 +142,8 @@ namespace hpx::experimental {
         template <typename F, typename... Ts>
         // clang-format off
             requires (
-                !detail::is_task_group_executor_v<F> &&
-                !detail::is_task_group_scheduler_v<F>
+                !hpx::traits::is_executor_any_v<std::decay_t<F>> &&
+                !hpx::execution::experimental::is_scheduler_v<std::decay_t<F>>
             )
         // clang-format on
         void run(F&& f, Ts&&... ts)

--- a/libs/core/algorithms/include/hpx/parallel/task_group.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/task_group.hpp
@@ -109,7 +109,8 @@ namespace hpx::experimental {
         {
             namespace ex = hpx::execution::experimental;
 
-            // Extract the lambda into a separate variable to prevent AST depth crashes on Clang compilers during complex template instantiations.
+            // Extract the lambda into a separate variable to prevent AST depth
+            // crashes on Clang compilers during complex template instantiations.
             auto task = wrap_task(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
 
             auto stopped_handler = []() { return ex::just(); };
@@ -118,7 +119,8 @@ namespace hpx::experimental {
                 ex::then(HPX_MOVE(task)) |
                 ex::let_error([this](std::exception_ptr e) mutable {
                     add_exception(HPX_MOVE(e));
-                    // Convert the error channel to a value channel to satisfy start_detached
+                    // Convert the error channel to a value channel to satisfy
+                    // start_detached
                     return ex::just();
                 }) |
                 ex::let_stopped(HPX_MOVE(stopped_handler));

--- a/libs/core/algorithms/tests/unit/block/run_on_all.cpp
+++ b/libs/core/algorithms/tests/unit/block/run_on_all.cpp
@@ -14,7 +14,6 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
-
 #include <stdexcept>
 
 void test_sync_exception()

--- a/libs/core/algorithms/tests/unit/block/run_on_all.cpp
+++ b/libs/core/algorithms/tests/unit/block/run_on_all.cpp
@@ -25,9 +25,10 @@ void test_sync_exception()
     std::atomic<int> count{0};
     try
     {
-        run_on_all(hpx::execution::par, reduction_plus(n),
-            [&count](std::uint32_t&) { 
-                if (count++ == 0) throw std::runtime_error("test sync"); 
+        run_on_all(
+            hpx::execution::par, reduction_plus(n), [&count](std::uint32_t&) {
+                if (count++ == 0)
+                    throw std::runtime_error("test sync");
             });
     }
     catch (std::exception const&)
@@ -46,9 +47,9 @@ void test_async_exception()
     try
     {
         auto f = run_on_all(hpx::execution::par(hpx::execution::task),
-            reduction_plus(n),
-            [&count](std::uint32_t&) { 
-                if (count++ == 0) throw std::runtime_error("test async"); 
+            reduction_plus(n), [&count](std::uint32_t&) {
+                if (count++ == 0)
+                    throw std::runtime_error("test async");
             });
         f.get();
     }

--- a/libs/core/algorithms/tests/unit/block/run_on_all.cpp
+++ b/libs/core/algorithms/tests/unit/block/run_on_all.cpp
@@ -60,6 +60,28 @@ void test_async_exception()
     HPX_TEST(caught);
 }
 
+void test_scheduler_exception()
+{
+    using namespace hpx::experimental;
+    std::uint32_t n = 0;
+    bool caught = false;
+    std::atomic<int> count{0};
+    try
+    {
+        auto sched = hpx::execution::experimental::thread_pool_scheduler{};
+        auto s = run_on_all(sched, reduction_plus(n), [&count](std::uint32_t&) {
+            if (count++ == 0)
+                throw std::runtime_error("test scheduler");
+        });
+        hpx::this_thread::experimental::sync_wait(std::move(s));
+    }
+    catch (std::exception const&)
+    {
+        caught = true;
+    }
+    HPX_TEST(caught);
+}
+
 int main()
 {
     using namespace hpx::experimental;
@@ -183,6 +205,17 @@ int main()
             static_cast<std::uint32_t>(hpx::get_num_worker_threads()));
     }
 
+    // Test with P2300 scheduler
+    {
+        auto sched = hpx::execution::experimental::thread_pool_scheduler{};
+        std::uint32_t n = 0;
+        auto s = run_on_all(sched, reduction_plus(n),
+            [](std::uint32_t& local_n) { ++local_n; });
+        hpx::this_thread::experimental::sync_wait(std::move(s));
+        HPX_TEST_EQ(
+            n, static_cast<std::uint32_t>(hpx::get_num_worker_threads()));
+    }
+
     // Test with different number of tasks
     {
         auto policy = hpx::execution::experimental::with_processing_units_count(
@@ -206,6 +239,7 @@ int main()
 
     test_sync_exception();
     test_async_exception();
+    test_scheduler_exception();
 
     return hpx::util::report_errors();
 }

--- a/libs/core/algorithms/tests/unit/block/run_on_all.cpp
+++ b/libs/core/algorithms/tests/unit/block/run_on_all.cpp
@@ -15,6 +15,50 @@
 #include <cstddef>
 #include <cstdint>
 
+#include <stdexcept>
+
+void test_sync_exception()
+{
+    using namespace hpx::experimental;
+    std::uint32_t n = 0;
+    bool caught = false;
+    std::atomic<int> count{0};
+    try
+    {
+        run_on_all(hpx::execution::par, reduction_plus(n),
+            [&count](std::uint32_t&) { 
+                if (count++ == 0) throw std::runtime_error("test sync"); 
+            });
+    }
+    catch (std::exception const&)
+    {
+        caught = true;
+    }
+    HPX_TEST(caught);
+}
+
+void test_async_exception()
+{
+    using namespace hpx::experimental;
+    std::uint32_t n = 0;
+    bool caught = false;
+    std::atomic<int> count{0};
+    try
+    {
+        auto f = run_on_all(hpx::execution::par(hpx::execution::task),
+            reduction_plus(n),
+            [&count](std::uint32_t&) { 
+                if (count++ == 0) throw std::runtime_error("test async"); 
+            });
+        f.get();
+    }
+    catch (std::exception const&)
+    {
+        caught = true;
+    }
+    HPX_TEST(caught);
+}
+
 int main()
 {
     using namespace hpx::experimental;
@@ -158,6 +202,9 @@ int main()
             [](std::uint32_t& local_n) { ++local_n; });
         HPX_TEST_EQ(n, static_cast<std::uint32_t>(4));
     }
+
+    test_sync_exception();
+    test_async_exception();
 
     return hpx::util::report_errors();
 }

--- a/libs/core/algorithms/tests/unit/block/run_on_all.cpp
+++ b/libs/core/algorithms/tests/unit/block/run_on_all.cpp
@@ -15,6 +15,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <stdexcept>
+#include <utility>
 
 void test_sync_exception()
 {

--- a/libs/core/algorithms/tests/unit/block/task_group.cpp
+++ b/libs/core/algorithms/tests/unit/block/task_group.cpp
@@ -115,6 +115,19 @@ void task_group_test3()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+void task_group_test_scheduler()
+{
+    hpx::execution::experimental::thread_pool_scheduler sched{};
+    hpx::experimental::task_group g;
+    std::atomic<bool> executed{false};
+
+    g.run(sched, [&]() { executed = true; });
+    g.wait();
+
+    HPX_TEST(executed);
+}
+
+///////////////////////////////////////////////////////////////////////////////
 void task_group_test_scheduler_exception()
 {
     bool throws_exception = true;
@@ -150,6 +163,7 @@ int hpx_main()
     task_group_test1_reuse();
     task_group_test2();
     task_group_test3();
+    task_group_test_scheduler();
     task_group_test_scheduler_exception();
 
     return hpx::local::finalize();

--- a/libs/core/algorithms/tests/unit/block/task_group.cpp
+++ b/libs/core/algorithms/tests/unit/block/task_group.cpp
@@ -9,6 +9,7 @@
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/testing.hpp>
 
+#include <atomic>
 #include <cstddef>
 #include <string>
 #include <vector>

--- a/libs/core/algorithms/tests/unit/block/task_group.cpp
+++ b/libs/core/algorithms/tests/unit/block/task_group.cpp
@@ -114,12 +114,66 @@ void task_group_test3()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+template <typename Scheduler>
+int fib_sched(Scheduler const& sched, int n)
+{
+    if (n < 2)
+    {
+        return n;
+    }
+
+    int x = 0, y = 0;
+
+    hpx::experimental::task_group g;
+    g.run(sched, [&](int n) { x = fib_sched(sched, n); }, n - 1);
+    g.run(sched, [&](int n) { y = fib_sched(sched, n); }, n - 2);
+    g.wait();    // wait for both tasks to complete
+
+    return x + y;
+}
+
+void task_group_test_scheduler()
+{
+    hpx::execution::experimental::thread_pool_scheduler sched;
+    HPX_TEST_EQ(fib_sched(sched, 22), 17711);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void task_group_test_scheduler_exception()
+{
+    hpx::execution::experimental::thread_pool_scheduler sched;
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::experimental::task_group g;
+        g.run(sched, [] { throw std::runtime_error("sched_test1"); });
+        g.run(sched, [] { throw std::runtime_error("sched_test2"); });
+
+        g.wait();    // rethrows after waiting for all tasks to finish
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& l)
+    {
+        caught_exception = true;
+        HPX_TEST_EQ(l.size(), std::size_t(2));
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+    HPX_TEST(caught_exception);
+}
+
+///////////////////////////////////////////////////////////////////////////////
 int hpx_main()
 {
     task_group_test1();
     task_group_test1_reuse();
     task_group_test2();
     task_group_test3();
+    task_group_test_scheduler();
+    task_group_test_scheduler_exception();
 
     return hpx::local::finalize();
 }

--- a/libs/core/algorithms/tests/unit/block/task_group.cpp
+++ b/libs/core/algorithms/tests/unit/block/task_group.cpp
@@ -6,6 +6,7 @@
 
 #include <hpx/init.hpp>
 #include <hpx/modules/algorithms.hpp>
+#include <hpx/modules/execution.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <cstddef>
@@ -114,12 +115,42 @@ void task_group_test3()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+void task_group_test_scheduler_exception()
+{
+    bool throws_exception = true;
+    bool caught_exception = false;
+    try
+    {
+        hpx::experimental::task_group g;
+        hpx::execution::experimental::thread_pool_scheduler sched{};
+        g.run(sched, [] { throw std::runtime_error("test1"); });
+        g.run(sched, [] { throw std::runtime_error("test2"); });
+        throws_exception = false;
+
+        g.wait();    // rethrows after waiting for all tasks to finish
+        HPX_TEST(false);
+    }
+    catch (hpx::exception_list const& l)
+    {
+        caught_exception = true;
+        HPX_TEST_EQ(l.size(), std::size_t(2));
+    }
+    catch (...)
+    {
+        HPX_TEST(false);
+    }
+    HPX_TEST(!throws_exception);
+    HPX_TEST(caught_exception);
+}
+
+///////////////////////////////////////////////////////////////////////////////
 int hpx_main()
 {
     task_group_test1();
     task_group_test1_reuse();
     task_group_test2();
     task_group_test3();
+    task_group_test_scheduler_exception();
 
     return hpx::local::finalize();
 }


### PR DESCRIPTION
Fixes part of #5219

## Proposed Changes

  - **P2300 Sender Graph Migration:** Modernized the `run_on_all` algorithm by replacing the legacy `hpx::parallel::execution::bulk_async_execute` and `hpx::future::then` continuations with a P2300 sender graph (`ex::schedule` -> `ex::bulk` -> `ex::then`).
  - **Synchronous Path Safety:** Replaced the legacy synchronous execution path with `hpx::this_thread::experimental::sync_wait` to ensure the algorithm strictly blocks and returns correctly without introducing race conditions.
  - **Clang 22 AST Depth Workaround:** Extracted the inner pipeline lambdas (`bulk_task` and `cleanup_task`) prior to constructing the sender graph. This prevents the known Clang 22 compiler crash (exit code 139) caused by deep template AST instantiation.
  - **Executor Hints:** Removed legacy `thread_priority` and `thread_sharing` hints which are not natively consumed by the `thread_pool_scheduler` constructor. Added a `// TODO` to map these via P2300 environments in the future.
  - **Strict Modularization:** Relied exclusively on the `<hpx/modules/execution.hpp>` umbrella header.

## Any background context you want to provide?

This PR is part of the effort to reimplement the executor API on top of the sender/receiver infrastructure. It completely decouples the `run_on_all` block algorithm from legacy `hpx::parallel::execution` primitives. 

## Checklist

Not all points below apply to all pull requests.

- [x] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.