### PR TITLE
Use dedicated AGAS-specific RPC timeout for hosted namespaces

### DIFF
--- a/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
+++ b/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
@@ -746,6 +746,7 @@ The ``hpx.agas`` configuration section
    use_caching = ${HPX_AGAS_USE_CACHING:1}
    use_range_caching = ${HPX_AGAS_USE_RANGE_CACHING:1}
    local_cache_size = ${HPX_AGAS_LOCAL_CACHE_SIZE:<hpx_agas_local_cache_size>}
+   rpc_timeout = ${HPX_AGAS_RPC_TIMEOUT:5000}
 
 .. REVIEW regarding hpx.agas.address and hpx.agas.port: Technically, I believe
    --hpx:agas sets this parameter, this may need to be reworded.

--- a/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
+++ b/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
@@ -746,7 +746,7 @@ The ``hpx.agas`` configuration section
    use_caching = ${HPX_AGAS_USE_CACHING:1}
    use_range_caching = ${HPX_AGAS_USE_RANGE_CACHING:1}
    local_cache_size = ${HPX_AGAS_LOCAL_CACHE_SIZE:<hpx_agas_local_cache_size>}
-   rpc_timeout = ${HPX_AGAS_RPC_TIMEOUT:5000}
+   rpc_timeout = ${HPX_AGAS_RPC_TIMEOUT:60000}
 
 .. REVIEW regarding hpx.agas.address and hpx.agas.port: Technically, I believe
    --hpx:agas sets this parameter, this may need to be reworded.
@@ -803,7 +803,7 @@ The ``hpx.agas`` configuration section
        preprocessor constant ``HPX_AGAS_LOCAL_CACHE_SIZE`` (``4096``).
    * * ``hpx.agas.rpc_timeout``
      * This property specifies the timeout (in milliseconds) for :term:`AGAS`
-       RPC requests. Defaults to ``5000`` ms. This property can be configured
+       RPC requests. Defaults to ``60000`` ms. This property can be configured
        at startup (e.g., ``--hpx:ini=hpx.agas.rpc_timeout=...``), set through
        the ``HPX_AGAS_RPC_TIMEOUT`` environment variable, or updated at
        runtime via the atomic setter ``hpx::agas::set_rpc_timeout()``.

--- a/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
+++ b/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
@@ -801,6 +801,12 @@ The ``hpx.agas`` configuration section
        maximum number of ranges stored in the cache, not the number of entries
        spanned by the cache. The default depends on the compile time
        preprocessor constant ``HPX_AGAS_LOCAL_CACHE_SIZE`` (``4096``).
+   * * ``hpx.agas.rpc_timeout``
+     * This property specifies the timeout (in milliseconds) for :term:`AGAS`
+       RPC requests. Defaults to ``5000`` ms. This property can be configured
+       at startup (e.g., ``--hpx:ini=hpx.agas.rpc_timeout=...``), set through
+       the ``HPX_AGAS_RPC_TIMEOUT`` environment variable, or updated at
+       runtime via the atomic setter ``hpx::agas::set_rpc_timeout()``.
 
 The ``hpx.commandline`` configuration section
 .............................................

--- a/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
+++ b/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
@@ -804,7 +804,7 @@ The ``hpx.agas`` configuration section
    * * ``hpx.agas.rpc_timeout``
      * This property specifies the timeout (in milliseconds) for :term:`AGAS`
        RPC requests. Defaults to ``60000`` ms. This property can be configured
-       at startup (e.g., ``--hpx:ini=hpx.agas.rpc_timeout=...``), set through
+       at startup (e.g., ``--hpx:ini=hpx.agas.rpc_timeout=val``), set through
        the ``HPX_AGAS_RPC_TIMEOUT`` environment variable, or updated at
        runtime via the atomic setter ``hpx::agas::set_rpc_timeout()``.
 

--- a/libs/core/config/include/hpx/config.hpp
+++ b/libs/core/config/include/hpx/config.hpp
@@ -171,6 +171,18 @@
 #  define HPX_AGAS_LOCAL_CACHE_SIZE 4096
 #endif
 
