### PR TITLE
Fix C++23 fold_left_first and fold_right_last return type deduction

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/fold.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/fold.hpp
@@ -328,8 +328,8 @@ namespace hpx::ranges {
 
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::ranges::fold_left_first_with_iter
-    HPX_CXX_CORE_EXPORT inline constexpr struct fold_left_first_with_iter_t
-        final
+    HPX_CXX_CORE_EXPORT inline constexpr struct
+        fold_left_first_with_iter_t final
       : hpx::detail::tag_dispatch<fold_left_first_with_iter_t,
             hpx::detail::tag_parallel_algorithm<fold_left_first_with_iter_t>>
     {

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/fold.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/fold.hpp
@@ -337,11 +337,14 @@ namespace hpx::ranges {
         // clang-format off
         requires (
             std::input_iterator<InIter> &&
-            std::constructible_from<hpx::traits::iter_value_t<InIter>,
-                hpx::traits::iter_reference_t<InIter>> &&
             std::sentinel_for<Sent, InIter> &&
             hpx::is_indirectly_binary_left_foldable<F,
-                hpx::traits::iter_value_t<InIter>, InIter>
+                hpx::traits::iter_value_t<InIter>, InIter> &&
+            std::constructible_from<
+                std::decay_t<hpx::util::invoke_result_t<F&,
+                    hpx::traits::iter_value_t<InIter>,
+                    hpx::traits::iter_reference_t<InIter>>>,
+                hpx::traits::iter_reference_t<InIter>>
         )
         // clang-format on
         static auto invoke_default(InIter first, Sent last, F f)
@@ -372,12 +375,14 @@ namespace hpx::ranges {
         // clang-format off
         requires (
             std::ranges::input_range<Rng> &&
-            std::constructible_from<
-                hpx::traits::iter_value_t<std::ranges::iterator_t<Rng>>,
-                std::ranges::range_reference_t<Rng>> &&
             hpx::is_indirectly_binary_left_foldable<F,
                 hpx::traits::iter_value_t<std::ranges::iterator_t<Rng>>,
-                std::ranges::iterator_t<Rng>>
+                std::ranges::iterator_t<Rng>> &&
+            std::constructible_from<
+                std::decay_t<hpx::util::invoke_result_t<F&,
+                    hpx::traits::iter_value_t<std::ranges::iterator_t<Rng>>,
+                    std::ranges::range_reference_t<Rng>>>,
+                std::ranges::range_reference_t<Rng>>
         )
         // clang-format on
         static auto invoke_default(Rng&& rng, F f)
@@ -437,11 +442,14 @@ namespace hpx::ranges {
         // clang-format off
         requires (
             std::input_iterator<InIter> &&
-            std::constructible_from<hpx::traits::iter_value_t<InIter>,
-                hpx::traits::iter_reference_t<InIter>> &&
             std::sentinel_for<Sent, InIter> &&
             hpx::is_indirectly_binary_left_foldable<F,
-                hpx::traits::iter_value_t<InIter>, InIter>
+                hpx::traits::iter_value_t<InIter>, InIter> &&
+            std::constructible_from<
+                std::decay_t<hpx::util::invoke_result_t<F&,
+                    hpx::traits::iter_value_t<InIter>,
+                    hpx::traits::iter_reference_t<InIter>>>,
+                hpx::traits::iter_reference_t<InIter>>
         )
         // clang-format on
         static auto invoke_default(InIter first, Sent last, F f)
@@ -455,12 +463,14 @@ namespace hpx::ranges {
         // clang-format off
         requires (
             std::ranges::input_range<Rng> &&
-            std::constructible_from<
-                hpx::traits::iter_value_t<std::ranges::iterator_t<Rng>>,
-                std::ranges::range_reference_t<Rng>> &&
             hpx::is_indirectly_binary_left_foldable<F,
                 hpx::traits::iter_value_t<std::ranges::iterator_t<Rng>>,
-                std::ranges::iterator_t<Rng>>
+                std::ranges::iterator_t<Rng>> &&
+            std::constructible_from<
+                std::decay_t<hpx::util::invoke_result_t<F&,
+                    hpx::traits::iter_value_t<std::ranges::iterator_t<Rng>>,
+                    std::ranges::range_reference_t<Rng>>>,
+                std::ranges::range_reference_t<Rng>>
         )
         // clang-format on
         static auto invoke_default(Rng&& rng, F f)
@@ -533,11 +543,14 @@ namespace hpx::ranges {
         // clang-format off
         requires (
             std::bidirectional_iterator<BidIter> &&
-            std::constructible_from<hpx::traits::iter_value_t<BidIter>,
-                hpx::traits::iter_reference_t<BidIter>> &&
             std::sentinel_for<Sent, BidIter> &&
             hpx::is_indirectly_binary_right_foldable<F,
-                hpx::traits::iter_value_t<BidIter>, BidIter>
+                hpx::traits::iter_value_t<BidIter>, BidIter> &&
+            std::constructible_from<
+                std::decay_t<hpx::util::invoke_result_t<F&,
+                    hpx::traits::iter_reference_t<BidIter>,
+                    hpx::traits::iter_value_t<BidIter>>>,
+                hpx::traits::iter_reference_t<BidIter>>
         )
         // clang-format on
         static auto invoke_default(BidIter first, Sent last, F f)
@@ -566,12 +579,14 @@ namespace hpx::ranges {
         // clang-format off
         requires (
             std::ranges::bidirectional_range<Rng> &&
-            std::constructible_from<
-                hpx::traits::iter_value_t<std::ranges::iterator_t<Rng>>,
-                std::ranges::range_reference_t<Rng>> &&
             hpx::is_indirectly_binary_right_foldable<F,
                 hpx::traits::iter_value_t<std::ranges::iterator_t<Rng>>,
-                std::ranges::iterator_t<Rng>>
+                std::ranges::iterator_t<Rng>> &&
+            std::constructible_from<
+                std::decay_t<hpx::util::invoke_result_t<F&,
+                    std::ranges::range_reference_t<Rng>,
+                    hpx::traits::iter_value_t<std::ranges::iterator_t<Rng>>>>,
+                std::ranges::range_reference_t<Rng>>
         )
         // clang-format on
         static auto invoke_default(Rng&& rng, F f)

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/fold.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/fold.hpp
@@ -254,6 +254,7 @@ namespace hpx::ranges {
 #include <hpx/iterator_support/traits/is_foldable.hpp>
 #include <hpx/iterator_support/traits/is_iterator.hpp>
 #include <hpx/iterator_support/traits/is_range.hpp>
+#include <hpx/parallel/algorithms/detail/advance_to_sentinel.hpp>
 #include <hpx/parallel/algorithms/detail/tag_dispatch.hpp>
 #include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/ranges_facilities.hpp>
@@ -290,8 +291,8 @@ namespace hpx::ranges {
         // clang-format on
         static auto invoke_default(InIter first, Sent last, T init, F f)
         {
-            using U = std::decay_t<hpx::util::invoke_result_t<F&, T,
-                hpx::traits::iter_reference_t<InIter>>>;
+            using U = std::decay_t<std::invoke_result_t<F&, T,
+                std::iter_reference_t<InIter>>>;
             using result_type = fold_left_with_iter_result<InIter, U>;
 
             if (first == last)
@@ -349,9 +350,9 @@ namespace hpx::ranges {
         // clang-format on
         static auto invoke_default(InIter first, Sent last, F f)
         {
-            using U = std::decay_t<hpx::util::invoke_result_t<F&,
-                hpx::traits::iter_value_t<InIter>,
-                hpx::traits::iter_reference_t<InIter>>>;
+            using U = std::decay_t<std::invoke_result_t<F&,
+                std::iter_value_t<InIter>,
+                std::iter_reference_t<InIter>>>;
             using result_type =
                 fold_left_first_with_iter_result<InIter, hpx::optional<U>>;
 

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/fold.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/fold.hpp
@@ -328,8 +328,8 @@ namespace hpx::ranges {
 
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::ranges::fold_left_first_with_iter
-    HPX_CXX_CORE_EXPORT inline constexpr struct
-        fold_left_first_with_iter_t final
+    HPX_CXX_CORE_EXPORT inline constexpr struct fold_left_first_with_iter_t
+        final
       : hpx::detail::tag_dispatch<fold_left_first_with_iter_t,
             hpx::detail::tag_parallel_algorithm<fold_left_first_with_iter_t>>
     {

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/fold.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/fold.hpp
@@ -329,8 +329,8 @@ namespace hpx::ranges {
 
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::ranges::fold_left_first_with_iter
-    HPX_CXX_CORE_EXPORT inline constexpr struct
-        fold_left_first_with_iter_t final
+    HPX_CXX_CORE_EXPORT inline constexpr struct fold_left_first_with_iter_t
+        final
       : hpx::detail::tag_dispatch<fold_left_first_with_iter_t,
             hpx::detail::tag_parallel_algorithm<fold_left_first_with_iter_t>>
     {

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/fold.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/fold.hpp
@@ -357,7 +357,7 @@ namespace hpx::ranges {
                 return result_type{HPX_MOVE(first), hpx::optional<U>()};
             }
 
-            U result = *first;
+            U result = hpx::traits::iter_value_t<InIter>(*first);
             ++first;
 
             for (; first != last; ++first)
@@ -553,7 +553,7 @@ namespace hpx::ranges {
             }
 
             auto it = hpx::parallel::detail::advance_to_sentinel(first, last);
-            U result = *--it;
+            U result = hpx::traits::iter_value_t<BidIter>(*--it);
 
             while (it != first)
             {

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/fold.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/fold.hpp
@@ -291,8 +291,8 @@ namespace hpx::ranges {
         // clang-format on
         static auto invoke_default(InIter first, Sent last, T init, F f)
         {
-            using U = std::decay_t<std::invoke_result_t<F&, T,
-                std::iter_reference_t<InIter>>>;
+            using U = std::decay_t<
+                std::invoke_result_t<F&, T, std::iter_reference_t<InIter>>>;
             using result_type = fold_left_with_iter_result<InIter, U>;
 
             if (first == last)
@@ -329,8 +329,8 @@ namespace hpx::ranges {
 
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::ranges::fold_left_first_with_iter
-    HPX_CXX_CORE_EXPORT inline constexpr struct fold_left_first_with_iter_t
-        final
+    HPX_CXX_CORE_EXPORT inline constexpr struct
+        fold_left_first_with_iter_t final
       : hpx::detail::tag_dispatch<fold_left_first_with_iter_t,
             hpx::detail::tag_parallel_algorithm<fold_left_first_with_iter_t>>
     {
@@ -351,8 +351,7 @@ namespace hpx::ranges {
         static auto invoke_default(InIter first, Sent last, F f)
         {
             using U = std::decay_t<std::invoke_result_t<F&,
-                std::iter_value_t<InIter>,
-                std::iter_reference_t<InIter>>>;
+                std::iter_value_t<InIter>, std::iter_reference_t<InIter>>>;
             using result_type =
                 fold_left_first_with_iter_result<InIter, hpx::optional<U>>;
 

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/fold.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/fold.hpp
@@ -337,6 +337,8 @@ namespace hpx::ranges {
         // clang-format off
         requires (
             std::input_iterator<InIter> &&
+            std::constructible_from<hpx::traits::iter_value_t<InIter>,
+                hpx::traits::iter_reference_t<InIter>> &&
             std::sentinel_for<Sent, InIter> &&
             hpx::is_indirectly_binary_left_foldable<F,
                 hpx::traits::iter_value_t<InIter>, InIter>
@@ -355,7 +357,7 @@ namespace hpx::ranges {
                 return result_type{HPX_MOVE(first), hpx::optional<U>()};
             }
 
-            U result = HPX_MOVE(*first);
+            U result = *first;
             ++first;
 
             for (; first != last; ++first)
@@ -370,6 +372,9 @@ namespace hpx::ranges {
         // clang-format off
         requires (
             std::ranges::input_range<Rng> &&
+            std::constructible_from<
+                hpx::traits::iter_value_t<std::ranges::iterator_t<Rng>>,
+                hpx::traits::range_reference_t<Rng>> &&
             hpx::is_indirectly_binary_left_foldable<F,
                 hpx::traits::iter_value_t<std::ranges::iterator_t<Rng>>,
                 std::ranges::iterator_t<Rng>>
@@ -432,6 +437,8 @@ namespace hpx::ranges {
         // clang-format off
         requires (
             std::input_iterator<InIter> &&
+            std::constructible_from<hpx::traits::iter_value_t<InIter>,
+                hpx::traits::iter_reference_t<InIter>> &&
             std::sentinel_for<Sent, InIter> &&
             hpx::is_indirectly_binary_left_foldable<F,
                 hpx::traits::iter_value_t<InIter>, InIter>
@@ -448,6 +455,9 @@ namespace hpx::ranges {
         // clang-format off
         requires (
             std::ranges::input_range<Rng> &&
+            std::constructible_from<
+                hpx::traits::iter_value_t<std::ranges::iterator_t<Rng>>,
+                hpx::traits::range_reference_t<Rng>> &&
             hpx::is_indirectly_binary_left_foldable<F,
                 hpx::traits::iter_value_t<std::ranges::iterator_t<Rng>>,
                 std::ranges::iterator_t<Rng>>
@@ -523,6 +533,8 @@ namespace hpx::ranges {
         // clang-format off
         requires (
             std::bidirectional_iterator<BidIter> &&
+            std::constructible_from<hpx::traits::iter_value_t<BidIter>,
+                hpx::traits::iter_reference_t<BidIter>> &&
             std::sentinel_for<Sent, BidIter> &&
             hpx::is_indirectly_binary_right_foldable<F,
                 hpx::traits::iter_value_t<BidIter>, BidIter>
@@ -541,7 +553,7 @@ namespace hpx::ranges {
             }
 
             auto it = hpx::parallel::detail::advance_to_sentinel(first, last);
-            U result = HPX_MOVE(*--it);
+            U result = *--it;
 
             while (it != first)
             {
@@ -554,6 +566,9 @@ namespace hpx::ranges {
         // clang-format off
         requires (
             std::ranges::bidirectional_range<Rng> &&
+            std::constructible_from<
+                hpx::traits::iter_value_t<std::ranges::iterator_t<Rng>>,
+                hpx::traits::range_reference_t<Rng>> &&
             hpx::is_indirectly_binary_right_foldable<F,
                 hpx::traits::iter_value_t<std::ranges::iterator_t<Rng>>,
                 std::ranges::iterator_t<Rng>>

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/fold.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/fold.hpp
@@ -344,7 +344,9 @@ namespace hpx::ranges {
         // clang-format on
         static auto invoke_default(InIter first, Sent last, F f)
         {
-            using U = decltype(HPX_INVOKE(f, *first, *first));
+            using U = std::decay_t<hpx::util::invoke_result_t<F&,
+                hpx::traits::iter_value_t<InIter>,
+                hpx::traits::iter_reference_t<InIter>>>;
             using result_type =
                 fold_left_first_with_iter_result<InIter, hpx::optional<U>>;
 
@@ -353,7 +355,7 @@ namespace hpx::ranges {
                 return result_type{HPX_MOVE(first), hpx::optional<U>()};
             }
 
-            U result = *first;
+            U result = HPX_MOVE(*first);
             ++first;
 
             for (; first != last; ++first)
@@ -528,7 +530,9 @@ namespace hpx::ranges {
         // clang-format on
         static auto invoke_default(BidIter first, Sent last, F f)
         {
-            using U = decltype(HPX_INVOKE(f, *first, *first));
+            using U = std::decay_t<hpx::util::invoke_result_t<F&,
+                hpx::traits::iter_reference_t<BidIter>,
+                hpx::traits::iter_value_t<BidIter>>>;
             using result_type = hpx::optional<U>;
 
             if (first == last)
@@ -537,7 +541,7 @@ namespace hpx::ranges {
             }
 
             auto it = hpx::parallel::detail::advance_to_sentinel(first, last);
-            U result = *--it;
+            U result = HPX_MOVE(*--it);
 
             while (it != first)
             {

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/fold.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/fold.hpp
@@ -177,8 +177,8 @@ namespace hpx::ranges {
     template <typename InIter, typename Sent, typename T, typename F>
     auto fold_left_with_iter(InIter first, Sent last, T init, F f)
         -> fold_left_with_iter_result<InIter,
-            std::decay_t<hpx::util::invoke_result_t<F&, T,
-                hpx::traits::iter_reference_t<InIter>>>>;
+            std::decay_t<std::invoke_result_t<F&, T,
+                std::iter_reference_t<InIter>>>>;
 
     /// Left-folds a range and returns both the result and the end iterator.
     ///
@@ -197,8 +197,8 @@ namespace hpx::ranges {
     auto fold_left_with_iter(Rng&& rng, T init, F f)
         -> fold_left_with_iter_result<
             std::ranges::iterator_t<Rng>,
-            std::decay_t<hpx::util::invoke_result_t<F&, T,
-                hpx::traits::range_reference_t<Rng>>>>;
+            std::decay_t<std::invoke_result_t<F&, T,
+                std::ranges::range_reference_t<Rng>>>>;
 
     /// Left-folds a range using the first element and returns both an optional
     /// result and the end iterator.
@@ -218,9 +218,9 @@ namespace hpx::ranges {
     auto fold_left_first_with_iter(InIter first, Sent last, F f)
         -> fold_left_first_with_iter_result<InIter,
             hpx::optional<
-                std::decay_t<hpx::util::invoke_result_t<F&,
-                    hpx::traits::iter_reference_t<InIter>,
-                    hpx::traits::iter_reference_t<InIter>>>>>;
+                std::decay_t<std::invoke_result_t<F&,
+                    std::iter_reference_t<InIter>,
+                    std::iter_reference_t<InIter>>>>>;
 
     /// Left-folds a range using the first element and returns both an optional
     /// result and the end iterator.
@@ -239,9 +239,9 @@ namespace hpx::ranges {
         -> fold_left_first_with_iter_result<
             std::ranges::iterator_t<Rng>,
             hpx::optional<
-                std::decay_t<hpx::util::invoke_result_t<F&,
-                    hpx::traits::range_reference_t<Rng>,
-                    hpx::traits::range_reference_t<Rng>>>>>;
+                std::decay_t<std::invoke_result_t<F&,
+                    std::ranges::range_reference_t<Rng>,
+                    std::ranges::range_reference_t<Rng>>>>>;
 
     // clang-format on
 }    // namespace hpx::ranges
@@ -284,7 +284,7 @@ namespace hpx::ranges {
         // clang-format off
         requires (
             std::input_iterator<InIter> &&
-            std::is_convertible_v<hpx::traits::iter_value_t<InIter>, T> &&
+            std::is_convertible_v<std::iter_value_t<InIter>, T> &&
             std::sentinel_for<Sent, InIter> &&
             hpx::is_indirectly_binary_left_foldable<F, T, InIter>
         )
@@ -314,7 +314,7 @@ namespace hpx::ranges {
         // clang-format off
         requires (
             std::ranges::input_range<Rng> &&
-            std::is_convertible_v<hpx::traits::iter_value_t<
+            std::is_convertible_v<std::iter_value_t<
                 std::ranges::iterator_t<Rng>>, T> &&
             hpx::is_indirectly_binary_left_foldable<F, T,
                 std::ranges::iterator_t<Rng>>
@@ -340,12 +340,12 @@ namespace hpx::ranges {
             std::input_iterator<InIter> &&
             std::sentinel_for<Sent, InIter> &&
             hpx::is_indirectly_binary_left_foldable<F,
-                hpx::traits::iter_value_t<InIter>, InIter> &&
+                std::iter_value_t<InIter>, InIter> &&
             std::constructible_from<
-                std::decay_t<hpx::util::invoke_result_t<F&,
-                    hpx::traits::iter_value_t<InIter>,
-                    hpx::traits::iter_reference_t<InIter>>>,
-                hpx::traits::iter_reference_t<InIter>>
+                std::decay_t<std::invoke_result_t<F&,
+                    std::iter_value_t<InIter>,
+                    std::iter_reference_t<InIter>>>,
+                std::iter_reference_t<InIter>>
         )
         // clang-format on
         static auto invoke_default(InIter first, Sent last, F f)
@@ -360,7 +360,7 @@ namespace hpx::ranges {
                 return result_type{HPX_MOVE(first), hpx::optional<U>()};
             }
 
-            U result{*first};
+            U result(*first);
             ++first;
 
             for (; first != last; ++first)
@@ -376,11 +376,11 @@ namespace hpx::ranges {
         requires (
             std::ranges::input_range<Rng> &&
             hpx::is_indirectly_binary_left_foldable<F,
-                hpx::traits::iter_value_t<std::ranges::iterator_t<Rng>>,
+                std::iter_value_t<std::ranges::iterator_t<Rng>>,
                 std::ranges::iterator_t<Rng>> &&
             std::constructible_from<
-                std::decay_t<hpx::util::invoke_result_t<F&,
-                    hpx::traits::iter_value_t<std::ranges::iterator_t<Rng>>,
+                std::decay_t<std::invoke_result_t<F&,
+                    std::iter_value_t<std::ranges::iterator_t<Rng>>,
                     std::ranges::range_reference_t<Rng>>>,
                 std::ranges::range_reference_t<Rng>>
         )
@@ -403,7 +403,7 @@ namespace hpx::ranges {
         requires (
             std::input_iterator<InIter> &&
             std::sentinel_for<Sent, InIter> &&
-            std::is_convertible_v<hpx::traits::iter_value_t<InIter>, T> &&
+            std::is_convertible_v<std::iter_value_t<InIter>, T> &&
             hpx::is_indirectly_binary_left_foldable<F, T, InIter>
         )
         // clang-format on
@@ -418,7 +418,7 @@ namespace hpx::ranges {
         // clang-format off
         requires (
             std::ranges::input_range<Rng> &&
-            std::is_convertible_v<hpx::traits::iter_value_t<
+            std::is_convertible_v<std::iter_value_t<
                 std::ranges::iterator_t<Rng>>, T> &&
             hpx::is_indirectly_binary_left_foldable<F, T,
                 std::ranges::iterator_t<Rng>>
@@ -444,12 +444,12 @@ namespace hpx::ranges {
             std::input_iterator<InIter> &&
             std::sentinel_for<Sent, InIter> &&
             hpx::is_indirectly_binary_left_foldable<F,
-                hpx::traits::iter_value_t<InIter>, InIter> &&
+                std::iter_value_t<InIter>, InIter> &&
             std::constructible_from<
-                std::decay_t<hpx::util::invoke_result_t<F&,
-                    hpx::traits::iter_value_t<InIter>,
-                    hpx::traits::iter_reference_t<InIter>>>,
-                hpx::traits::iter_reference_t<InIter>>
+                std::decay_t<std::invoke_result_t<F&,
+                    std::iter_value_t<InIter>,
+                    std::iter_reference_t<InIter>>>,
+                std::iter_reference_t<InIter>>
         )
         // clang-format on
         static auto invoke_default(InIter first, Sent last, F f)
@@ -464,11 +464,11 @@ namespace hpx::ranges {
         requires (
             std::ranges::input_range<Rng> &&
             hpx::is_indirectly_binary_left_foldable<F,
-                hpx::traits::iter_value_t<std::ranges::iterator_t<Rng>>,
+                std::iter_value_t<std::ranges::iterator_t<Rng>>,
                 std::ranges::iterator_t<Rng>> &&
             std::constructible_from<
-                std::decay_t<hpx::util::invoke_result_t<F&,
-                    hpx::traits::iter_value_t<std::ranges::iterator_t<Rng>>,
+                std::decay_t<std::invoke_result_t<F&,
+                    std::iter_value_t<std::ranges::iterator_t<Rng>>,
                     std::ranges::range_reference_t<Rng>>>,
                 std::ranges::range_reference_t<Rng>>
         )
@@ -491,15 +491,15 @@ namespace hpx::ranges {
         // clang-format off
         requires (
             std::bidirectional_iterator<BidIter> &&
-            std::is_convertible_v<hpx::traits::iter_value_t<BidIter>, T> &&
+            std::is_convertible_v<std::iter_value_t<BidIter>, T> &&
             std::sentinel_for<Sent, BidIter> &&
             hpx::is_indirectly_binary_right_foldable<F, T, BidIter>
         )
         // clang-format on
         static auto invoke_default(BidIter first, Sent last, T init, F f)
         {
-            using U = std::decay_t<hpx::util::invoke_result_t<F&,
-                hpx::traits::iter_reference_t<BidIter>, T>>;
+            using U = std::decay_t<
+                std::invoke_result_t<F&, std::iter_reference_t<BidIter>, T>>;
 
             if (first == last)
             {
@@ -520,7 +520,7 @@ namespace hpx::ranges {
         // clang-format off
         requires (
             std::ranges::bidirectional_range<Rng> &&
-            std::is_convertible_v<hpx::traits::iter_value_t<
+            std::is_convertible_v<std::iter_value_t<
                 std::ranges::iterator_t<Rng>>, T> &&
             hpx::is_indirectly_binary_right_foldable<F, T,
                 std::ranges::iterator_t<Rng>>
@@ -545,19 +545,18 @@ namespace hpx::ranges {
             std::bidirectional_iterator<BidIter> &&
             std::sentinel_for<Sent, BidIter> &&
             hpx::is_indirectly_binary_right_foldable<F,
-                hpx::traits::iter_value_t<BidIter>, BidIter> &&
+                std::iter_value_t<BidIter>, BidIter> &&
             std::constructible_from<
-                std::decay_t<hpx::util::invoke_result_t<F&,
-                    hpx::traits::iter_reference_t<BidIter>,
-                    hpx::traits::iter_value_t<BidIter>>>,
-                hpx::traits::iter_reference_t<BidIter>>
+                std::decay_t<std::invoke_result_t<F&,
+                    std::iter_reference_t<BidIter>,
+                    std::iter_value_t<BidIter>>>,
+                std::iter_reference_t<BidIter>>
         )
         // clang-format on
         static auto invoke_default(BidIter first, Sent last, F f)
         {
-            using U = std::decay_t<hpx::util::invoke_result_t<F&,
-                hpx::traits::iter_reference_t<BidIter>,
-                hpx::traits::iter_value_t<BidIter>>>;
+            using U = std::decay_t<std::invoke_result_t<F&,
+                std::iter_reference_t<BidIter>, std::iter_value_t<BidIter>>>;
             using result_type = hpx::optional<U>;
 
             if (first == last)
@@ -566,7 +565,7 @@ namespace hpx::ranges {
             }
 
             auto it = hpx::parallel::detail::advance_to_sentinel(first, last);
-            U result{*--it};
+            U result(*--it);
 
             while (it != first)
             {
@@ -580,12 +579,12 @@ namespace hpx::ranges {
         requires (
             std::ranges::bidirectional_range<Rng> &&
             hpx::is_indirectly_binary_right_foldable<F,
-                hpx::traits::iter_value_t<std::ranges::iterator_t<Rng>>,
+                std::iter_value_t<std::ranges::iterator_t<Rng>>,
                 std::ranges::iterator_t<Rng>> &&
             std::constructible_from<
-                std::decay_t<hpx::util::invoke_result_t<F&,
+                std::decay_t<std::invoke_result_t<F&,
                     std::ranges::range_reference_t<Rng>,
-                    hpx::traits::iter_value_t<std::ranges::iterator_t<Rng>>>>,
+                    std::iter_value_t<std::ranges::iterator_t<Rng>>>>,
                 std::ranges::range_reference_t<Rng>>
         )
         // clang-format on

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/fold.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/fold.hpp
@@ -357,7 +357,7 @@ namespace hpx::ranges {
                 return result_type{HPX_MOVE(first), hpx::optional<U>()};
             }
 
-            U result = hpx::traits::iter_value_t<InIter>(*first);
+            U result{*first};
             ++first;
 
             for (; first != last; ++first)
@@ -553,7 +553,7 @@ namespace hpx::ranges {
             }
 
             auto it = hpx::parallel::detail::advance_to_sentinel(first, last);
-            U result = hpx::traits::iter_value_t<BidIter>(*--it);
+            U result{*--it};
 
             while (it != first)
             {

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/fold.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/fold.hpp
@@ -374,7 +374,7 @@ namespace hpx::ranges {
             std::ranges::input_range<Rng> &&
             std::constructible_from<
                 hpx::traits::iter_value_t<std::ranges::iterator_t<Rng>>,
-                hpx::traits::range_reference_t<Rng>> &&
+                std::ranges::range_reference_t<Rng>> &&
             hpx::is_indirectly_binary_left_foldable<F,
                 hpx::traits::iter_value_t<std::ranges::iterator_t<Rng>>,
                 std::ranges::iterator_t<Rng>>
@@ -457,7 +457,7 @@ namespace hpx::ranges {
             std::ranges::input_range<Rng> &&
             std::constructible_from<
                 hpx::traits::iter_value_t<std::ranges::iterator_t<Rng>>,
-                hpx::traits::range_reference_t<Rng>> &&
+                std::ranges::range_reference_t<Rng>> &&
             hpx::is_indirectly_binary_left_foldable<F,
                 hpx::traits::iter_value_t<std::ranges::iterator_t<Rng>>,
                 std::ranges::iterator_t<Rng>>
@@ -568,7 +568,7 @@ namespace hpx::ranges {
             std::ranges::bidirectional_range<Rng> &&
             std::constructible_from<
                 hpx::traits::iter_value_t<std::ranges::iterator_t<Rng>>,
-                hpx::traits::range_reference_t<Rng>> &&
+                std::ranges::range_reference_t<Rng>> &&
             hpx::is_indirectly_binary_right_foldable<F,
                 hpx::traits::iter_value_t<std::ranges::iterator_t<Rng>>,
                 std::ranges::iterator_t<Rng>>

--- a/libs/core/algorithms/tests/unit/container_algorithms/fold_range.cpp
+++ b/libs/core/algorithms/tests/unit/container_algorithms/fold_range.cpp
@@ -365,7 +365,7 @@ struct ref_constructible_accumulator
 {
     int value;
 
-    // Constructible from a const lvalue reference — matches iter_reference_t
+    // Constructible from a const lvalue reference - matches iter_reference_t
     explicit ref_constructible_accumulator(int const& v)
       : value(v)
     {
@@ -474,7 +474,7 @@ void test_fold_right_last_asymmetric()
 // Exercises the tightened constructible_from<U, iter_reference_t<Iter>>
 // constraint with ref_constructible_accumulator as the accumulator type U.
 // The seed expression U result{*first} / U result{*--it} constructs U
-// directly from the iterator reference — exactly what the requires()-clause
+// directly from the iterator reference - exactly what the requires()-clause
 // now mandates.
 void test_fold_left_first_ref_constructible_constraint()
 {

--- a/libs/core/algorithms/tests/unit/container_algorithms/fold_range.cpp
+++ b/libs/core/algorithms/tests/unit/container_algorithms/fold_range.cpp
@@ -356,48 +356,62 @@ void test_fold_left_first_with_iter_empty()
 
 #include <memory>
 
+struct copyable_asymmetric_accumulator
+{
+    int value;
+
+    copyable_asymmetric_accumulator(int v)
+      : value(v)
+    {
+    }
+    copyable_asymmetric_accumulator(
+        copyable_asymmetric_accumulator const&) = default;
+    copyable_asymmetric_accumulator(
+        copyable_asymmetric_accumulator&&) = default;
+    copyable_asymmetric_accumulator& operator=(
+        copyable_asymmetric_accumulator const&) = default;
+    copyable_asymmetric_accumulator& operator=(
+        copyable_asymmetric_accumulator&&) = default;
+};
+
 void test_fold_left_first_asymmetric()
 {
-    std::vector<std::unique_ptr<int>> c;
-    for (int i = 1; i <= 5; ++i)
-    {
-        c.push_back(std::make_unique<int>(i));
-    }
+    std::vector<int> c = {1, 2, 3, 4, 5};
+    std::vector<int> expected_c = {1, 2, 3, 4, 5};
 
-    auto custom_op = [](std::unique_ptr<int>&& acc,
-                         const std::unique_ptr<int>& elem) {
-        *acc += *elem;
-        return std::move(acc);
+    auto custom_op = [](copyable_asymmetric_accumulator acc, int elem) {
+        acc.value += elem;
+        return acc;
     };
 
-    auto hpx_result = hpx::ranges::fold_left_first(std::move(c), custom_op);
+    auto hpx_result = hpx::ranges::fold_left_first(c, custom_op);
     HPX_TEST(hpx_result.has_value());
     if (hpx_result)
     {
-        HPX_TEST_EQ(*(*hpx_result), 15);
+        HPX_TEST_EQ(hpx_result->value, 15);
     }
+
+    HPX_TEST(std::equal(c.begin(), c.end(), expected_c.begin()));
 }
 
 void test_fold_right_last_asymmetric()
 {
-    std::vector<std::unique_ptr<int>> c;
-    for (int i = 1; i <= 5; ++i)
-    {
-        c.push_back(std::make_unique<int>(i));
-    }
+    std::vector<int> c = {1, 2, 3, 4, 5};
+    std::vector<int> expected_c = {1, 2, 3, 4, 5};
 
-    auto custom_op = [](const std::unique_ptr<int>& elem,
-                         std::unique_ptr<int>&& acc) {
-        *acc += *elem;
-        return std::move(acc);
+    auto custom_op = [](int elem, copyable_asymmetric_accumulator acc) {
+        acc.value += elem;
+        return acc;
     };
 
-    auto hpx_result = hpx::ranges::fold_right_last(std::move(c), custom_op);
+    auto hpx_result = hpx::ranges::fold_right_last(c, custom_op);
     HPX_TEST(hpx_result.has_value());
     if (hpx_result)
     {
-        HPX_TEST_EQ(*(*hpx_result), 15);
+        HPX_TEST_EQ(hpx_result->value, 15);
     }
+
+    HPX_TEST(std::equal(c.begin(), c.end(), expected_c.begin()));
 }
 
 void test_fold_custom_op()

--- a/libs/core/algorithms/tests/unit/container_algorithms/fold_range.cpp
+++ b/libs/core/algorithms/tests/unit/container_algorithms/fold_range.cpp
@@ -354,6 +354,52 @@ void test_fold_left_first_with_iter_empty()
     HPX_TEST(!hpx_value.has_value());
 }
 
+#include <memory>
+
+void test_fold_left_first_asymmetric()
+{
+    std::vector<std::unique_ptr<int>> c;
+    for (int i = 1; i <= 5; ++i)
+    {
+        c.push_back(std::make_unique<int>(i));
+    }
+
+    auto custom_op = [](std::unique_ptr<int>&& acc,
+                         const std::unique_ptr<int>& elem) {
+        *acc += *elem;
+        return std::move(acc);
+    };
+
+    auto hpx_result = hpx::ranges::fold_left_first(std::move(c), custom_op);
+    HPX_TEST(hpx_result.has_value());
+    if (hpx_result)
+    {
+        HPX_TEST_EQ(*(*hpx_result), 15);
+    }
+}
+
+void test_fold_right_last_asymmetric()
+{
+    std::vector<std::unique_ptr<int>> c;
+    for (int i = 1; i <= 5; ++i)
+    {
+        c.push_back(std::make_unique<int>(i));
+    }
+
+    auto custom_op = [](const std::unique_ptr<int>& elem,
+                         std::unique_ptr<int>&& acc) {
+        *acc += *elem;
+        return std::move(acc);
+    };
+
+    auto hpx_result = hpx::ranges::fold_right_last(std::move(c), custom_op);
+    HPX_TEST(hpx_result.has_value());
+    if (hpx_result)
+    {
+        HPX_TEST_EQ(*(*hpx_result), 15);
+    }
+}
+
 void test_fold_custom_op()
 {
     std::vector<std::size_t> c = test::random_repeat(1007, std::size_t(100));
@@ -391,6 +437,9 @@ int hpx_main()
     test_fold_left_first_with_iter_iter();
     test_fold_left_first_with_iter_range();
     test_fold_left_first_with_iter_empty();
+
+    test_fold_left_first_asymmetric();
+    test_fold_right_last_asymmetric();
 
     test_fold_custom_op();
 

--- a/libs/core/algorithms/tests/unit/container_algorithms/fold_range.cpp
+++ b/libs/core/algorithms/tests/unit/container_algorithms/fold_range.cpp
@@ -13,6 +13,7 @@
 #include <cstddef>
 #include <functional>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -354,9 +355,6 @@ void test_fold_left_first_with_iter_empty()
     HPX_TEST(!hpx_value.has_value());
 }
 
-#include <memory>
-#include <type_traits>
-
 // A type that is constructible from int const& (the iterator reference type
 // for vector<int>) but does NOT have an implicit conversion from int (the
 // iter_value_t). This distinguishes the tightened constraint
@@ -417,7 +415,6 @@ struct copyable_asymmetric_accumulator
 namespace constraint_checks {
 
     using iter_ref_t = int const&;    // representative iter_reference_t
-    using iter_val_t = int;           // representative iter_value_t
 
     // U = ref_constructible_accumulator (produced by the fold callable below)
     // The constraint: constructible_from<U, iter_ref_t> must hold.

--- a/libs/core/algorithms/tests/unit/container_algorithms/fold_range.cpp
+++ b/libs/core/algorithms/tests/unit/container_algorithms/fold_range.cpp
@@ -374,8 +374,7 @@ struct ref_constructible_accumulator
     }
     ref_constructible_accumulator(
         ref_constructible_accumulator const&) = default;
-    ref_constructible_accumulator(
-        ref_constructible_accumulator&&) = default;
+    ref_constructible_accumulator(ref_constructible_accumulator&&) = default;
     ref_constructible_accumulator& operator=(
         ref_constructible_accumulator const&) = default;
     ref_constructible_accumulator& operator=(
@@ -422,14 +421,14 @@ namespace constraint_checks {
 
     // U = ref_constructible_accumulator (produced by the fold callable below)
     // The constraint: constructible_from<U, iter_ref_t> must hold.
-    static_assert(std::constructible_from<ref_constructible_accumulator,
-                      iter_ref_t>,
+    static_assert(
+        std::constructible_from<ref_constructible_accumulator, iter_ref_t>,
         "fold_left_first constraint: U must be constructible from "
         "iter_reference_t<Iter>");
 
     // Symmetrically for fold_right_last (same iterator/reference types here).
-    static_assert(std::constructible_from<ref_constructible_accumulator,
-                      iter_ref_t>,
+    static_assert(
+        std::constructible_from<ref_constructible_accumulator, iter_ref_t>,
         "fold_right_last constraint: U must be constructible from "
         "iter_reference_t<Iter>");
 
@@ -488,8 +487,8 @@ void test_fold_left_first_ref_constructible_constraint()
     // U = ref_constructible_accumulator
     // The requires()-clause checks constructible_from<U, int const&>,
     // which must hold for this to compile.
-    auto op = [](ref_constructible_accumulator acc, int const& elem)
-        -> ref_constructible_accumulator {
+    auto op = [](ref_constructible_accumulator acc,
+                  int const& elem) -> ref_constructible_accumulator {
         acc.value += elem;
         return acc;
     };

--- a/libs/core/algorithms/tests/unit/container_algorithms/fold_range.cpp
+++ b/libs/core/algorithms/tests/unit/container_algorithms/fold_range.cpp
@@ -415,6 +415,8 @@ struct copyable_asymmetric_accumulator
 namespace constraint_checks {
 
     using iter_ref_t = int const&;    // representative iter_reference_t
+    using vec_iter_ref_t =
+        std::iter_reference_t<std::vector<int>::iterator>;    // int&
 
     // U = ref_constructible_accumulator (produced by the fold callable below)
     // The constraint: constructible_from<U, iter_ref_t> must hold.
@@ -423,11 +425,21 @@ namespace constraint_checks {
         "fold_left_first constraint: U must be constructible from "
         "iter_reference_t<Iter>");
 
+    static_assert(
+        std::constructible_from<ref_constructible_accumulator, vec_iter_ref_t>,
+        "fold_left_first constraint: U must be constructible from "
+        "iter_reference_t<std::vector<int>::iterator>");
+
     // Symmetrically for fold_right_last (same iterator/reference types here).
     static_assert(
         std::constructible_from<ref_constructible_accumulator, iter_ref_t>,
         "fold_right_last constraint: U must be constructible from "
         "iter_reference_t<Iter>");
+
+    static_assert(
+        std::constructible_from<ref_constructible_accumulator, vec_iter_ref_t>,
+        "fold_right_last constraint: U must be constructible from "
+        "iter_reference_t<std::vector<int>::iterator>");
 
 }    // namespace constraint_checks
 

--- a/libs/core/algorithms/tests/unit/container_algorithms/fold_range.cpp
+++ b/libs/core/algorithms/tests/unit/container_algorithms/fold_range.cpp
@@ -366,7 +366,7 @@ struct ref_constructible_accumulator
     int value;
 
     // Constructible from a const lvalue reference - matches iter_reference_t
-    explicit ref_constructible_accumulator(int const& v)
+    ref_constructible_accumulator(int const& v)
       : value(v)
     {
     }
@@ -473,48 +473,80 @@ void test_fold_right_last_asymmetric()
 
 // Exercises the tightened constructible_from<U, iter_reference_t<Iter>>
 // constraint with ref_constructible_accumulator as the accumulator type U.
-// The seed expression U result{*first} / U result{*--it} constructs U
-// directly from the iterator reference - exactly what the requires()-clause
-// now mandates.
+//
+// For fold_left_first, U = decay_t<invoke_result_t<F&, iter_value_t<I>,
+// iter_reference_t<I>>>. The constraint additionally requires:
+//   constructible_from<U, iter_reference_t<I>>
+// so that the initial seed U result{*first} is valid.
+//
+// To satisfy is_indirect_binary_left_foldable the operator must also be
+// invocable with (U, iter_reference_t<I>), i.e. both the first call
+// F(iter_value_t, iter_reference_t) and subsequent calls F(U, iter_ref)
+// must compile. A generic lambda handles both overloads transparently.
 void test_fold_left_first_ref_constructible_constraint()
 {
     std::vector<int> c = {3, 1, 4, 1, 5};
 
-    // op: (ref_constructible_accumulator, int) -> ref_constructible_accumulator
-    // U = ref_constructible_accumulator
-    // The requires()-clause checks constructible_from<U, int const&>,
-    // which must hold for this to compile.
-    auto op = [](ref_constructible_accumulator acc,
-                  int const& elem) -> ref_constructible_accumulator {
-        acc.value += elem;
-        return acc;
+    // Use a struct with two overloads to handle both call sites:
+    // First call: F(int, int&)  -> rca  (satisfies invocable<F&, int, int&>)
+    // Later calls: F(rca, int&) -> rca  (satisfies invocable<F&, rca, int&>)
+    // U = ref_constructible_accumulator.
+    // constructible_from<rca, int&> is satisfied by rca(int const&).
+    struct fold_op
+    {
+        ref_constructible_accumulator operator()(
+            int seed, int const& elem) const
+        {
+            return ref_constructible_accumulator(seed + elem);
+        }
+        ref_constructible_accumulator operator()(
+            ref_constructible_accumulator acc, int const& elem) const
+        {
+            return ref_constructible_accumulator(acc.value + elem);
+        }
     };
 
-    auto result = hpx::ranges::fold_left_first(c, op);
+    auto result = hpx::ranges::fold_left_first(c, fold_op{});
     HPX_TEST(result.has_value());
-    // 3 + 1 + 4 + 1 + 5 = 14
+    // seed = c[0] = 3, then op(3, 1)=rca{4}, op(rca{4},4)=rca{8},
+    // op(rca{8},1)=rca{9}, op(rca{9},5)=rca{14}
     if (result)
     {
         HPX_TEST_EQ(result->value, 14);
     }
 }
 
+// Exercises the tightened constructible_from<U, iter_reference_t<Iter>>
+// constraint on fold_right_last. U = decay_t<invoke_result_t<F&,
+// iter_reference_t<I>, iter_value_t<I>>>. The constraint requires:
+//   constructible_from<U, iter_reference_t<I>>
+// so that U result{*--it} is valid.
 void test_fold_right_last_ref_constructible_constraint()
 {
     std::vector<int> c = {3, 1, 4, 1, 5};
 
-    // op: (int, ref_constructible_accumulator) -> ref_constructible_accumulator
-    // U = ref_constructible_accumulator
-    // The requires()-clause checks constructible_from<U, int const&>.
-    auto op = [](int const& elem, ref_constructible_accumulator acc)
-        -> ref_constructible_accumulator {
-        acc.value += elem;
-        return acc;
+    // Generic op: (int const&, auto) -> ref_constructible_accumulator.
+    // First call: F(int&, int) -> rca   (satisfies invocable<F&, int&, int>)
+    // Later calls: F(int&, rca) -> rca  (satisfies invocable<F&, int&, rca>)
+    struct fold_op
+    {
+        ref_constructible_accumulator operator()(
+            int const& elem, int seed) const
+        {
+            return ref_constructible_accumulator(elem + seed);
+        }
+        ref_constructible_accumulator operator()(
+            int const& elem, ref_constructible_accumulator acc) const
+        {
+            return ref_constructible_accumulator(elem + acc.value);
+        }
     };
 
-    auto result = hpx::ranges::fold_right_last(c, op);
+    auto result = hpx::ranges::fold_right_last(c, fold_op{});
     HPX_TEST(result.has_value());
-    // 3 + 1 + 4 + 1 + 5 = 14
+    // fold_right_last on {3,1,4,1,5}:
+    // seed=c[4]=5, op(1,5)=rca{6}, op(4,rca{6})=rca{10},
+    // op(1,rca{10})=rca{11}, op(3,rca{11})=rca{14}
     if (result)
     {
         HPX_TEST_EQ(result->value, 14);

--- a/libs/core/algorithms/tests/unit/container_algorithms/fold_range.cpp
+++ b/libs/core/algorithms/tests/unit/container_algorithms/fold_range.cpp
@@ -355,6 +355,32 @@ void test_fold_left_first_with_iter_empty()
 }
 
 #include <memory>
+#include <type_traits>
+
+// A type that is constructible from int const& (the iterator reference type
+// for vector<int>) but does NOT have an implicit conversion from int (the
+// iter_value_t). This distinguishes the tightened constraint
+//   constructible_from<U, iter_reference_t<Iter>>
+// from the old, weaker
+//   constructible_from<iter_value_t<Iter>, iter_reference_t<Iter>>.
+struct ref_constructible_accumulator
+{
+    int value;
+
+    // Constructible from a const lvalue reference — matches iter_reference_t
+    explicit ref_constructible_accumulator(int const& v)
+      : value(v)
+    {
+    }
+    ref_constructible_accumulator(
+        ref_constructible_accumulator const&) = default;
+    ref_constructible_accumulator(
+        ref_constructible_accumulator&&) = default;
+    ref_constructible_accumulator& operator=(
+        ref_constructible_accumulator const&) = default;
+    ref_constructible_accumulator& operator=(
+        ref_constructible_accumulator&&) = default;
+};
 
 struct copyable_asymmetric_accumulator
 {
@@ -373,6 +399,41 @@ struct copyable_asymmetric_accumulator
     copyable_asymmetric_accumulator& operator=(
         copyable_asymmetric_accumulator&&) = default;
 };
+
+// ---------------------------------------------------------------------------
+// Constraint verification (static_assert)
+//
+// The requires()-clause on fold_left_first / fold_right_last now enforces
+//   std::constructible_from<U, iter_reference_t<Iter>>
+// where U = decay_t<invoke_result_t<F&, iter_value_t<Iter>,
+//                                       iter_reference_t<Iter>>>.
+//
+// For vector<int>::iterator:
+//   iter_value_t      = int
+//   iter_reference_t  = int const& (conceptually; actually int& for vector)
+//
+// ref_constructible_accumulator is constructible from int const& directly,
+// so the constraint is satisfied. Verify this statically.
+// ---------------------------------------------------------------------------
+namespace constraint_checks {
+
+    using iter_ref_t = int const&;    // representative iter_reference_t
+    using iter_val_t = int;           // representative iter_value_t
+
+    // U = ref_constructible_accumulator (produced by the fold callable below)
+    // The constraint: constructible_from<U, iter_ref_t> must hold.
+    static_assert(std::constructible_from<ref_constructible_accumulator,
+                      iter_ref_t>,
+        "fold_left_first constraint: U must be constructible from "
+        "iter_reference_t<Iter>");
+
+    // Symmetrically for fold_right_last (same iterator/reference types here).
+    static_assert(std::constructible_from<ref_constructible_accumulator,
+                      iter_ref_t>,
+        "fold_right_last constraint: U must be constructible from "
+        "iter_reference_t<Iter>");
+
+}    // namespace constraint_checks
 
 void test_fold_left_first_asymmetric()
 {
@@ -412,6 +473,56 @@ void test_fold_right_last_asymmetric()
     }
 
     HPX_TEST(std::equal(c.begin(), c.end(), expected_c.begin()));
+}
+
+// Exercises the tightened constructible_from<U, iter_reference_t<Iter>>
+// constraint with ref_constructible_accumulator as the accumulator type U.
+// The seed expression U result{*first} / U result{*--it} constructs U
+// directly from the iterator reference — exactly what the requires()-clause
+// now mandates.
+void test_fold_left_first_ref_constructible_constraint()
+{
+    std::vector<int> c = {3, 1, 4, 1, 5};
+
+    // op: (ref_constructible_accumulator, int) -> ref_constructible_accumulator
+    // U = ref_constructible_accumulator
+    // The requires()-clause checks constructible_from<U, int const&>,
+    // which must hold for this to compile.
+    auto op = [](ref_constructible_accumulator acc, int const& elem)
+        -> ref_constructible_accumulator {
+        acc.value += elem;
+        return acc;
+    };
+
+    auto result = hpx::ranges::fold_left_first(c, op);
+    HPX_TEST(result.has_value());
+    // 3 + 1 + 4 + 1 + 5 = 14
+    if (result)
+    {
+        HPX_TEST_EQ(result->value, 14);
+    }
+}
+
+void test_fold_right_last_ref_constructible_constraint()
+{
+    std::vector<int> c = {3, 1, 4, 1, 5};
+
+    // op: (int, ref_constructible_accumulator) -> ref_constructible_accumulator
+    // U = ref_constructible_accumulator
+    // The requires()-clause checks constructible_from<U, int const&>.
+    auto op = [](int const& elem, ref_constructible_accumulator acc)
+        -> ref_constructible_accumulator {
+        acc.value += elem;
+        return acc;
+    };
+
+    auto result = hpx::ranges::fold_right_last(c, op);
+    HPX_TEST(result.has_value());
+    // 3 + 1 + 4 + 1 + 5 = 14
+    if (result)
+    {
+        HPX_TEST_EQ(result->value, 14);
+    }
 }
 
 void test_fold_custom_op()
@@ -454,6 +565,9 @@ int hpx_main()
 
     test_fold_left_first_asymmetric();
     test_fold_right_last_asymmetric();
+
+    test_fold_left_first_ref_constructible_constraint();
+    test_fold_right_last_ref_constructible_constraint();
 
     test_fold_custom_op();
 

--- a/libs/core/iterator_support/include/hpx/iterator_support/traits/is_foldable.hpp
+++ b/libs/core/iterator_support/include/hpx/iterator_support/traits/is_foldable.hpp
@@ -8,9 +8,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/iterator_support/boost_iterator_categories.hpp>
-#include <hpx/modules/functional.hpp>
-#include <hpx/modules/type_support.hpp>
+
 
 #include <concepts>
 #include <iterator>
@@ -26,9 +24,10 @@ namespace hpx {
         std::assignable_from<U&,
             std::invoke_result_t<F&, U, std::iter_reference_t<I>>>;
 
-    HPX_CXX_CORE_EXPORT template <typename F, typename T, typename I>
+    template <typename F, typename T, typename I>
     concept is_indirectly_binary_left_foldable =
-        std::copy_constructible<F> && std::indirectly_readable<I> &&
+        std::copy_constructible<F> &&
+        std::indirectly_readable<I> &&
         std::invocable<F&, T, std::iter_reference_t<I>> &&
         std::convertible_to<
             std::invoke_result_t<F&, T, std::iter_reference_t<I>>,
@@ -46,9 +45,10 @@ namespace hpx {
         std::assignable_from<U&,
             std::invoke_result_t<F&, std::iter_reference_t<I>, U>>;
 
-    HPX_CXX_CORE_EXPORT template <typename F, typename T, typename I>
+    template <typename F, typename T, typename I>
     concept is_indirectly_binary_right_foldable =
-        std::copy_constructible<F> && std::indirectly_readable<I> &&
+        std::copy_constructible<F> &&
+        std::indirectly_readable<I> &&
         std::invocable<F&, std::iter_reference_t<I>, T> &&
         std::convertible_to<
             std::invoke_result_t<F&, std::iter_reference_t<I>, T>,

--- a/libs/core/iterator_support/include/hpx/iterator_support/traits/is_foldable.hpp
+++ b/libs/core/iterator_support/include/hpx/iterator_support/traits/is_foldable.hpp
@@ -9,7 +9,6 @@
 
 #include <hpx/config.hpp>
 
-
 #include <concepts>
 #include <iterator>
 #include <type_traits>
@@ -26,8 +25,7 @@ namespace hpx {
 
     template <typename F, typename T, typename I>
     concept is_indirectly_binary_left_foldable =
-        std::copy_constructible<F> &&
-        std::indirectly_readable<I> &&
+        std::copy_constructible<F> && std::indirectly_readable<I> &&
         std::invocable<F&, T, std::iter_reference_t<I>> &&
         std::convertible_to<
             std::invoke_result_t<F&, T, std::iter_reference_t<I>>,
@@ -47,8 +45,7 @@ namespace hpx {
 
     template <typename F, typename T, typename I>
     concept is_indirectly_binary_right_foldable =
-        std::copy_constructible<F> &&
-        std::indirectly_readable<I> &&
+        std::copy_constructible<F> && std::indirectly_readable<I> &&
         std::invocable<F&, std::iter_reference_t<I>, T> &&
         std::convertible_to<
             std::invoke_result_t<F&, std::iter_reference_t<I>, T>,


### PR DESCRIPTION
This PR fixes a standard conformance bug in C++23 `fold_left_first` and `fold_right_last` algorithms where the accumulator return type was incorrectly deduced using two lvalue references. 

When invoking asymmetric binary operations (e.g., accumulating into a move-only type like `std::unique_ptr` using rvalue references), the previous `decltype(HPX_INVOKE(f, *first, *first))` would fail to compile because lvalue references cannot bind to rvalue references.

This commit updates the implementation to correctly use `decay_t<invoke_result_t<...>>` with the standard-mandated argument types (`iter_value_t` and `iter_reference_t`), ensuring full conformance with C++23 `[alg.fold]`. It also ensures the initial accumulator value is correctly moved using `HPX_MOVE`.

Added regression tests in `fold_range.cpp` to verify the fix with asymmetric accumulator functors.