+/// This defines the default AGAS RPC timeout in milliseconds.
+///
+/// This value can be changed at runtime by setting the configuration parameter:
+///
+///   hpx.agas.rpc_timeout = ...
+///
+/// (or by setting the corresponding environment variable
+/// HPX_AGAS_RPC_TIMEOUT)
+#if !defined(HPX_AGAS_RPC_TIMEOUT)
+#  define HPX_AGAS_RPC_TIMEOUT 60000
+#endif
+
 ///////////////////////////////////////////////////////////////////////////////
 #if !defined(HPX_INITIAL_AGAS_MAX_PENDING_REFCNT_REQUESTS)
 #  define HPX_INITIAL_AGAS_MAX_PENDING_REFCNT_REQUESTS 4096

--- a/libs/core/config/include/hpx/config.hpp
+++ b/libs/core/config/include/hpx/config.hpp
@@ -174,11 +174,10 @@
 /// This defines the default AGAS RPC timeout in milliseconds.
 ///
 /// This value can be changed at runtime by setting the configuration parameter:
-///
-///   hpx.agas.rpc_timeout = ...
-///
-/// (or by setting the corresponding environment variable
-/// HPX_AGAS_RPC_TIMEOUT)
+/// \code
+///   hpx.agas.rpc_timeout = val
+/// \endcode
+/// (or by setting the corresponding environment variable HPX_AGAS_RPC_TIMEOUT)
 #if !defined(HPX_AGAS_RPC_TIMEOUT)
 #  define HPX_AGAS_RPC_TIMEOUT 60000
 #endif

--- a/libs/core/runtime_configuration/include/hpx/runtime_configuration/runtime_configuration.hpp
+++ b/libs/core/runtime_configuration/include/hpx/runtime_configuration/runtime_configuration.hpp
@@ -90,6 +90,9 @@ namespace hpx::util {
 
         bool get_agas_range_caching_mode() const;
 
+        // Get AGAS RPC timeout in milliseconds
+        std::uint64_t get_agas_rpc_timeout(std::uint64_t dflt = 5000) const;
+
         std::size_t get_agas_max_pending_refcnt_requests() const;
 
         // Load application specific configuration and merge it with the

--- a/libs/core/runtime_configuration/include/hpx/runtime_configuration/runtime_configuration.hpp
+++ b/libs/core/runtime_configuration/include/hpx/runtime_configuration/runtime_configuration.hpp
@@ -91,7 +91,7 @@ namespace hpx::util {
         bool get_agas_range_caching_mode() const;
 
         // Get AGAS RPC timeout in milliseconds
-        std::uint64_t get_agas_rpc_timeout(std::uint64_t dflt = 5000) const;
+        std::uint64_t get_agas_rpc_timeout(std::uint64_t dflt = 60000) const;
 
         std::size_t get_agas_max_pending_refcnt_requests() const;
 

--- a/libs/core/runtime_configuration/include/hpx/runtime_configuration/runtime_configuration.hpp
+++ b/libs/core/runtime_configuration/include/hpx/runtime_configuration/runtime_configuration.hpp
@@ -91,7 +91,8 @@ namespace hpx::util {
         bool get_agas_range_caching_mode() const;
 
         // Get AGAS RPC timeout in milliseconds
-        std::uint64_t get_agas_rpc_timeout(std::uint64_t dflt = 60000) const;
+        std::uint64_t get_agas_rpc_timeout(
+            std::uint64_t dflt = HPX_AGAS_RPC_TIMEOUT) const;
 
         std::size_t get_agas_max_pending_refcnt_requests() const;
 

--- a/libs/core/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/core/runtime_configuration/src/runtime_configuration.cpp
@@ -318,6 +318,7 @@ namespace hpx::util {
                 HPX_PP_EXPAND(HPX_AGAS_LOCAL_CACHE_SIZE)) "}",
             "use_range_caching = ${HPX_AGAS_USE_RANGE_CACHING:1}",
             "use_caching = ${HPX_AGAS_USE_CACHING:1}",
+            "rpc_timeout = ${HPX_AGAS_RPC_TIMEOUT:5000}",
 
             "[hpx.components]",
             "load_external = ${HPX_LOAD_EXTERNAL_COMPONENTS:1}",
@@ -939,6 +940,19 @@ namespace hpx::util {
                 0;
         }
         return false;
+    }
+
+    std::uint64_t runtime_configuration::get_agas_rpc_timeout(
+        std::uint64_t const dflt) const
+    {
+        std::uint64_t timeout = dflt;
+
+        if (util::section const* sec = get_section("hpx.agas"); nullptr != sec)
+        {
+            timeout = hpx::util::get_entry_as<std::uint64_t>(
+                *sec, "rpc_timeout", timeout);
+        }
+        return timeout;
     }
 
     std::size_t runtime_configuration::get_agas_max_pending_refcnt_requests()

--- a/libs/core/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/core/runtime_configuration/src/runtime_configuration.cpp
@@ -318,7 +318,7 @@ namespace hpx::util {
                 HPX_PP_EXPAND(HPX_AGAS_LOCAL_CACHE_SIZE)) "}",
             "use_range_caching = ${HPX_AGAS_USE_RANGE_CACHING:1}",
             "use_caching = ${HPX_AGAS_USE_CACHING:1}",
-            "rpc_timeout = ${HPX_AGAS_RPC_TIMEOUT:5000}",
+            "rpc_timeout = ${HPX_AGAS_RPC_TIMEOUT:60000}",
 
             "[hpx.components]",
             "load_external = ${HPX_LOAD_EXTERNAL_COMPONENTS:1}",

--- a/libs/core/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/core/runtime_configuration/src/runtime_configuration.cpp
@@ -318,7 +318,8 @@ namespace hpx::util {
                 HPX_PP_EXPAND(HPX_AGAS_LOCAL_CACHE_SIZE)) "}",
             "use_range_caching = ${HPX_AGAS_USE_RANGE_CACHING:1}",
             "use_caching = ${HPX_AGAS_USE_CACHING:1}",
-            "rpc_timeout = ${HPX_AGAS_RPC_TIMEOUT:60000}",
+            "rpc_timeout = ${HPX_AGAS_RPC_TIMEOUT:" HPX_PP_STRINGIZE(
+                HPX_PP_EXPAND(HPX_AGAS_RPC_TIMEOUT)) "}",
 
             "[hpx.components]",
             "load_external = ${HPX_LOAD_EXTERNAL_COMPONENTS:1}",

--- a/libs/full/agas/src/addressing_service.cpp
+++ b/libs/full/agas/src/addressing_service.cpp
@@ -132,6 +132,10 @@ namespace hpx::agas {
     {
         if (caching_)
             gva_cache_->reserve(ini_.get_agas_local_cache_size());
+
+        std::uint64_t const timeout_ms = ini_.get_agas_rpc_timeout();
+        hpx::agas::set_rpc_timeout(hpx::chrono::steady_duration(
+            std::chrono::milliseconds(timeout_ms)));
     }
 
     void addressing_service::bootstrap(

--- a/libs/full/agas_base/CMakeLists.txt
+++ b/libs/full/agas_base/CMakeLists.txt
@@ -55,6 +55,7 @@ set(agas_base_sources
     gva.cpp
     locality_namespace.cpp
     primary_namespace.cpp
+    rpc_timeout.cpp
     server/component_namespace_server.cpp
     server/locality_namespace_server.cpp
     server/primary_namespace_server.cpp

--- a/libs/full/agas_base/include/hpx/agas_base/agas_fwd.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/agas_fwd.hpp
@@ -9,6 +9,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/modules/functional.hpp>
+#include <hpx/modules/timing.hpp>
 
 #include <cstdint>
 #include <string>
@@ -47,6 +48,16 @@ namespace hpx::agas {
     HPX_CXX_EXPORT using iterate_types_function_type =
         hpx::function<void(std::string const&, components::component_type),
             true>;
+
+    /// \brief Get the currently configured timeout for AGAS RPC operations.
+    HPX_CXX_EXPORT HPX_EXPORT hpx::chrono::steady_duration
+    get_rpc_timeout() noexcept;
+
+    /// \brief Set the timeout for AGAS RPC operations.
+    ///
+    /// \param timeout The new duration for AGAS RPC timeouts.
+    HPX_CXX_EXPORT HPX_EXPORT void set_rpc_timeout(
+        hpx::chrono::steady_duration const& timeout) noexcept;
 
     HPX_CXX_EXPORT struct HPX_EXPORT component_namespace;
     HPX_CXX_EXPORT struct HPX_EXPORT locality_namespace;

--- a/libs/full/agas_base/include/hpx/agas_base/agas_fwd.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/agas_fwd.hpp
@@ -56,7 +56,7 @@ namespace hpx::agas {
     /// \brief Set the timeout for AGAS RPC operations.
     ///
     /// \param timeout The new duration for AGAS RPC timeouts.
-    /// \returns true if timeout is valid (>0) and set successfully, false otherwise.
+    /// \returns true if timeout is strictly positive and set successfully, false otherwise.
     HPX_CXX_EXPORT HPX_EXPORT bool set_rpc_timeout(
         hpx::chrono::steady_duration const& timeout) noexcept;
 

--- a/libs/full/agas_base/include/hpx/agas_base/agas_fwd.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/agas_fwd.hpp
@@ -56,7 +56,8 @@ namespace hpx::agas {
     /// \brief Set the timeout for AGAS RPC operations.
     ///
     /// \param timeout The new duration for AGAS RPC timeouts.
-    HPX_CXX_EXPORT HPX_EXPORT void set_rpc_timeout(
+    /// \returns true if timeout is valid (>0) and set successfully, false otherwise.
+    HPX_CXX_EXPORT HPX_EXPORT bool set_rpc_timeout(
         hpx::chrono::steady_duration const& timeout) noexcept;
 
     HPX_CXX_EXPORT struct HPX_EXPORT component_namespace;

--- a/libs/full/agas_base/src/detail/hosted_component_namespace.cpp
+++ b/libs/full/agas_base/src/detail/hosted_component_namespace.cpp
@@ -40,7 +40,8 @@ namespace hpx::agas::detail {
         constexpr server::component_namespace::bind_prefix_action action;
         return hpx::wait_or_handle_timeout(
             hpx::async(action, gid_, key, prefix),
-            "hosted_component_namespace::bind_prefix");
+            "hosted_component_namespace::bind_prefix",
+            hpx::agas::get_rpc_timeout());
 #else
         HPX_ASSERT(false);
         return components::component_type{};
@@ -53,7 +54,8 @@ namespace hpx::agas::detail {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         constexpr server::component_namespace::bind_name_action action;
         return hpx::wait_or_handle_timeout(hpx::async(action, gid_, name),
-            "hosted_component_namespace::bind_name");
+            "hosted_component_namespace::bind_name",
+            hpx::agas::get_rpc_timeout());
 #else
         HPX_ASSERT(false);
         return components::component_type{};
@@ -66,7 +68,8 @@ namespace hpx::agas::detail {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         constexpr server::component_namespace::resolve_id_action action;
         return hpx::wait_or_handle_timeout(hpx::async(action, gid_, key),
-            "hosted_component_namespace::resolve_id");
+            "hosted_component_namespace::resolve_id",
+            hpx::agas::get_rpc_timeout());
 #else
         HPX_ASSERT(false);
         return std::vector<std::uint32_t>{1, std::uint32_t(0)};
@@ -79,7 +82,7 @@ namespace hpx::agas::detail {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         constexpr server::component_namespace::unbind_action action;
         return hpx::wait_or_handle_timeout(hpx::async(action, gid_, key),
-            "hosted_component_namespace::unbind");
+            "hosted_component_namespace::unbind", hpx::agas::get_rpc_timeout());
 #else
         HPX_ASSERT(false);
         return true;
@@ -92,7 +95,8 @@ namespace hpx::agas::detail {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         constexpr server::component_namespace::iterate_types_action action;
         return hpx::wait_or_handle_timeout(hpx::async(action, gid_, f),
-            "hosted_component_namespace::iterate_types");
+            "hosted_component_namespace::iterate_types",
+            hpx::agas::get_rpc_timeout());
 #else
         HPX_ASSERT(false);
 #endif
@@ -105,7 +109,8 @@ namespace hpx::agas::detail {
         constexpr server::component_namespace::get_component_type_name_action
             action;
         return hpx::wait_or_handle_timeout(hpx::async(action, gid_, type),
-            "hosted_component_namespace::get_component_type_name");
+            "hosted_component_namespace::get_component_type_name",
+            hpx::agas::get_rpc_timeout());
 #else
         HPX_ASSERT(false);
         return std::string{};

--- a/libs/full/agas_base/src/detail/hosted_locality_namespace.cpp
+++ b/libs/full/agas_base/src/detail/hosted_locality_namespace.cpp
@@ -48,7 +48,7 @@ namespace hpx::agas::detail {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         constexpr server::locality_namespace::free_action action;
         return hpx::wait_or_handle_timeout(hpx::async(action, gid_, locality),
-            "hosted_locality_namespace::free");
+            "hosted_locality_namespace::free", hpx::agas::get_rpc_timeout());
 #else
         HPX_ASSERT(false);
         return false;
@@ -59,8 +59,9 @@ namespace hpx::agas::detail {
     {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         constexpr server::locality_namespace::localities_action action;
-        return hpx::wait_or_handle_timeout(
-            hpx::async(action, gid_), "hosted_locality_namespace::localities");
+        return hpx::wait_or_handle_timeout(hpx::async(action, gid_),
+            "hosted_locality_namespace::localities",
+            hpx::agas::get_rpc_timeout());
 #else
         HPX_ASSERT(false);
         return std::vector<std::uint32_t>{};
@@ -85,7 +86,8 @@ namespace hpx::agas::detail {
         }
 
         return hpx::wait_or_handle_timeout(HPX_MOVE(endpoints_future),
-            "hosted_locality_namespace::resolve_locality");
+            "hosted_locality_namespace::resolve_locality",
+            hpx::agas::get_rpc_timeout());
 #else
         HPX_ASSERT(false);
         return parcelset::endpoints_type{};
@@ -97,7 +99,8 @@ namespace hpx::agas::detail {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         constexpr server::locality_namespace::get_num_localities_action action;
         return hpx::wait_or_handle_timeout(hpx::async(action, gid_),
-            "hosted_locality_namespace::get_num_localities");
+            "hosted_locality_namespace::get_num_localities",
+            hpx::agas::get_rpc_timeout());
 #else
         HPX_ASSERT(false);
         return std::uint32_t{};
@@ -121,7 +124,8 @@ namespace hpx::agas::detail {
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         constexpr server::locality_namespace::get_num_threads_action action;
         return hpx::wait_or_handle_timeout(hpx::async(action, gid_),
-            "hosted_locality_namespace::get_num_threads");
+            "hosted_locality_namespace::get_num_threads",
+            hpx::agas::get_rpc_timeout());
 #else
         HPX_ASSERT(false);
         return std::vector<std::uint32_t>{};
@@ -146,7 +150,8 @@ namespace hpx::agas::detail {
         constexpr server::locality_namespace::get_num_overall_threads_action
             action;
         return hpx::wait_or_handle_timeout(hpx::async(action, gid_),
-            "hosted_locality_namespace::get_num_overall_threads");
+            "hosted_locality_namespace::get_num_overall_threads",
+            hpx::agas::get_rpc_timeout());
 #else
         HPX_ASSERT(false);
         return hpx::resource::get_num_threads();

--- a/libs/full/agas_base/src/rpc_timeout.cpp
+++ b/libs/full/agas_base/src/rpc_timeout.cpp
@@ -16,13 +16,14 @@ namespace hpx::agas {
 
     void set_rpc_timeout(hpx::chrono::steady_duration const& timeout) noexcept
     {
-        auto const timeout_ms =
-            std::chrono::duration_cast<std::chrono::milliseconds>(
-                timeout.value());
-        
-        if (timeout_ms.count() >= 0){
+        if (timeout.value() >= timeout.value().zero())
+        {
+            auto const timeout_ms =
+                std::chrono::duration_cast<std::chrono::milliseconds>(
+                    timeout.value());
+
             agas_rpc_timeout_ms.store(
-                static_cast<std::uint64_t>(timeout_ms.count()), 
+                static_cast<std::uint64_t>(timeout_ms.count()),
                 std::memory_order_relaxed);
         }
     }

--- a/libs/full/agas_base/src/rpc_timeout.cpp
+++ b/libs/full/agas_base/src/rpc_timeout.cpp
@@ -12,7 +12,7 @@
 
 namespace hpx::agas {
 
-    static std::atomic<std::uint64_t> agas_rpc_timeout_ms{5000};
+    static std::atomic<std::uint64_t> agas_rpc_timeout_ms{60000};
 
     void set_rpc_timeout(hpx::chrono::steady_duration const& timeout) noexcept
     {

--- a/libs/full/agas_base/src/rpc_timeout.cpp
+++ b/libs/full/agas_base/src/rpc_timeout.cpp
@@ -1,0 +1,31 @@
+//  Copyright (c) 2026 Apoorv Shah
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/agas_base/agas_fwd.hpp>
+#include <hpx/modules/timing.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+
+namespace hpx::agas {
+
+    static std::atomic<std::uint64_t> agas_rpc_timeout_ms{5000};
+
+    void set_rpc_timeout(hpx::chrono::steady_duration const& timeout) noexcept
+    {
+        auto const timeout_ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                timeout.value());
+        agas_rpc_timeout_ms.store(
+            timeout_ms.count(), std::memory_order_relaxed);
+    }
+
+    hpx::chrono::steady_duration get_rpc_timeout() noexcept
+    {
+        auto const ms = agas_rpc_timeout_ms.load(std::memory_order_relaxed);
+        return hpx::chrono::steady_duration(std::chrono::milliseconds(ms));
+    }
+}    // namespace hpx::agas

--- a/libs/full/agas_base/src/rpc_timeout.cpp
+++ b/libs/full/agas_base/src/rpc_timeout.cpp
@@ -19,8 +19,12 @@ namespace hpx::agas {
         auto const timeout_ms =
             std::chrono::duration_cast<std::chrono::milliseconds>(
                 timeout.value());
-        agas_rpc_timeout_ms.store(
-            timeout_ms.count(), std::memory_order_relaxed);
+        
+        if (timeout_ms.count() >= 0){
+            agas_rpc_timeout_ms.store(
+                static_cast<std::uint64_t>(timeout_ms.count()), 
+                std::memory_order_relaxed);
+        }
     }
 
     hpx::chrono::steady_duration get_rpc_timeout() noexcept

--- a/libs/full/agas_base/src/rpc_timeout.cpp
+++ b/libs/full/agas_base/src/rpc_timeout.cpp
@@ -12,11 +12,11 @@
 
 namespace hpx::agas {
 
-    static std::atomic<std::uint64_t> agas_rpc_timeout_ms{60000};
+    static std::atomic<std::uint64_t> agas_rpc_timeout_ms{HPX_AGAS_RPC_TIMEOUT};
 
-    void set_rpc_timeout(hpx::chrono::steady_duration const& timeout) noexcept
+    bool set_rpc_timeout(hpx::chrono::steady_duration const& timeout) noexcept
     {
-        if (timeout.value() >= timeout.value().zero())
+        if (timeout.value() > timeout.value().zero())
         {
             auto const timeout_ms =
                 std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -25,7 +25,9 @@ namespace hpx::agas {
             agas_rpc_timeout_ms.store(
                 static_cast<std::uint64_t>(timeout_ms.count()),
                 std::memory_order_relaxed);
+            return true;
         }
+        return false;
     }
 
     hpx::chrono::steady_duration get_rpc_timeout() noexcept

--- a/libs/full/agas_base/tests/unit/CMakeLists.txt
+++ b/libs/full/agas_base/tests/unit/CMakeLists.txt
@@ -3,3 +3,24 @@
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests agas_rpc_timeout agas_rpc_timeout_ini)
+
+foreach(test ${tests})
+  set(sources ${test}.cpp)
+
+  source_group("Source Files" FILES ${sources})
+
+  set(folder_name "Tests/Unit/Modules/Full/AgasBase")
+
+  add_hpx_executable(
+    ${test}_test INTERNAL_FLAGS
+    SOURCES ${sources} ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    FOLDER ${folder_name}
+    DEPENDENCIES hpx_agas_base
+  )
+
+  add_hpx_unit_test("modules.agas_base" ${test} ${${test}_PARAMETERS})
+  add_hpx_pseudo_dependencies(tests.unit.modules.agas_base ${test}_test)
+endforeach()

--- a/libs/full/agas_base/tests/unit/CMakeLists.txt
+++ b/libs/full/agas_base/tests/unit/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The STE||AR-Group
+# Copyright (c) 2020-2026 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -18,9 +18,7 @@ foreach(test ${tests})
     SOURCES ${sources} ${${test}_FLAGS}
     EXCLUDE_FROM_ALL
     FOLDER ${folder_name}
-    DEPENDENCIES hpx_agas_base
   )
 
   add_hpx_unit_test("modules.agas_base" ${test} ${${test}_PARAMETERS})
-  add_hpx_pseudo_dependencies(tests.unit.modules.agas_base ${test}_test)
 endforeach()

--- a/libs/full/agas_base/tests/unit/agas_rpc_timeout.cpp
+++ b/libs/full/agas_base/tests/unit/agas_rpc_timeout.cpp
@@ -1,0 +1,46 @@
+//  Copyright (c) 2026 Apoorv Shah
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/agas_base/agas_fwd.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/modules/timing.hpp>
+
+#include <chrono>
+#include <cstdint>
+
+int hpx_main()
+{
+    {
+        auto const current_timeout = hpx::agas::get_rpc_timeout();
+        auto const ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+            current_timeout.value())
+                            .count();
+
+        HPX_TEST_EQ(ms, std::int64_t(5000));
+    }
+
+    {
+        hpx::chrono::steady_duration const custom_timeout(
+            std::chrono::milliseconds(12345));
+
+        hpx::agas::set_rpc_timeout(custom_timeout);
+
+        auto const current_timeout = hpx::agas::get_rpc_timeout();
+        auto const ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+            current_timeout.value())
+                            .count();
+
+        HPX_TEST_EQ(ms, std::int64_t(12345));
+    }
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ(hpx::init(argc, argv), 0);
+    return hpx::util::report_errors();
+}

--- a/libs/full/agas_base/tests/unit/agas_rpc_timeout.cpp
+++ b/libs/full/agas_base/tests/unit/agas_rpc_timeout.cpp
@@ -51,6 +51,20 @@ int hpx_main()
     }
 
     {
+        hpx::chrono::steady_duration const sub_ms_negative_timeout(
+            hpx::chrono::steady_clock::duration(-1));
+
+        hpx::agas::set_rpc_timeout(sub_ms_negative_timeout);
+
+        auto const current_timeout = hpx::agas::get_rpc_timeout();
+        auto const ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+            current_timeout.value())
+                            .count();
+
+        HPX_TEST_EQ(ms, std::int64_t(12345));
+    }
+
+    {
         hpx::chrono::steady_duration const zero_timeout(
             std::chrono::milliseconds(0));
 

--- a/libs/full/agas_base/tests/unit/agas_rpc_timeout.cpp
+++ b/libs/full/agas_base/tests/unit/agas_rpc_timeout.cpp
@@ -36,6 +36,34 @@ int hpx_main()
         HPX_TEST_EQ(ms, std::int64_t(12345));
     }
 
+    {
+        hpx::chrono::steady_duration const negative_timeout(
+            std::chrono::milliseconds(-1));
+
+        hpx::agas::set_rpc_timeout(negative_timeout);
+
+        auto const current_timeout = hpx::agas::get_rpc_timeout();
+        auto const ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+            current_timeout.value())
+                            .count();
+
+        HPX_TEST_EQ(ms, std::int64_t(12345));
+    }
+
+    {
+        hpx::chrono::steady_duration const zero_timeout(
+            std::chrono::milliseconds(0));
+
+        hpx::agas::set_rpc_timeout(zero_timeout);
+
+        auto const current_timeout = hpx::agas::get_rpc_timeout();
+        auto const ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+            current_timeout.value())
+                            .count();
+
+        HPX_TEST_EQ(ms, std::int64_t(0));
+    }
+
     return hpx::finalize();
 }
 

--- a/libs/full/agas_base/tests/unit/agas_rpc_timeout.cpp
+++ b/libs/full/agas_base/tests/unit/agas_rpc_timeout.cpp
@@ -19,7 +19,7 @@ int hpx_main()
             current_timeout.value())
                             .count();
 
-        HPX_TEST_EQ(ms, std::int64_t(5000));
+        HPX_TEST_EQ(ms, std::int64_t(60000));
     }
 
     {

--- a/libs/full/agas_base/tests/unit/agas_rpc_timeout.cpp
+++ b/libs/full/agas_base/tests/unit/agas_rpc_timeout.cpp
@@ -26,7 +26,7 @@ int hpx_main()
         hpx::chrono::steady_duration const custom_timeout(
             std::chrono::milliseconds(12345));
 
-        hpx::agas::set_rpc_timeout(custom_timeout);
+        HPX_TEST(hpx::agas::set_rpc_timeout(custom_timeout));
 
         auto const current_timeout = hpx::agas::get_rpc_timeout();
         auto const ms = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -40,7 +40,7 @@ int hpx_main()
         hpx::chrono::steady_duration const negative_timeout(
             std::chrono::milliseconds(-1));
 
-        hpx::agas::set_rpc_timeout(negative_timeout);
+        HPX_TEST(!hpx::agas::set_rpc_timeout(negative_timeout));
 
         auto const current_timeout = hpx::agas::get_rpc_timeout();
         auto const ms = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -54,7 +54,7 @@ int hpx_main()
         hpx::chrono::steady_duration const sub_ms_negative_timeout(
             hpx::chrono::steady_clock::duration(-1));
 
-        hpx::agas::set_rpc_timeout(sub_ms_negative_timeout);
+        HPX_TEST(!hpx::agas::set_rpc_timeout(sub_ms_negative_timeout));
 
         auto const current_timeout = hpx::agas::get_rpc_timeout();
         auto const ms = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -68,14 +68,14 @@ int hpx_main()
         hpx::chrono::steady_duration const zero_timeout(
             std::chrono::milliseconds(0));
 
-        hpx::agas::set_rpc_timeout(zero_timeout);
+        HPX_TEST(!hpx::agas::set_rpc_timeout(zero_timeout));
 
         auto const current_timeout = hpx::agas::get_rpc_timeout();
         auto const ms = std::chrono::duration_cast<std::chrono::milliseconds>(
             current_timeout.value())
                             .count();
 
-        HPX_TEST_EQ(ms, std::int64_t(0));
+        HPX_TEST_EQ(ms, std::int64_t(12345));
     }
 
     return hpx::finalize();

--- a/libs/full/agas_base/tests/unit/agas_rpc_timeout_ini.cpp
+++ b/libs/full/agas_base/tests/unit/agas_rpc_timeout_ini.cpp
@@ -1,0 +1,37 @@
+//  Copyright (c) 2026 Apoorv Shah
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/agas_base/agas_fwd.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/modules/timing.hpp>
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+int hpx_main()
+{
+    auto const current_timeout = hpx::agas::get_rpc_timeout();
+    auto const ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+        current_timeout.value())
+                        .count();
+
+    HPX_TEST_EQ(ms, std::int64_t(8888));
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> const cfg = {"hpx.agas.rpc_timeout = 8888"};
+
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
+    return hpx::util::report_errors();
+}

--- a/libs/full/agas_base/tests/unit/agas_rpc_timeout_ini.cpp
+++ b/libs/full/agas_base/tests/unit/agas_rpc_timeout_ini.cpp
@@ -19,7 +19,6 @@ int hpx_main()
     auto const ms = std::chrono::duration_cast<std::chrono::milliseconds>(
         current_timeout.value())
                         .count();
-
     HPX_TEST_EQ(ms, std::int64_t(8888));
 
     return hpx::finalize();


### PR DESCRIPTION
Fixes #7467

## Proposed Changes
- Add `rpc_timeout` configuration entry to `[hpx.agas]` INI table (defaulting to 5000 ms via `${HPX_AGAS_RPC_TIMEOUT:5000}`) and document it in the Sphinx manual.
- Add `runtime_configuration::get_agas_rpc_timeout()` to retrieve the configured AGAS RPC timeout.
- Introduce `hpx::agas::get_rpc_timeout()` and `hpx::agas::set_rpc_timeout()` in `agas_base`.
- Propagate the configured timeout in `addressing_service` initialization during runtime.
- Explicitly pass `hpx::agas::get_rpc_timeout()` to `hpx::wait_or_handle_timeout(...)` across all AGAS RPC call sites in `hosted_locality_namespace.cpp` and `hosted_component_namespace.cpp`.
- Add unit tests (`agas_rpc_timeout` and `agas_rpc_timeout_ini`) in `agas_base` to verify.

## Any background context you want to provide?
Previously, wrapped AGAS RPC calls in `hosted_locality_namespace` and `hosted_component_namespace` defaulted to using the global process-wide future timeout (`hpx::get_future_timeout()`). 

This change decouples AGAS operations from generic process-wide future timeouts, preventing unintended side effects when modifying global future wait timeouts and allowing AGAS RPC timing to be configured independently.

## Checklist
- [x] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.