### PR TITLE
Fix cross-references in documentation

### DIFF
--- a/components/supervision_dispatch/docs/index.rst
+++ b/components/supervision_dispatch/docs/index.rst
@@ -15,8 +15,8 @@ The supervision dispatch module provides peer discovery, cooperative
 lifecycle management, failure detection, and fenced action dispatch across
 localities, built on top of the :ref:`supervision <modules_supervision>`
 module's lifecycle events and admission checks. See that module's reference
-for the semantics of :cpp:func:`hpx::supervision::check_admission` and
-:cpp:type:`hpx::supervision::dispatch_outcome`; this page documents only the
+for the semantics of :hpx:func:`hpx::supervision::check_admission` and
+:hpx:type:`hpx::supervision::dispatch_outcome`; this page documents only the
 dispatch-specific surface layered on top of them. For the narrative on
 initialization ordering, one-shot discovery, shadow-state semantics, and
 client-side filtering versus fenced-dispatch admission, see
@@ -211,7 +211,7 @@ Fenced dispatch
     short-circuit an already-known-fenced target, then dispatches to the
     target's own locality (via ``hpx::colocated``) where an authoritative
     re-check against the same latch consulted by
-    :cpp:func:`hpx::supervision::check_admission` runs immediately before the
+    :hpx:func:`hpx::supervision::check_admission` runs immediately before the
     wrapped action executes, on the same thread, closing the
     admission/invocation race. See
     :doc:`/manual/supervision_dispatch` for the full client-side-filtering

--- a/docs/sphinx/examples/accumulator.rst
+++ b/docs/sphinx/examples/accumulator.rst
@@ -117,15 +117,15 @@ The following code is from
 :hpx-header:`examples/accumulators,server/accumulator.hpp`.
 
 All |hpx| component server classes must inherit publicly from the |hpx|
-component base class: :cpp:class:`hpx::components::component_base`
+component base class: :hpx:class:`hpx::components::component_base`
 
 The accumulator component inherits from
-:cpp:class:`hpx::components::locking_hook`. This allows the runtime system to
+:hpx:class:`hpx::components::locking_hook`. This allows the runtime system to
 ensure that all action invocations are serialized. That means that the system
 ensures that no two actions are invoked at the same time on a given component
 instance. This makes the component thread safe and no additional locking has to
 be implemented by the user. Moreover, an accumulator component is a component
-because it also inherits from :cpp:class:`hpx::components::component_base` (the
+because it also inherits from :hpx:class:`hpx::components::component_base` (the
 template argument passed to locking_hook is used as its base class). The
 following snippet shows the corresponding code:
 
@@ -207,7 +207,7 @@ and to invoke component actions::
     c.add(hpx::launch::apply, 4);
 
 Clients, like servers, need to inherit from a base class, this time,
-:cpp:class:`hpx::components::client_base`:
+:hpx:class:`hpx::components::client_base`:
 
 .. literalinclude:: ../../examples/accumulators/accumulator.hpp
    :language: c++
@@ -229,7 +229,7 @@ There are a few different ways of invoking actions:
   care about the result of an action, we can invoke the action using
   fire-and-forget semantics. This means that once we have asked |hpx| to compute
   the action, we forget about it completely and continue with our computation.
-  We use :cpp:func:`hpx::post` to invoke an action in a non-blocking fashion.
+  We use :hpx:func:`hpx::post` to invoke an action in a non-blocking fashion.
 
 .. literalinclude:: ../../examples/accumulators/accumulator.hpp
    :language: c++
@@ -247,8 +247,8 @@ There are a few different ways of invoking actions:
    :end-before: //]
 
 * **Synchronous**: To invoke an action in a fully synchronous manner, we can
-  simply call :cpp:func:`hpx::sync` which is semantically equivalent to
-  :cpp:func:`hpx::async`\ ``().get()`` (i.e., create a future and immediately
+  simply call :hpx:func:`hpx::sync` which is semantically equivalent to
+  :hpx:func:`hpx::async`\ ``().get()`` (i.e., create a future and immediately
   wait on it to be ready). Here's an example from the accumulator
   client class:
 
@@ -258,12 +258,12 @@ There are a few different ways of invoking actions:
    :end-before: //]
 
 Note that ``this->get_id()`` references a data member of the
-:cpp:class:`hpx::components::client_base` base class which identifies the server
+:hpx:class:`hpx::components::client_base` base class which identifies the server
 accumulator instance.
 
-:cpp:class:`hpx::id_type` is a type which represents a global identifier
+:hpx:struct:`hpx::id_type` is a type which represents a global identifier
 in |hpx|. This type specifies the target of an action. This is the type that is
-returned by :cpp:func:`hpx::find_here` in which case it represents the
+returned by :hpx:func:`hpx::find_here` in which case it represents the
 :term:`locality` the code is running on.
 
 
@@ -280,8 +280,8 @@ The following code is from
 :hpx-header:`examples/accumulators,server/template_accumulator.hpp`.
 
 Similarly to the accumulator example, the component server class
-inherits publicly from :cpp:class:`hpx::components::component_base` and from
-:cpp:class:`hpx::components::locking_hook` ensuring thread-safe method invocations.
+inherits publicly from :hpx:class:`hpx::components::component_base` and from
+:hpx:class:`hpx::components::locking_hook` ensuring thread-safe method invocations.
 
 .. literalinclude:: ../../examples/accumulators/server/template_accumulator.hpp
    :language: c++
@@ -334,7 +334,7 @@ The server class
 The following code is from
 :hpx-header:`examples/accumulators,server/template_function_accumulator.hpp`.
 
-The component server class inherits publicly from :cpp:class:`hpx::components::component_base`.
+The component server class inherits publicly from :hpx:class:`hpx::components::component_base`.
 
 .. literalinclude:: ../../examples/accumulators/server/template_function_accumulator.hpp
    :language: c++

--- a/docs/sphinx/examples/fibonacci.rst
+++ b/docs/sphinx/examples/fibonacci.rst
@@ -16,7 +16,7 @@ Asynchronous execution with actions
 This example extends the :ref:`previous example <examples_fibonacci_local>` by
 introducing :term:`actions<action>`: functions that can be run remotely. In this
 example, however, we will still only run the action locally. The mechanism to
-execute :term:`actions<action>` stays the same: :cpp:func:`hpx::async`. Later
+execute :term:`actions<action>` stays the same: :hpx:func:`hpx::async`. Later
 examples will demonstrate running actions on remote :term:`localities<locality>`
 (e.g. :ref:`examples_hello_world`).
 
@@ -76,10 +76,10 @@ The code needed to initialize the |hpx| runtime is the same as in the
    :end-before: //]
 
 
-The :cpp:func:`hpx::init` function in ``main()`` starts the runtime system, and
+The :hpx:func:`hpx::init` function in ``main()`` starts the runtime system, and
 invokes ``hpx_main()`` as the first |hpx|-thread. The command line option
 ``--n-value`` is read in, a timer
-(:cpp:class:`hpx::chrono::high_resolution_timer`) is set up to record the time it
+(:hpx:class:`hpx::chrono::high_resolution_timer`) is set up to record the time it
 takes to do the computation, the ``fibonacci`` :term:`action` is invoked
 synchronously, and the answer is printed out.
 
@@ -98,7 +98,7 @@ send packets of work to different processing units. These vehicles allow users
 to calculate work now, later, or on certain nodes. The first argument to our
 :term:`action` is the location where the :term:`action` should be run. In this
 case, we just want to run the :term:`action` on the machine that we are
-currently on, so we use :cpp:func:`hpx::find_here`. To
+currently on, so we use :hpx:func:`hpx::find_here`. To
 further understand this we turn to the code to find where ``fibonacci_action``
 was defined:
 
@@ -131,7 +131,7 @@ This block of code is much more straightforward and should look familiar from
 the :ref:`previous example <examples_fibonacci_local>`. First, ``if (n < 2)``,
 meaning n is 0 or 1, then we return 0 or 1 (recall the first element of the
 Fibonacci sequence is 0 and the second is 1). If n is larger than 1 we spawn two
-tasks using :cpp:func:`hpx::async`. Each of these futures represents an
+tasks using :hpx:func:`hpx::async`. Each of these futures represents an
 asynchronous, recursive call to ``fibonacci``. As previously we wait for both
 futures to finish computing, get the results, add them together, and return that
 value as our result. The recursive call tree will continue until n is equal to 0

--- a/docs/sphinx/examples/fibonacci_local.rst
+++ b/docs/sphinx/examples/fibonacci_local.rst
@@ -112,7 +112,7 @@ In |hpx| ``main()`` is used to initialize the runtime system and pass the
 command line arguments to the program. If you wish to add command line options
 to your program you would add them here using the instance of the Boost class
 ``options_description``, and invoking the public member function
-``.add_options()`` (see |boost_doc|_ for more details). :cpp:func:`hpx::init`
+``.add_options()`` (see |boost_doc|_ for more details). :hpx:func:`hpx::init`
 calls ``hpx_main()`` after setting up |hpx|, which is where the logic of our
 program is encoded.
 
@@ -120,10 +120,10 @@ program is encoded.
    :start-after: //[main
    :end-before: //main]
 
-The :cpp:func:`hpx::init` function in ``main()`` starts the runtime system, and
+The :hpx:func:`hpx::init` function in ``main()`` starts the runtime system, and
 invokes ``hpx_main()`` as the first |hpx|-thread. Below we can see that the
 basic program is simple. The command line option ``--n-value`` is read in, a
-timer (:cpp:class:`hpx::chrono::high_resolution_timer`) is set up to record the
+timer (:hpx:class:`hpx::chrono::high_resolution_timer`) is set up to record the
 time it takes to do the computation, the ``fibonacci`` function is invoked
 synchronously, and the answer is printed out.
 
@@ -143,7 +143,7 @@ This block of code looks similar to regular C++ code. First, ``if (n < 2)``,
 meaning n is 0 or 1, then we return 0 or 1 (recall the first element of the
 Fibonacci sequence is 0 and the second is 1). If n is larger than 1 we spawn two
 new tasks whose results are contained in ``n1`` and ``n2``. This is done using
-:cpp:func:`hpx::async` which takes as arguments a function (function pointer,
+:hpx:func:`hpx::async` which takes as arguments a function (function pointer,
 object or lambda) and the arguments to the function. Instead of returning a
 ``std::uint64_t`` like ``fibonacci`` does, ``hpx::async`` returns a future of a
 ``std::uint64_t``, i.e. ``hpx::future<std::uint64_t>``. Each of these futures

--- a/docs/sphinx/examples/hello_world.rst
+++ b/docs/sphinx/examples/hello_world.rst
@@ -81,20 +81,20 @@ beginning with ``main()``:
 
 In this excerpt of the code we again see the use of futures. This time the
 futures are stored in a vector so that they can easily be accessed.
-:cpp:func:`hpx::wait_all` is a family of functions that wait on for an
+:hpx:func:`hpx::wait_all` is a family of functions that wait on for an
 ``std::vector<>`` of futures to become ready. In this piece of code, we are
-using the synchronous version of :cpp:func:`hpx::wait_all()`, which takes one
+using the synchronous version of :hpx:func:`hpx::wait_all()`, which takes one
 argument (the ``std::vector<>`` of futures to wait on). This function will not
 return until all the futures in the vector have been executed.
 
-In :ref:`examples_fibonacci` we used :cpp:func:`hpx::find_here()` to specify the
+In :ref:`examples_fibonacci` we used :hpx:func:`hpx::find_here()` to specify the
 target of our actions. Here, we instead use
-:cpp:func:`hpx::find_all_localities()`, which returns an ``std::vector<>``
+:hpx:func:`hpx::find_all_localities()`, which returns an ``std::vector<>``
 containing the identifiers of all the machines in the system, including the one
 that we are on.
 
 As in :ref:`examples_fibonacci` our futures are set using
-:cpp:func:`hpx::async\<>()`. The ``hello_world_foreman_action`` is declared
+:hpx:func:`hpx::async\<>()`. The ``hello_world_foreman_action`` is declared
 here:
 
 .. literalinclude:: ../../examples/quickstart/hello_world_distributed.cpp
@@ -115,15 +115,15 @@ wrapped in the action above:
    :end-before: //]
 
 Now, before we discuss ``hello_world_foreman()``, let's talk about the
-:cpp:func:`hpx::wait_each()` function.
-The version of :cpp:func:`hpx::wait_each` invokes a callback function
+:hpx:func:`hpx::wait_each()` function.
+The version of :hpx:func:`hpx::wait_each` invokes a callback function
 provided by the user, supplying the callback function with the result of the
 future.
 
 In ``hello_world_foreman()``, an ``std::set<>`` called ``attendance`` keeps
 track of which OS-threads have printed out the hello world message. When the
 OS-thread prints out the statement, the future is marked as ready, and
-:cpp:func:`hpx::wait_each` in ``hello_world_foreman()``. If it is not
+:hpx:func:`hpx::wait_each` in ``hello_world_foreman()``. If it is not
 executing on the correct OS-thread, it returns a value of -1, which causes
 ``hello_world_foreman()`` to leave the OS-thread id in ``attendance``.
 

--- a/docs/sphinx/examples/interest_calculator.rst
+++ b/docs/sphinx/examples/interest_calculator.rst
@@ -100,14 +100,14 @@ Here we find our command line variables read in, the rate is converted from a
 percent to a decimal, the number of calculation iterations is determined, and
 then our shared_futures are set up. Notice that we first place our principal and
 rate into shares futures by passing the variables ``init_principal`` and
-``init_rate`` using :cpp:class:`hpx::make_ready_future`.
+``init_rate`` using :hpx:func:`hpx::make_ready_future`.
 
-In this way :cpp:class:`hpx::shared_future`\ ``<double>`` ``principal``
+In this way :hpx:class:`hpx::shared_future`\ ``<double>`` ``principal``
 and ``rate`` will be initialized to ``init_principal`` and ``init_rate`` when
-:cpp:class:`hpx::make_ready_future`\ ``<double>`` returns a future containing
+:hpx:func:`hpx::make_ready_future`\ ``<double>`` returns a future containing
 those initial values. These shared futures then enter the for loop and are
 passed to ``interest``. Next ``principal`` and ``interest`` are passed to the
-reassignment of ``principal`` using a :cpp:class:`hpx::dataflow`. A dataflow
+reassignment of ``principal`` using a :hpx:func:`hpx::dataflow`. A dataflow
 will first wait for its arguments to be ready before launching any callbacks, so
 ``add`` in this case will not begin until both ``principal`` and ``interest``
 are ready. This loop continues for each compound period that must be calculated.
@@ -126,7 +126,7 @@ following statement:
 
    double result = principal.get();
 
-This statement calls :cpp:member:`hpx::future::get` on the shared future
+This statement calls :hpx:member:`hpx::future::get` on the shared future
 principal which had its value calculated by our for loop. The program will wait
 here until the entire dataflow tree has been calculated and the value assigned
 to result. The program then prints out the final value of the investment and the

--- a/docs/sphinx/examples/matrix_multiplication.rst
+++ b/docs/sphinx/examples/matrix_multiplication.rst
@@ -106,9 +106,9 @@ To give some random initial values to our matrices, we use `std::uniform_int_dis
 along with ``hpx::ranges::generate()`` to yield two matrices A and B, which contain values in the range of [0, 10] or in
 the range defined by the user at the command-line arguments. The seed to generate the values can also be defined by the user.
 
-The next step is to perform the matrix multiplication in parallel. This can be done by just using an :cpp:func:`\hpx::experimental::for_loop`
+The next step is to perform the matrix multiplication in parallel. This can be done by just using an :hpx:func:`\hpx::experimental::for_loop`
 combined with a parallel execution policy ``hpx::execution::par`` as the outer loop of the multiplication. Note that the execution
-of :cpp:func:`\hpx::experimental::for_loop` without specifying an execution policy is equivalent to specifying ``hpx::execution::seq``
+of :hpx:func:`\hpx::experimental::for_loop` without specifying an execution policy is equivalent to specifying ``hpx::execution::seq``
 as the execution policy.
 
 Finally, the matrices A, B that are multiplied as well as the resultant matrix R are printed using the following function.

--- a/docs/sphinx/examples/termination_detection.rst
+++ b/docs/sphinx/examples/termination_detection.rst
@@ -21,7 +21,7 @@ Overview
 
 The termination detection API provides a way to wait for all local |hpx|-threads
 to complete their work. This is essential in scenarios where you spawn
-asynchronous tasks using :cpp:func:`hpx::post` or :cpp:func:`hpx::async` and
+asynchronous tasks using :hpx:func:`hpx::post` or :hpx:func:`hpx::async` and
 need to ensure they all finish before the runtime shuts down.
 
 The API supports several use cases:
@@ -158,6 +158,6 @@ The termination detection API is particularly useful in the following scenarios:
 See also
 ========
 
-* :cpp:func:`hpx::post` - Fire-and-forget asynchronous execution
-* :cpp:func:`hpx::async` - Asynchronous execution with a future
-* :cpp:func:`hpx::finalize` - Shut down the |hpx| runtime
+* :hpx:func:`hpx::post` - Fire-and-forget asynchronous execution
+* :hpx:func:`hpx::async` - Asynchronous execution with a future
+* :hpx:func:`hpx::finalize` - Shut down the |hpx| runtime

--- a/docs/sphinx/extensions/sphinx-hpx.py
+++ b/docs/sphinx/extensions/sphinx-hpx.py
@@ -8,6 +8,7 @@
 import json
 import os
 from docutils import nodes
+from sphinx.domains import Domain
 from sphinx.roles import ReferenceRole
 from sphinx import addnodes
 
@@ -85,6 +86,14 @@ class HPXCppRole(ReferenceRole):
 _HPX_CPP_ROLE_KINDS = ('func', 'class', 'struct', 'member', 'type', 'enum', 'concept', 'var')
 
 
+class HPXDomain(Domain):
+    """Domain exposing disambiguation-aware HPX C++ cross-reference roles."""
+
+    name = 'hpx'
+    label = 'HPX'
+    roles = {kind: HPXCppRole(kind) for kind in _HPX_CPP_ROLE_KINDS}
+
+
 def setup(app):
     app.add_role('hpx-issue', autolink('https://github.com/TheHPXProject/hpx/issues/%s', "Issue #"))
     app.add_role('hpx-header', autolink_hpx_file('http://github.com/TheHPXProject/hpx/blob/%s/%s/%s'))
@@ -94,8 +103,7 @@ def setup(app):
     app.add_role('cppreference-memory', autolink('http://en.cppreference.com/w/cpp/memory/%s'))
     app.add_role('cppreference-container', autolink('http://en.cppreference.com/w/cpp/container/%s'))
     app.add_role('cppreference-generic', autolink_generic('http://en.cppreference.com/w/cpp/%s/%s'))
-    for kind in _HPX_CPP_ROLE_KINDS:
-        app.add_role('hpx:' + kind, HPXCppRole(kind))
+    app.add_domain(HPXDomain)
 
 
 def autolink(pattern, prefix=''):

--- a/docs/sphinx/manual/error_handling.rst
+++ b/docs/sphinx/manual/error_handling.rst
@@ -36,7 +36,7 @@ is executed by invoking the plain action ``raise_exception_type``.
    :end-before: //]
 
 The exception is thrown using the macro :c:macro:`HPX_THROW_EXCEPTION`. The type
-of the thrown exception is :cpp:class:`hpx::exception`. This associates
+of the thrown exception is :hpx:class:`hpx::exception`. This associates
 additional diagnostic information with the exception, such as file name and line
 number, :term:`locality` id and thread id, and stack backtrace from the point
 where the exception was thrown.
@@ -58,7 +58,7 @@ calling thread tries to wait for the result of the action by invoking either
 
 Additionally, this example demonstrates how an exception thrown by an (possibly
 remote) action can be handled. It shows the use of
-:cpp:func:`hpx::diagnostic_information`, which retrieves all available diagnostic
+:hpx:func:`hpx::diagnostic_information`, which retrieves all available diagnostic
 information from the exception as a formatted string. This includes, for
 instance, the name of the source file and line number, the sequence number of
 the OS thread and the |hpx| thread id, the :term:`locality` id and the stack
@@ -82,9 +82,9 @@ Working with error codes
 Most of the API functions exposed by |hpx| can be invoked in two different
 modes. By default those will throw an exception on error as described above.
 However, sometimes it is desirable not to throw an exception in case of an error
-condition. In this case an object instance of the :cpp:class:`hpx::error_code`
+condition. In this case an object instance of the :hpx:class:`hpx::error_code`
 type can be passed as the last argument to the API function. In case of an error,
-the error condition will be returned in that :cpp:class:`hpx::error_code`
+the error condition will be returned in that :hpx:class:`hpx::error_code`
 instance. The following example demonstrates extracting the full diagnostic
 information without exception handling:
 
@@ -99,9 +99,9 @@ information without exception handling:
    is executed on a different :term:`locality`.
 
 This example show how an error can be handled without having to resolve to
-exceptions and that the returned :cpp:class:`hpx::error_code` instance can be
-used in a very similar way as the :cpp:class:`hpx::exception` type above. Simply
-pass it to the :cpp:func:`hpx::diagnostic_information`, which retrieves all
+exceptions and that the returned :hpx:class:`hpx::error_code` instance can be
+used in a very similar way as the :hpx:class:`hpx::exception` type above. Simply
+pass it to the :hpx:func:`hpx::diagnostic_information`, which retrieves all
 available diagnostic information from the error code instance as a formatted
 string.
 
@@ -117,14 +117,14 @@ code snippet:
    :end-before: //]
 
 For more information please refer to the documentation of
-:cpp:func:`hpx::get_error_what`, :cpp:func:`hpx::get_error_locality_id`,
-:cpp:func:`hpx::get_error_host_name`, :cpp:func:`hpx::get_error_process_id`,
-:cpp:func:`hpx::get_error_function_name`, :cpp:func:`hpx::get_error_file_name`,
-:cpp:func:`hpx::get_error_line_number`, :cpp:func:`hpx::get_error_os_thread`,
-:cpp:func:`hpx::get_error_thread_id`,
-:cpp:func:`hpx::get_error_thread_description`,
-:cpp:func:`hpx::get_error_backtrace`, :cpp:func:`hpx::get_error_env`, and
-:cpp:func:`hpx::get_error_state`.
+:hpx:func:`hpx::get_error_what`, :hpx:func:`hpx::get_error_locality_id`,
+:hpx:func:`hpx::get_error_host_name`, :hpx:func:`hpx::get_error_process_id`,
+:hpx:func:`hpx::get_error_function_name`, :hpx:func:`hpx::get_error_file_name`,
+:hpx:func:`hpx::get_error_line_number`, :hpx:func:`hpx::get_error_os_thread`,
+:hpx:func:`hpx::get_error_thread_id`,
+:hpx:func:`hpx::get_error_thread_description`,
+:hpx:func:`hpx::get_error_backtrace`, :hpx:func:`hpx::get_error_env`, and
+:hpx:func:`hpx::get_error_state`.
 
 .. _lightweight_error_code:
 
@@ -142,5 +142,5 @@ that will hold the error code only. The following snippet demonstrates its use:
    :end-before: //]
 
 All functions that retrieve other diagnostic elements from the
-:cpp:class:`hpx::error_code` will fail if called with a lightweight error_code
+:hpx:class:`hpx::error_code` will fail if called with a lightweight error_code
 instance.

--- a/docs/sphinx/manual/hpx_runtime_and_resources.rst
+++ b/docs/sphinx/manual/hpx_runtime_and_resources.rst
@@ -199,9 +199,9 @@ thread pool.
 Using the resource partitioner
 ------------------------------
 
-The :cpp:class:`hpx::resource::partitioner` is now created during |hpx| runtime
+The :hpx:class:`hpx::resource::partitioner` is now created during |hpx| runtime
 initialization without explicit action needed from the user. To specify some of
-the initialization parameters you can use the :cpp:struct:`hpx::init_params`.
+the initialization parameters you can use the :hpx:struct:`hpx::init_params`.
 
 .. literalinclude:: ../../libs/full/resource_partitioner/examples/simplest_resource_partitioner_1.cpp
    :start-after: //[body
@@ -210,17 +210,17 @@ the initialization parameters you can use the :cpp:struct:`hpx::init_params`.
 The resource partitioner callback is the interface to add thread pools to the
 |hpx| runtime and to assign resources to the thread pools.  In order to create
 custom thread pools you can specify the resource partitioner callback
-:cpp:member:`hpx::init_params::rp_callback` which will be called once the
+:hpx:member:`hpx::init_params::rp_callback` which will be called once the
 resource partitioner will be created , see the example below. You can also
-specify other parameters, see :cpp:struct:`hpx::init_params`.
+specify other parameters, see :hpx:struct:`hpx::init_params`.
 
 To add a thread pool use the
-:cpp:member:`hpx::resource::partitioner::create_thread_pool` method. If you
+:hpx:member:`hpx::resource::partitioner::create_thread_pool` method. If you
 simply want to use the default scheduler and scheduler options, it is enough to
 call ``rp.create_thread_pool("my-thread-pool")``.
 
 Then, to add resources to the thread pool you can use the
-:cpp:member:`hpx::resource::partitioner::add_resource` method. The resource
+:hpx:member:`hpx::resource::partitioner::add_resource` method. The resource
 partitioner exposes the hardware topology retrieved using |hwloc|_ and lets you
 iterate through the topology to add the wanted processing units to the thread
 pool. Below is an example of adding all processing units from the first NUMA
@@ -234,7 +234,7 @@ case we leave the first processing unit for the default thread pool:
 .. note::
 
    Whatever processing units are not assigned to a thread pool by the time
-   :cpp:func:`hpx::init` is called will be added to the default thread pool. It
+   :hpx:func:`hpx::init` is called will be added to the default thread pool. It
    is also possible to explicitly add processing units to the default thread
    pool, and to create the default thread pool manually (in order to e.g. set
    the scheduler type).
@@ -248,7 +248,7 @@ Difference between the old and new version
 ------------------------------------------
 
 In the old version, you had to create an instance of the
-:cpp:class:`resource_partitioner` with ``argc`` and ``argv``.
+:hpx:class:`resource_partitioner` with ``argc`` and ``argv``.
 
 .. code-block:: c++
 
@@ -344,7 +344,7 @@ Advanced usage
 --------------
 
 It is possible to customize the built in schedulers by passing scheduler options
-to :cpp:member:`hpx::resource::partitioner::create_thread_pool`. It is also possible
+to :hpx:member:`hpx::resource::partitioner::create_thread_pool`. It is also possible
 to create and use custom schedulers.
 
 .. note::
@@ -366,8 +366,8 @@ when creating the thread pool like this::
             hpx::policies::scheduler_mode::enable_elasticity));
 
 The available schedulers are documented here:
-:cpp:enum:`hpx::resource::scheduling_policy`, and the available scheduler modes
-here: :cpp:enum:`hpx::threads::policies::scheduler_mode`. Also see the examples
+:hpx:enum:`hpx::resource::scheduling_policy`, and the available scheduler modes
+here: :hpx:enum:`hpx::threads::policies::scheduler_mode`. Also see the examples
 folder for examples of advanced resource partitioner usage:
 ``simple_resource_partitioner.cpp`` and
 ``oversubscribing_resource_partitioner.cpp``.

--- a/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
+++ b/docs/sphinx/manual/launching_and_configuring_hpx_applications.rst
@@ -1412,7 +1412,7 @@ one of the localities the application runs on.
 ==========================
 
 The predefined command line options for any application using
-:cpp:func:`hpx::init` are described in the following subsections.
+:hpx:func:`hpx::init` are described in the following subsections.
 
 .. todo:: Proofread the options.
 

--- a/docs/sphinx/manual/migration_guide.rst
+++ b/docs/sphinx/manual/migration_guide.rst
@@ -78,7 +78,7 @@ Parallel for loop
 
 
 In the above code, the |openmp| `#pragma omp parallel for` directive is replaced with
-:cpp:func:`hpx::experimental::for_loop` from the |hpx| library. The loop body within the lambda
+:hpx:func:`hpx::experimental::for_loop` from the |hpx| library. The loop body within the lambda
 function will be executed in parallel for each iteration.
 
 Private variables
@@ -167,7 +167,7 @@ Number of threads
 
 To declare the number of threads to be used for the parallel region, you can use
 `hpx::execution::experimental::num_cores` and pass the number of cores (`nc`) to
-:cpp:func:`hpx::experimental::for_loop` using `hpx::execution::par.with(nc)`.
+:hpx:func:`hpx::experimental::for_loop` using `hpx::execution::par.with(nc)`.
 This example uses 2 threads for the parallel loop.
 
 Reduction
@@ -236,7 +236,7 @@ Schedule
 
 To define the scheduling type, you can use the corresponding execution policy from
 `hpx::execution::experimental`, define the chunk size (cs, here declared as 1000) and pass
-it to the to :cpp:func:`hpx::experimental::for_loop` using `hpx::execution::par.with(cs)`.
+it to the to :hpx:func:`hpx::experimental::for_loop` using `hpx::execution::par.with(cs)`.
 
 Accordingly, other types of scheduling are available and can be used in a similar manner:
 
@@ -287,7 +287,7 @@ Accordingly, other types of scheduling are available and can be used in a simila
     }
 
 To make sure that only one thread accesses a specific code within a parallel section
-you can use :cpp:class:`hpx::mutex` and `std::scoped_lock` to take ownership of the given
+you can use :hpx:class:`hpx::mutex` and `std::scoped_lock` to take ownership of the given
 mutex `mtx`. For more information about mutexes please refer to :ref:`mutex`.
 
 |openmp| tasks
@@ -326,14 +326,14 @@ or
         // task code
     }); // fire and forget
 
-The tasks in |hpx| can be defined simply by using the :cpp:func:`async` function and passing as argument
-the code you wish to run asynchronously. Another alternative is to use :cpp:func:`post` which is a
+The tasks in |hpx| can be defined simply by using the :hpx:func:`async` function and passing as argument
+the code you wish to run asynchronously. Another alternative is to use :hpx:func:`post` which is a
 fire-and-forget method.
 
 .. tip::
 
     If you think you will like to synchronize your tasks later on, we suggest you use
-    :cpp:func:`hpx::async` which provides synchronization options, while :cpp:func:`hpx::post`
+    :hpx:func:`hpx::async` which provides synchronization options, while :hpx:func:`hpx::post`
     explicitly states that there is no return value or way to synchronize with the function
     execution. Synchronization options are listed below.
 
@@ -364,7 +364,7 @@ Task wait
 
     // code after completion of task
 
-The `get()` function can be used to ensure that the task created with :cpp:func:`hpx::async`
+The `get()` function can be used to ensure that the task created with :hpx:func:`hpx::async`
 is completed before the code continues executing beyond that point.
 
 Multiple tasks synchronization
@@ -406,7 +406,7 @@ Multiple tasks synchronization
     });
 
 
-If you would like to synchronize multiple tasks, you can use the :cpp:func:`hpx::when_all` function
+If you would like to synchronize multiple tasks, you can use the :hpx:func:`hpx::when_all` function
 to define which futures have to be ready and the `then()` function to declare what should
 be executed once these futures are ready.
 
@@ -454,10 +454,10 @@ Dependencies
 
     c = future_c.get();
 
-If one of the arguments of :cpp:func:`hpx::dataflow` is a future, then it will wait for the
+If one of the arguments of :hpx:func:`hpx::dataflow` is a future, then it will wait for the
 future to be ready to launch the thread. Hence, to define the dependencies of tasks
 you have to create futures representing the variables that create dependencies and pass
-them as arguments to :cpp:func:`hpx::dataflow`. `get()` is used to save the result of the future
+them as arguments to :hpx:func:`hpx::dataflow`. `get()` is used to save the result of the future
 to the desired variable.
 
 
@@ -505,8 +505,8 @@ or
         });
     });
 
-If you have nested tasks, you can simply use nested :cpp:func:`hpx::async` or
-:cpp:func:`hpx::post` calls. The implementation is similar if you want to take
+If you have nested tasks, you can simply use nested :hpx:func:`hpx::async` or
+:hpx:func:`hpx::post` calls. The implementation is similar if you want to take
 care of synchronization:
 
 |openmp| code:
@@ -568,7 +568,7 @@ Task yield
 
     // code after yielding
 
-After creating a task using :cpp:func:`hpx::async`, :cpp:func:`hpx::this_thread::yield`
+After creating a task using :hpx:func:`hpx::async`, :hpx:func:`hpx::this_thread::yield`
 can be used to reschedule the execution of threads, allowing other threads to run.
 
 Task group
@@ -612,7 +612,7 @@ Task group
     // Wait for the task group
     tg.wait();
 
-To create task groups, you can use :cpp:class:`hpx::experimental::task_group`. The function
+To create task groups, you can use :hpx:class:`hpx::experimental::task_group`. The function
 `run()` can be used to run each task within the task group, while `wait()` can be used to
 achieve synchronization. If you do not care about waiting for the task group to complete
 its execution, you can simply remove the `wait()` function.
@@ -650,12 +650,12 @@ its execution, you can simply remove the `wait()` function.
     hpx::wait_all(future_section1, future_section2);
 
 Unlike tasks, there is an implicit synchronization barrier at the end of each `sections`
-directive in |openmp|. This synchronization is achieved using :cpp:func:`hpx::wait_all` function.
+directive in |openmp|. This synchronization is achieved using :hpx:func:`hpx::wait_all` function.
 
 .. note::
 
     If the `nowait` clause is used in the `sections` directive, then you can just remove
-    the :cpp:func:`hpx::wait_all` function while keeping the rest of the code as it is.
+    the :hpx:func:`hpx::wait_all` function while keeping the rest of the code as it is.
 
 .. _tbb:
 
@@ -697,7 +697,7 @@ parallel_for
     });
 
 
-In the above code, `tbb::parallel_for` is replaced with :cpp:func:`hpx::experimental::for_loop`
+In the above code, `tbb::parallel_for` is replaced with :hpx:func:`hpx::experimental::for_loop`
 from the |hpx| library. The loop body within the lambda function will be executed in
 parallel for each iteration.
 
@@ -727,7 +727,7 @@ parallel_for_each
         // loop body
     });
 
-By utilizing :cpp:func:`hpx::for_each` and specifying a parallel execution policy with
+By utilizing :hpx:func:`hpx::for_each` and specifying a parallel execution policy with
 `hpx::execution::par`, it is possible to transform `tbb::parallel_for_each` into its
 equivalent counterpart in |hpx|.
 
@@ -748,9 +748,9 @@ parallel_invoke
 
     hpx::wait_all(hpx::async(task1), hpx::async(task2), hpx::async(task3));
 
-To convert `tbb::parallel_invoke` to |hpx|, we use :cpp:func:`hpx::async` to asynchronously
+To convert `tbb::parallel_invoke` to |hpx|, we use :hpx:func:`hpx::async` to asynchronously
 execute each task, which returns a future representing the result of each task.
-We then pass these futures to :cpp:func:`hpx::when_all`, which waits for all the futures
+We then pass these futures to :hpx:func:`hpx::when_all`, which waits for all the futures
 to complete before returning.
 
 
@@ -880,7 +880,7 @@ Reduction
     auto total = hpx::reduce(
         hpx::execution::par, values.begin(), values.end(), 0, std::plus{});
 
-By utilizing :cpp:func:`hpx::reduce` and specifying a parallel execution policy with
+By utilizing :hpx:func:`hpx::reduce` and specifying a parallel execution policy with
 `hpx::execution::par`, it is possible to transform `tbb::parallel_reduce` into its
 equivalent counterpart in |hpx|. As demonstrated in the previous example, the management
 of intermediate results is seamlessly handled internally by |hpx|, eliminating the need
@@ -931,7 +931,7 @@ Transformation & Reduction
         [&](double current_value) { return transform_function(current_value); });
 
 In situations where certain values require transformation before the reduction process,
-|hpx| provides a straightforward solution through :cpp:func:`hpx::transform_reduce`. The
+|hpx| provides a straightforward solution through :hpx:func:`hpx::transform_reduce`. The
 `transform_function()` allows for the application of the desired transformation to each value.
 
 parallel_scan
@@ -968,7 +968,7 @@ parallel_scan
         output.begin(),
         [](const int& left, const int& right) { return left + right; });
 
-:cpp:func:`hpx::inclusive_scan` with `hpx::execution::par` as execution policy
+:hpx:func:`hpx::inclusive_scan` with `hpx::execution::par` as execution policy
 can be used to perform a prefix scan in parallel. The management of intermediate
 results is seamlessly handled internally by |hpx|, eliminating the need
 for explicit consideration. `input.begin()` and `input.end()` refer to the beginning
@@ -978,7 +978,7 @@ specifies the function which will be invoked for each of the values of the input
 
 .. seealso::
 
-Apart from :cpp:func:`hpx::inclusive_scan`, |hpx| provides its users with :cpp:func:`hpx::exclusive_scan`.
+Apart from :hpx:func:`hpx::inclusive_scan`, |hpx| provides its users with :hpx:func:`hpx::exclusive_scan`.
 The key difference between inclusive scan and exclusive scan lies in the treatment of the current element
 during the scan operation. In an inclusive scan, each element in the output sequence includes the
 contribution of the corresponding element in the input sequence, while in an exclusive scan, the current
@@ -1007,7 +1007,7 @@ parallel_sort
 
     hpx::sort(hpx::execution::par, numbers.begin(), numbers.end());
 
-:cpp:func:`hpx::sort` provides an equivalent functionality to `tbb::parallel_sort`.
+:hpx:func:`hpx::sort` provides an equivalent functionality to `tbb::parallel_sort`.
 When given a parallel execution policy with `hpx::execution::par`, the algorithm employs
 parallel execution, allowing for efficient sorting across available threads.
 
@@ -1045,8 +1045,8 @@ task_group
     // Wait for the task group
     tg.wait();
 
-|hpx| drew inspiration from |tbb| to introduce the :cpp:func:`hpx::experimental::task_group`
-feature. Therefore, utilizing :cpp:func:`hpx::experimental::task_group` provides an
+|hpx| drew inspiration from |tbb| to introduce the :hpx:class:`hpx::experimental::task_group`
+feature. Therefore, utilizing :hpx:class:`hpx::experimental::task_group` provides an
 equivalent functionality to `tbb::task_group`.
 
 .. _mpi:
@@ -1062,25 +1062,25 @@ List of |mpi|-|hpx| functions
 
    .. table:: |hpx| equivalent functions of |mpi|
 
-   ========================================  ===================================================================================================================
+   ========================================  ========================================================================================================================
    |mpi| function                            |hpx| equivalent
-   ========================================  ===================================================================================================================
-   :ref:`MPI_Allgather`                      :cpp:class:`hpx::collectives::all_gather`
-   :ref:`MPI_Allreduce`                      :cpp:class:`hpx::collectives::all_reduce`
-   :ref:`MPI_Alltoall`                       :cpp:class:`hpx::collectives::all_to_all`
-   :ref:`MPI_Barrier`                        :cpp:class:`hpx::distributed::barrier`
-   :ref:`MPI_Bcast`                          :cpp:class:`hpx::collectives::broadcast_to()` and :cpp:class:`hpx::collectives::broadcast_from()` used with :code:`get()`
-   :ref:`MPI_Comm_size <MPI_Send_MPI_Recv>`  :cpp:class:`hpx::get_num_localities`
-   :ref:`MPI_Comm_rank <MPI_Send_MPI_Recv>`  :cpp:class:`hpx::get_locality_id()`
-   :ref:`MPI_Exscan`                         :cpp:class:`hpx::collectives::exclusive_scan()` used with :code:`get()`
-   :ref:`MPI_Gather`                         :cpp:class:`hpx::collectives::gather_here()` and :cpp:class:`hpx::collectives::gather_there()` used with :code:`get()`
-   :ref:`MPI_Irecv <MPI_Send_MPI_Recv>`      :cpp:class:`hpx::collectives::get()`
-   :ref:`MPI_Isend <MPI_Send_MPI_Recv>`      :cpp:class:`hpx::collectives::set()`
-   :ref:`MPI_Reduce`                         :cpp:class:`hpx::collectives::reduce_here` and :cpp:class:`hpx::collectives::reduce_there` used with :code:`get()`
-   :ref:`MPI_Scan`                           :cpp:class:`hpx::collectives::inclusive_scan()` used with :code:`get()`
-   :ref:`MPI_Scatter`                        :cpp:class:`hpx::collectives::scatter_to()` and :cpp:class:`hpx::collectives::scatter_from()`
-   :ref:`MPI_Wait <MPI_Send_MPI_Recv>`       :cpp:class:`hpx::collectives::get()` used with a future i.e. :code:`setf.get()`
-   ========================================  ===================================================================================================================
+   ========================================  ========================================================================================================================
+   :ref:`MPI_Allgather`                      :hpx:func:`hpx::collectives::all_gather`
+   :ref:`MPI_Allreduce`                      :hpx:func:`hpx::collectives::all_reduce`
+   :ref:`MPI_Alltoall`                       :hpx:func:`hpx::collectives::all_to_all`
+   :ref:`MPI_Barrier`                        :hpx:class:`hpx::distributed::barrier`
+   :ref:`MPI_Bcast`                          :hpx:func:`hpx::collectives::broadcast_to()` and :hpx:class:`hpx::collectives::broadcast_from()` used with :code:`get()`
+   :ref:`MPI_Comm_size <MPI_Send_MPI_Recv>`  :hpx:func:`hpx::get_num_localities`
+   :ref:`MPI_Comm_rank <MPI_Send_MPI_Recv>`  :hpx:func:`hpx::get_locality_id()`
+   :ref:`MPI_Exscan`                         :hpx:func:`hpx::collectives::exclusive_scan()` used with :code:`get()`
+   :ref:`MPI_Gather`                         :hpx:func:`hpx::collectives::gather_here()` and :hpx:class:`hpx::collectives::gather_there()` used with :code:`get()`
+   :ref:`MPI_Irecv <MPI_Send_MPI_Recv>`      :hpx:func:`hpx::collectives::get()`
+   :ref:`MPI_Isend <MPI_Send_MPI_Recv>`      :hpx:func:`hpx::collectives::set()`
+   :ref:`MPI_Reduce`                         :hpx:func:`hpx::collectives::reduce_here` and :hpx:class:`hpx::collectives::reduce_there` used with :code:`get()`
+   :ref:`MPI_Scan`                           :hpx:func:`hpx::collectives::inclusive_scan()` used with :code:`get()`
+   :ref:`MPI_Scatter`                        :hpx:func:`hpx::collectives::scatter_to()` and :hpx:class:`hpx::collectives::scatter_from()`
+   :ref:`MPI_Wait <MPI_Send_MPI_Recv>`       :hpx:func:`hpx::collectives::get()` used with a future i.e. :code:`setf.get()`
+   ========================================  ========================================================================================================================
 
 .. _MPI_Send_MPI_Recv:
 

--- a/docs/sphinx/manual/optimizing_hpx_applications.rst
+++ b/docs/sphinx/manual/optimizing_hpx_applications.rst
@@ -686,7 +686,7 @@ functions of the created client component instance should be called::
     hpx::cout << count.get_value<int>().get() << std::endl;
 
 For more information about the client component type, see
-:cpp:class:`hpx::performance_counters::performance_counter`
+:hpx:class:`hpx::performance_counters::performance_counter`
 
 .. note::
 
@@ -755,7 +755,7 @@ requests the counter data of this performance counter.
 
 The next step in exposing this counter to the runtime system is to register the
 function as a new raw counter type using the |hpx| API function
-:cpp:func:`hpx::performance_counters::install_counter_type`. A counter type
+:hpx:func:`hpx::performance_counters::install_counter_type`. A counter type
 represents certain common characteristics of counters, like their counter type
 name and any associated description information. The following snippet shows an
 example of how to register the function ``some_performance_data``, which is shown
@@ -780,7 +780,7 @@ Now it is possible to instantiate a new counter instance based on the naming
 scheme ``"/test{locality#*/total}/data"`` where ``*`` is a zero-based integer
 index identifying the :term:`locality` for which the counter instance should be
 accessed. The function
-:cpp:func:`hpx::performance_counters::install_counter_type` enables users to
+:hpx:func:`hpx::performance_counters::install_counter_type` enables users to
 instantiate exactly one counter instance for each :term:`locality`. Repeated
 requests to instantiate such a counter will return the same instance, i.e., the
 instance created for the first request.
@@ -789,7 +789,7 @@ If this counter needs to be accessed using the standard |hpx| command line
 options, the registration has to be performed during application startup, before
 ``hpx_main`` is executed. The best way to achieve this is to register an |hpx|
 startup function using the API function
-:cpp:func:`hpx::register_startup_function` before calling ``hpx::init`` to
+:hpx:func:`hpx::register_startup_function` before calling ``hpx::init`` to
 initialize the runtime system::
 
     int main(int argc, char* argv[])

--- a/docs/sphinx/manual/starting_the_hpx_runtime.rst
+++ b/docs/sphinx/manual/starting_the_hpx_runtime.rst
@@ -130,16 +130,16 @@ point of your |hpx| application on the console :term:`locality` only (this
 function will be invoked as the first |hpx| thread of your application). All
 |hpx| API functions can be used from within this function.
 
-The thread executing the function :cpp:func:`hpx::init` will block waiting for
+The thread executing the function :hpx:func:`hpx::init` will block waiting for
 the runtime system to exit. The value returned from ``hpx_main`` will be
-returned from :cpp:func:`hpx::init` after the runtime system has stopped.
+returned from :hpx:func:`hpx::init` after the runtime system has stopped.
 
-The function :cpp:func:`hpx::finalize` has to be called on one of the |hpx|
+The function :hpx:func:`hpx::finalize` has to be called on one of the |hpx|
 localities in order to signal that all work has been scheduled and the runtime
 system should be stopped after the scheduled work has been executed.
 
 This method of invoking |hpx| has the advantage of the user being able to decide
-which version of :cpp:func:`hpx::init` to call. This allows to pass
+which version of :hpx:func:`hpx::init` to call. This allows to pass
 additional configuration parameters while initializing the |hpx| runtime system.
 
 .. code-block:: c++
@@ -174,7 +174,7 @@ additional configuration parameters while initializing the |hpx| runtime system.
 The header file to include for this method of using |hpx| is
 ``hpx/hpx_init.hpp``.
 
-There are many additional overloads of :cpp:func:`hpx::init` available, such as
+There are many additional overloads of :hpx:func:`hpx::init` available, such as
 the ability to provide your own entry-point function instead of ``hpx_main``.
 Please refer to the function documentation for more details (see: ``hpx/hpx_init.hpp``).
 
@@ -189,17 +189,17 @@ point of your |hpx| application on the console :term:`locality` only (this
 function will be invoked as the first |hpx| thread of your application). All
 |hpx| API functions can be used from within this function.
 
-The thread executing the function :cpp:func:`hpx::start` will *not* block
+The thread executing the function :hpx:func:`hpx::start` will *not* block
 waiting for the runtime system to exit, but will return immediately.
-The function :cpp:func:`hpx::finalize` has to be called on one of the |hpx|
+The function :hpx:func:`hpx::finalize` has to be called on one of the |hpx|
 localities in order to signal that all work has been scheduled and the runtime
 system should be stopped after the scheduled work has been executed.
 
 This method of invoking |hpx| is useful for applications where the main thread
-is used for special operations, such a GUIs. The function :cpp:func:`hpx::stop`
+is used for special operations, such a GUIs. The function :hpx:func:`hpx::stop`
 can be used to wait for the |hpx| runtime system to exit and should at least be
 used as the last function called in ``main()``. The value returned from
-``hpx_main`` will be returned from :cpp:func:`hpx::stop` after the runtime
+``hpx_main`` will be returned from :hpx:func:`hpx::stop` after the runtime
 system has stopped.
 
 .. code-block:: c++
@@ -238,7 +238,7 @@ system has stopped.
 The header file to include for this method of using |hpx| is
 ``hpx/hpx_start.hpp``.
 
-There are many additional overloads of :cpp:func:`hpx::start` available, such as
+There are many additional overloads of :hpx:func:`hpx::start` available, such as
 the option for users to provide their own entry point function instead of ``hpx_main``.
 Please refer to the function documentation for more details (see:
 ``hpx/hpx_start.hpp``).
@@ -270,7 +270,7 @@ the main entry point for your |hpx| application:
 
 .. note::
 
-   The function supplied to :cpp:func:`hpx::init` must have one of the following
+   The function supplied to :hpx:func:`hpx::init` must have one of the following
    prototypes:
 
        int application_entry_point(int argc, char* argv[]);
@@ -287,12 +287,12 @@ Suspending and resuming the |hpx| runtime
 =========================================
 
 In some applications it is required to combine |hpx| with other runtimes. To
-support this use case, |hpx| provides two functions: :cpp:func:`hpx::suspend` and
-:cpp:func:`hpx::resume`. :cpp:func:`hpx::suspend` is a blocking call which will
+support this use case, |hpx| provides two functions: :hpx:func:`hpx::suspend` and
+:hpx:func:`hpx::resume`. :hpx:func:`hpx::suspend` is a blocking call which will
 wait for all scheduled tasks to finish executing and then put the thread pool OS
-threads to sleep. :cpp:func:`hpx::resume` simply wakes up the sleeping threads
-so that they are ready to accept new work. :cpp:func:`hpx::suspend` and
-:cpp:func:`hpx::resume` can be found in the header ``hpx/hpx_suspend.hpp``.
+threads to sleep. :hpx:func:`hpx::resume` simply wakes up the sleeping threads
+so that they are ready to accept new work. :hpx:func:`hpx::suspend` and
+:hpx:func:`hpx::resume` can be found in the header ``hpx/hpx_suspend.hpp``.
 
 .. code-block:: c++
 
@@ -325,19 +325,19 @@ so that they are ready to accept new work. :cpp:func:`hpx::suspend` and
 
 .. note::
 
-   :cpp:func:`hpx::suspend` does not wait for :cpp:func:`hpx::finalize` to be
-   called. Only call :cpp:func:`hpx::finalize` when you wish to fully stop the
+   :hpx:func:`hpx::suspend` does not wait for :hpx:func:`hpx::finalize` to be
+   called. Only call :hpx:func:`hpx::finalize` when you wish to fully stop the
    |hpx| runtime.
 
 .. warning::
 
-   :cpp:func:`hpx::suspend` only waits for local tasks, i.e. tasks on the
-    current locality, to finish executing. When using :cpp:func:`hpx::suspend`
+   :hpx:func:`hpx::suspend` only waits for local tasks, i.e. tasks on the
+    current locality, to finish executing. When using :hpx:func:`hpx::suspend`
     in a multi-locality scenario the user is responsible for ensuring that any
     work required from other localities has also finished.
 
 |hpx| also supports suspending individual thread pools and threads. For details
-on how to do that, see the documentation for :cpp:class:`hpx::threads::thread_pool_base`.
+on how to do that, see the documentation for :hpx:class:`hpx::threads::thread_pool_base`.
 
 Automatically suspending worker threads
 ---------------------------------------
@@ -381,7 +381,7 @@ this instead:
        return hpx::stop();
    }
 
-In this example each call to :cpp:func:`hpx::run_as_hpx_thread` acts as a
+In this example each call to :hpx:func:`hpx::run_as_hpx_thread` acts as a
 "parallel region".
 
 .. _hpx_main_implementation:

--- a/docs/sphinx/manual/using_hpx_on_compiler_explorer.rst
+++ b/docs/sphinx/manual/using_hpx_on_compiler_explorer.rst
@@ -235,7 +235,7 @@ efficiency, and a verdict (``Excellent scaling``, ``Good scaling``,
 
    All functions in ``hpx/experimental/sandbox.hpp`` must be called from within
    a running |hpx| runtime, i.e., from an |hpx| thread. Calling them before
-   :cpp:func:`hpx::init` or after :cpp:func:`hpx::finalize` is undefined
+   :hpx:func:`hpx::init` or after :hpx:func:`hpx::finalize` is undefined
    behaviour. When using ``hpx/hpx_main.hpp``, the body of ``main`` satisfies
    this requirement automatically.
 

--- a/docs/sphinx/manual/writing_distributed_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_distributed_hpx_applications.rst
@@ -52,25 +52,25 @@ The only predefined global addresses are assigned to all localities. The
 following |hpx| API functions allow one to retrieve the global addresses of
 localities:
 
-* :cpp:func:`hpx::find_here`: retrieves the global address of the
+* :hpx:func:`hpx::find_here`: retrieves the global address of the
   :term:`locality` this function is called on.
-* :cpp:func:`hpx::find_all_localities()`: retrieves the global addresses of all
+* :hpx:func:`hpx::find_all_localities()`: retrieves the global addresses of all
   localities available to this application (including the :term:`locality` the
   function is being called on).
-* :cpp:func:`hpx::find_remote_localities()`: retrieves the global addresses of
+* :hpx:func:`hpx::find_remote_localities()`: retrieves the global addresses of
   all remote localities available to this application (not including the
   :term:`locality` the function is being called on).
-* :cpp:func:`hpx::get_num_localities()`: retrieves the number of localities
+* :hpx:func:`hpx::get_num_localities()`: retrieves the number of localities
   available to this application.
-* :cpp:func:`hpx::find_locality()`: retrieves the global address of any
+* :hpx:func:`hpx::find_locality()`: retrieves the global address of any
   :term:`locality` supporting the given component type.
-* :cpp:func:`hpx::get_colocation_id()`: retrieves the global address of the
+* :hpx:func:`hpx::get_colocation_id()`: retrieves the global address of the
   :term:`locality` currently hosting the object with the given global address.
 
 Additionally, the global addresses of localities can be used to create new
 instances of components using the following |hpx| API function:
 
-* :cpp:func:`hpx::components::new_()`: Creates a new instance of the given
+* :hpx:func:`hpx::components::new_()`: Creates a new instance of the given
   ``Component`` type on the specified :term:`locality`.
 
 .. note::
@@ -238,8 +238,8 @@ a single macro instead of the three-step process described above::
     }
 
 The resulting ``some_member_action`` type can be used exactly like an action
-type created with :c:macro:`HPX_DEFINE_COMPONENT_ACTION`, with :cpp:func:`hpx::post`,
-:cpp:func:`hpx::async`, and :cpp:func:`hpx::sync`, or by invoking it directly. No
+type created with :c:macro:`HPX_DEFINE_COMPONENT_ACTION`, with :hpx:func:`hpx::post`,
+:hpx:func:`hpx::async`, and :hpx:func:`hpx::sync`, or by invoking it directly. No
 separate registration step is required in the source file.
 
 .. _action_invocation:
@@ -603,7 +603,7 @@ executed::
     HPX_PLAIN_ACTION(app::some_function_with_error, some_error_action);
 
 The use of :c:macro:`HPX_THROW_EXCEPTION` to report the error encapsulates the
-creation of a :cpp:class:`hpx::exception` which is initialized with the error
+creation of a :hpx:class:`hpx::exception` which is initialized with the error
 code ``hpx::error::bad_parameter``. Additionally it carries the passed strings, the
 information about the file name, line number, and call stack of the point the
 exception was thrown from.
@@ -780,7 +780,7 @@ A client side object stores the global id of the component instance it
 represents. This global id is accessible by calling the function
 ``client_base<>::get_id()``. The special constructor which is provided in the
 example allows to create this client side object directly using the API function
-:cpp:func:`hpx::new_`.
+:hpx:func:`hpx::new_`.
 
 .. _create_components:
 
@@ -1053,7 +1053,7 @@ beginning of the next segment.
 It is sometimes useful not only to iterate element by element, but also segment
 by segment, or simply get a local iterator in order to avoid additional
 construction costs at each deferencing operations. To mitigate this need, the
-:cpp:class:`hpx::traits::segmented_iterator_traits` are used.
+:hpx:struct:`hpx::traits::segmented_iterator_traits` are used.
 
 With ``segmented_iterator_traits`` users can uniformly get the iterators
 which specifically iterates over segments (by providing a segmented iterator

--- a/docs/sphinx/manual/writing_single_node_hpx_applications.rst
+++ b/docs/sphinx/manual/writing_single_node_hpx_applications.rst
@@ -343,7 +343,8 @@ futures::
 For this reason, |hpx| implements a set of extensions to
 :cppreference-generic:`thread,future` (as proposed by |cpp11_n4107|_). This
 proposal introduces the following key asynchronous operations to
-:cpp:func:`hpx::future`, :cpp:func:`hpx::shared_future` and :cpp:func:`hpx::async`,
+:hpx:class:`hpx::future`, :hpx:class:`hpx::shared_future` and
+:hpx:func:`hpx::async`,
 which enhance and enrich these facilities.
 
 .. list-table:: Facilities extending ``std::future``
@@ -351,7 +352,7 @@ which enhance and enrich these facilities.
 
    * * Facility
      * Description
-   * * :cpp:func:`hpx::future::then`
+   * * :hpx:member:`hpx::future::then`
      * In asynchronous programming, it is very common for one asynchronous
        operation, on completion, to invoke a second operation and pass data to
        it. The current C++ standard does not allow one to register a
@@ -360,7 +361,7 @@ which enhance and enrich these facilities.
        invoked when the result is ready. Continuations registered using then
        function will help to avoid blocking waits or wasting threads on polling,
        greatly improving the responsiveness and scalability of an application.
-   * * unwrapping constructor for :cpp:func:`hpx::future`
+   * * unwrapping constructor for :hpx:class:`hpx::future`
      * In some scenarios, you might want to create a future that returns another
        future, resulting in nested futures. Although it is possible to write
        code to unwrap the outer future and retrieve the nested future and its
@@ -368,13 +369,13 @@ which enhance and enrich these facilities.
        and it may cause a blocking call. Unwrapping can allow users to mitigate
        this problem by doing an asynchronous call to unwrap the outermost
        future.
-   * * :cpp:func:`hpx::future::is_ready`
+   * * :hpx:member:`hpx::future::is_ready`
      * There are often situations where a ``get()`` call on a future may not be
        a blocking call, or is only a blocking call under certain circumstances.
        This function gives the ability to test for early completion and allows
        us to avoid associating a continuation, which needs to be scheduled with
        some non-trivial overhead and near-certain loss of cache efficiency.
-   * * :cpp:func:`hpx::make_ready_future`
+   * * :hpx:func:`hpx::make_ready_future`
      * Some functions may know the value at the point of construction. In these
        cases the value is immediately available, but needs to be returned as a
        future. By using ``hpx::make_ready_future`` a future can be created that
@@ -396,27 +397,27 @@ allowing users to compose several futures in a more flexible way.
 
    * * Facility
      * Description
-   * * :cpp:func:`hpx::when_any`, :cpp:func:`hpx::when_any_n`
+   * * :hpx:func:`hpx::when_any`, :hpx:func:`hpx::when_any_n`
      * Asynchronously wait for at least one of multiple future or shared_future
        objects to finish.
-   * * :cpp:func:`hpx::wait_any`, :cpp:func:`hpx::wait_any_n`
+   * * :hpx:func:`hpx::wait_any`, :hpx:func:`hpx::wait_any_n`
      * Synchronously wait for at least one of multiple future or shared_future
        objects to finish.
-   * * :cpp:func:`hpx::when_all`, :cpp:func:`hpx::when_all_n`
+   * * :hpx:func:`hpx::when_all`, :hpx:func:`hpx::when_all_n`
      * Asynchronously wait for all future and shared_future objects to finish.
-   * * :cpp:func:`hpx::wait_all`, :cpp:func:`hpx::wait_all_n`
+   * * :hpx:func:`hpx::wait_all`, :hpx:func:`hpx::wait_all_n`
      * Synchronously wait for all future and shared_future objects to finish.
-   * * :cpp:func:`hpx::when_some`, :cpp:func:`hpx::when_some_n`
+   * * :hpx:func:`hpx::when_some`, :hpx:func:`hpx::when_some_n`
      * Asynchronously wait for multiple future and shared_future objects to
        finish.
-   * * :cpp:func:`hpx::wait_some`, :cpp:func:`hpx::wait_some_n`
+   * * :hpx:func:`hpx::wait_some`, :hpx:func:`hpx::wait_some_n`
      * Synchronously wait for multiple future and shared_future objects to
        finish.
-   * * :cpp:func:`hpx::when_each`
+   * * :hpx:func:`hpx::when_each`
      * Asynchronously wait for multiple future and shared_future objects to
        finish and call a function for each of the future objects as soon as it
        becomes ready.
-   * * :cpp:func:`hpx::wait_each`, :cpp:func:`hpx::wait_each_n`
+   * * :hpx:func:`hpx::wait_each`, :hpx:func:`hpx::wait_each_n`
      * Synchronously wait for multiple future and shared_future objects to
        finish and call a function for each of the future objects as soon as it
        becomes ready.
@@ -444,10 +445,10 @@ independent places in the program:
    :start-after: //[local_channel_send_receive
    :end-before: //]
 
-Note how :cpp:member:`hpx::lcos::local::channel::get` without any arguments
+Note how :hpx:member:`hpx::lcos::local::channel::get` without any arguments
 returns a future which is ready when a value has been set on the channel. The
 launch policy ``hpx::launch::sync`` can be used to make
-:cpp:member:`hpx::lcos::local::channel::get` block until a value is set and
+:hpx:member:`hpx::lcos::local::channel::get` block until a value is set and
 return the value directly.
 
 A channel component is created on one :term:`locality` and can be sent to
@@ -508,9 +509,9 @@ results::
     }
 
 The example above demonstrates the use of two of the functions,
-:cpp:func:`hpx::experimental::define_task_block` and the
-:cpp:member:`hpx::experimental::task_block::run` member function of a
-:cpp:class:`hpx::experimental::task_block`.
+:hpx:func:`hpx::experimental::define_task_block` and the
+:hpx:member:`hpx::experimental::task_block::run` member function of a
+:hpx:class:`hpx::experimental::task_block`.
 
 The ``task_block`` function delineates a region in a program code potentially
 containing invocations of threads spawned by the ``run`` member function of the
@@ -583,14 +584,14 @@ created ``task_block``. In the following example the use of an explicit
         return compute(n) + left + right;
     }
 
-This also causes the :cpp:class:`hpx::experimental::task_block` object to be a
+This also causes the :hpx:class:`hpx::experimental::task_block` object to be a
 template in our implementation. The template argument is the type of the
 execution policy used to create the task block. The template argument defaults
-to :cpp:class:`hpx::execution::parallel_policy`.
+to :hpx:class:`hpx::execution::parallel_policy`.
 
-|hpx| still supports calling :cpp:func:`hpx::experimental::define_task_block`
+|hpx| still supports calling :hpx:func:`hpx::experimental::define_task_block`
 without an explicit execution policy. In this case the task block will run using
-the :cpp:class:`hpx::execution::parallel_policy`.
+the :hpx:class:`hpx::execution::parallel_policy`.
 
 |hpx| also adds the ability to access the execution policy that was used to
 create a given ``task_block``.
@@ -627,10 +628,10 @@ function enables this use case::
         return compute(n) + left + right;
     }
 
-|hpx| still supports calling :cpp:func:`hpx::experimental::task_block::run`
+|hpx| still supports calling :hpx:member:`hpx::experimental::task_block::run`
 without an explicit executor object. In this case the task will be run using the
 executor associated with the execution policy that was used to call
-:cpp:func:`hpx::experimental::define_task_block`.
+:hpx:func:`hpx::experimental::define_task_block`.
 
 .. _task_group:
 
@@ -740,13 +741,13 @@ manner in which the execution of these algorithms may be parallelized and the
 manner in which they apply user-provided function objects.
 
 The applications of function objects in parallel algorithms invoked with an
-execution policy object of type :cpp:class:`hpx::execution::sequenced_policy` or
-:cpp:class:`hpx::execution::sequenced_task_policy` execute in sequential order. For
-:cpp:class:`hpx::execution::sequenced_policy` the execution happens in the calling thread.
+execution policy object of type :hpx:class:`hpx::execution::sequenced_policy` or
+:hpx:class:`hpx::execution::sequenced_task_policy` execute in sequential order. For
+:hpx:class:`hpx::execution::sequenced_policy` the execution happens in the calling thread.
 
 The applications of function objects in parallel algorithms invoked with an
-execution policy object of type :cpp:class:`hpx::execution::parallel_policy` or
-:cpp:class:`hpx::execution::parallel_task_policy` are permitted to execute in an unordered
+execution policy object of type :hpx:class:`hpx::execution::parallel_policy` or
+:hpx:class:`hpx::execution::parallel_task_policy` are permitted to execute in an unordered
 fashion in unspecified threads, and are indeterminately sequenced within each
 thread.
 
@@ -755,7 +756,7 @@ thread.
    It is the caller's responsibility to ensure correctness, such as making sure that the
    invocation does not introduce data races or deadlocks.
 
-The example below demonstrates how to perform a sequential and parallel :cpp:func:`hpx::for_each` \
+The example below demonstrates how to perform a sequential and parallel :hpx:func:`hpx::for_each` \
 loop on a vector of integers.
 
 .. literalinclude:: ../../examples/quickstart/for_each_docs.cpp
@@ -785,18 +786,18 @@ program is determined by the type of execution policy used to invoke the
 algorithm:
 
 * If the execution policy object is of type
-  :cpp:class:`hpx::execution::parallel_unsequenced_policy`, :cpp:func:`hpx::terminate` shall
+  :hpx:class:`hpx::execution::parallel_unsequenced_policy`, :hpx:func:`hpx::terminate` shall
   be called.
-* If the execution policy object is of type :cpp:class:`hpx::execution::sequenced_policy`,
-  :cpp:class:`hpx::execution::sequenced_task_policy`, :cpp:class:`hpx::execution::parallel_policy`, or
-  :cpp:class:`hpx::execution::parallel_task_policy`, the execution of the algorithm terminates
-  with an :cpp:class:`hpx::exception_list` exception. All uncaught exceptions thrown during the
+* If the execution policy object is of type :hpx:class:`hpx::execution::sequenced_policy`,
+  :hpx:class:`hpx::execution::sequenced_task_policy`, :hpx:class:`hpx::execution::parallel_policy`, or
+  :hpx:class:`hpx::execution::parallel_task_policy`, the execution of the algorithm terminates
+  with an :hpx:class:`hpx::exception_list` exception. All uncaught exceptions thrown during the
   application of user-provided function objects shall be contained in the
-  :cpp:class:`hpx::exception_list`.
+  :hpx:class:`hpx::exception_list`.
 
 For example, the number of invocations of the user-provided function object in
-for_each is unspecified. When :cpp:class:`hpx::for_each` is executed sequentially, only one
-exception will be contained in the :cpp:class:`hpx::exception_list` object.
+for_each is unspecified. When :hpx:class:`hpx::for_each` is executed sequentially, only one
+exception will be contained in the :hpx:class:`hpx::exception_list` object.
 
 These guarantees imply that, unless the algorithm has failed to allocate memory
 and terminated with ``std::bad_alloc``, all exceptions thrown during the
@@ -807,7 +808,7 @@ capturing a user exception.
 The algorithm may terminate with the ``std::bad_alloc`` exception even if one or
 more user-provided function objects have terminated with an exception. For
 example, this can happen when an algorithm fails to allocate memory while
-creating or adding elements to the :cpp:class:`hpx::exception_list` object.
+creating or adding elements to the :hpx:class:`hpx::exception_list` object.
 
 Parallel algorithms
 -------------------
@@ -820,58 +821,58 @@ Parallel algorithms
    * * Name
      * Description
      * C++ standard
-   * * :cpp:func:`hpx::adjacent_find`
+   * * :hpx:func:`hpx::adjacent_find`
      * Computes the differences between adjacent elements in a range.
      * :cppreference-algorithm:`adjacent_find`
-   * * :cpp:func:`hpx::all_of`
+   * * :hpx:func:`hpx::all_of`
      * Checks if a predicate is ``true`` for all of the elements in a range.
      * :cppreference-algorithm:`all_any_none_of`
-   * * :cpp:func:`hpx::any_of`
+   * * :hpx:func:`hpx::any_of`
      * Checks if a predicate is ``true`` for any of the elements in a range.
      * :cppreference-algorithm:`all_any_none_of`
-   * * :cpp:func:`hpx::count`
+   * * :hpx:func:`hpx::count`
      * Returns the number of elements equal to a given value.
      * :cppreference-algorithm:`count`
-   * * :cpp:func:`hpx::count_if`
+   * * :hpx:func:`hpx::count_if`
      * Returns the number of elements satisfying a specific criteria.
      * :cppreference-algorithm:`count_if`
-   * * :cpp:func:`hpx::equal`
+   * * :hpx:func:`hpx::equal`
      * Determines if two sets of elements are the same.
      * :cppreference-algorithm:`equal`
-   * * :cpp:func:`hpx::find`
+   * * :hpx:func:`hpx::find`
      * Finds the first element equal to a given value.
      * :cppreference-algorithm:`find`
-   * * :cpp:func:`hpx::find_end`
+   * * :hpx:func:`hpx::find_end`
      * Finds the last sequence of elements in a certain range.
      * :cppreference-algorithm:`find_end`
-   * * :cpp:func:`hpx::find_first_of`
+   * * :hpx:func:`hpx::find_first_of`
      * Searches for any one of a set of elements.
      * :cppreference-algorithm:`find_first_of`
-   * * :cpp:func:`hpx::find_if`
+   * * :hpx:func:`hpx::find_if`
      * Finds the first element satisfying a specific criteria.
      * :cppreference-algorithm:`find_if`
-   * * :cpp:func:`hpx::find_if_not`
+   * * :hpx:func:`hpx::find_if_not`
      * Finds the first element not satisfying a specific criteria.
      * :cppreference-algorithm:`find_if_not`
-   * * :cpp:func:`hpx::for_each`
+   * * :hpx:func:`hpx::for_each`
      * Applies a function to a range of elements.
      * :cppreference-algorithm:`for_each`
-   * * :cpp:func:`hpx::for_each_n`
+   * * :hpx:func:`hpx::for_each_n`
      * Applies a function to a number of elements.
      * :cppreference-algorithm:`for_each_n`
-   * * :cpp:func:`hpx::lexicographical_compare`
+   * * :hpx:func:`hpx::lexicographical_compare`
      * Checks if a range of values is lexicographically less than another range of values.
      * :cppreference-algorithm:`lexicographical_compare`
-   * * :cpp:func:`hpx::mismatch`
+   * * :hpx:func:`hpx::mismatch`
      * Finds the first position where two ranges differ.
      * :cppreference-algorithm:`mismatch`
-   * * :cpp:func:`hpx::none_of`
+   * * :hpx:func:`hpx::none_of`
      * Checks if a predicate is ``true`` for none of the elements in a range.
      * :cppreference-algorithm:`all_any_none_of`
-   * * :cpp:func:`hpx::search`
+   * * :hpx:func:`hpx::search`
      * Searches for a range of elements.
      * :cppreference-algorithm:`search`
-   * * :cpp:func:`hpx::search_n`
+   * * :hpx:func:`hpx::search_n`
      * Searches for a number consecutive copies of an element in a range.
      * :cppreference-algorithm:`search_n`
 
@@ -883,89 +884,89 @@ Parallel algorithms
    * * Name
      * Description
      * C++ standard
-   * * :cpp:func:`hpx::copy`
+   * * :hpx:func:`hpx::copy`
      * Copies a range of elements to a new location.
      * :cppreference-algorithm:`exclusive_scan`
-   * * :cpp:func:`hpx::copy_n`
+   * * :hpx:func:`hpx::copy_n`
      * Copies a number of elements to a new location.
      * :cppreference-algorithm:`copy_n`
-   * * :cpp:func:`hpx::copy_if`
+   * * :hpx:func:`hpx::copy_if`
      * Copies the elements from a range to a new location for which the given predicate is ``true``
      * :cppreference-algorithm:`copy`
-   * * :cpp:func:`hpx::move`
+   * * :hpx:func:`hpx::move`
      * Moves a range of elements to a new location.
      * :cppreference-algorithm:`move`
-   * * :cpp:func:`hpx::fill`
+   * * :hpx:func:`hpx::fill`
      * Assigns a range of elements a certain value.
      * :cppreference-algorithm:`fill`
-   * * :cpp:func:`hpx::fill_n`
+   * * :hpx:func:`hpx::fill_n`
      * Assigns a value to a number of elements.
      * :cppreference-algorithm:`fill_n`
-   * * :cpp:func:`hpx::generate`
+   * * :hpx:func:`hpx::generate`
      * Saves the result of a function in a range.
      * :cppreference-algorithm:`generate`
-   * * :cpp:func:`hpx::generate_n`
+   * * :hpx:func:`hpx::generate_n`
      * Saves the result of N applications of a function.
      * :cppreference-algorithm:`generate_n`
-   * * :cpp:func:`hpx::experimental::reduce_by_key`
+   * * :hpx:func:`hpx::experimental::reduce_by_key`
      * Performs an inclusive scan on consecutive elements with matching keys,
        with a reduction to output only the final sum for each key. The key
        sequence ``{1,1,1,2,3,3,3,3,1}`` and value sequence
        ``{2,3,4,5,6,7,8,9,10}`` would be reduced to ``keys={1,2,3,1}``,
        ``values={9,5,30,10}``.
      *
-   * * :cpp:func:`hpx::remove`
+   * * :hpx:func:`hpx::remove`
      * Removes the elements from a range that are equal to the given value.
      * :cppreference-algorithm:`remove`
-   * * :cpp:func:`hpx::remove_if`
+   * * :hpx:func:`hpx::remove_if`
      * Removes the elements from a range that are equal to the given predicate is ``false``
      * :cppreference-algorithm:`remove`
-   * * :cpp:func:`hpx::remove_copy`
+   * * :hpx:func:`hpx::remove_copy`
      * Copies the elements from a range to a new location that are not equal to the given value.
      * :cppreference-algorithm:`remove_copy`
-   * * :cpp:func:`hpx::remove_copy_if`
+   * * :hpx:func:`hpx::remove_copy_if`
      * Copies the elements from a range to a new location for which the given predicate is ``false``
      * :cppreference-algorithm:`remove_copy`
-   * * :cpp:func:`hpx::replace`
+   * * :hpx:func:`hpx::replace`
      * Replaces all values satisfying specific criteria with another value.
      * :cppreference-algorithm:`replace`
-   * * :cpp:func:`hpx::replace_if`
+   * * :hpx:func:`hpx::replace_if`
      * Replaces all values satisfying specific criteria with another value.
      * :cppreference-algorithm:`replace`
-   * * :cpp:func:`hpx::replace_copy`
+   * * :hpx:func:`hpx::replace_copy`
      * Copies a range, replacing elements satisfying specific criteria with another value.
      * :cppreference-algorithm:`replace_copy`
-   * * :cpp:func:`hpx::replace_copy_if`
+   * * :hpx:func:`hpx::replace_copy_if`
      * Copies a range, replacing elements satisfying specific criteria with another value.
      * :cppreference-algorithm:`replace_copy`
-   * * :cpp:func:`hpx::reverse`
+   * * :hpx:func:`hpx::reverse`
      * Reverses the order elements in a range.
      * :cppreference-algorithm:`reverse`
-   * * :cpp:func:`hpx::reverse_copy`
+   * * :hpx:func:`hpx::reverse_copy`
      * Creates a copy of a range that is reversed.
      * :cppreference-algorithm:`reverse_copy`
-   * * :cpp:func:`hpx::rotate`
+   * * :hpx:func:`hpx::rotate`
      * Rotates the order of elements in a range.
      * :cppreference-algorithm:`rotate`
-   * * :cpp:func:`hpx::rotate_copy`
+   * * :hpx:func:`hpx::rotate_copy`
      * Copies and rotates a range of elements.
      * :cppreference-algorithm:`rotate_copy`
-   * * :cpp:func:`hpx::shift_left`
+   * * :hpx:func:`hpx::shift_left`
      * Shifts the elements in the range left by n positions.
      * :cppreference-algorithm:`shift_left`
-   * * :cpp:func:`hpx::shift_right`
+   * * :hpx:func:`hpx::shift_right`
      * Shifts the elements in the range right by n positions.
      * :cppreference-algorithm:`shift_right`
-   * * :cpp:func:`hpx::swap_ranges`
+   * * :hpx:func:`hpx::swap_ranges`
      * Swaps two ranges of elements.
      * :cppreference-algorithm:`swap_ranges`
-   * * :cpp:func:`hpx::transform`
+   * * :hpx:func:`hpx::transform`
      * Applies a function to a range of elements.
      * :cppreference-algorithm:`transform`
-   * * :cpp:func:`hpx::unique`
+   * * :hpx:func:`hpx::unique`
      * Eliminates all but the first element from every consecutive group of equivalent elements from a range.
      * :cppreference-algorithm:`unique`
-   * * :cpp:func:`hpx::unique_copy`
+   * * :hpx:func:`hpx::unique_copy`
      * Copies the elements from one range to another in such a way that there are no consecutive equal elements.
      * :cppreference-algorithm:`unique_copy`
 
@@ -977,25 +978,25 @@ Parallel algorithms
    * * Name
      * Description
      * C++ standard
-   * * :cpp:func:`hpx::merge`
+   * * :hpx:func:`hpx::merge`
      * Merges two sorted ranges.
      * :cppreference-algorithm:`merge`
-   * * :cpp:func:`hpx::inplace_merge`
+   * * :hpx:func:`hpx::inplace_merge`
      * Merges two ordered ranges in-place.
      * :cppreference-algorithm:`inplace_merge`
-   * * :cpp:func:`hpx::includes`
+   * * :hpx:func:`hpx::includes`
      * Returns true if one set is a subset of another.
      * :cppreference-algorithm:`includes`
-   * * :cpp:func:`hpx::set_difference`
+   * * :hpx:func:`hpx::set_difference`
      * Computes the difference between two sets.
      * :cppreference-algorithm:`set_difference`
-   * * :cpp:func:`hpx::set_intersection`
+   * * :hpx:func:`hpx::set_intersection`
      * Computes the intersection of two sets.
      * :cppreference-algorithm:`set_intersection`
-   * * :cpp:func:`hpx::set_symmetric_difference`
+   * * :hpx:func:`hpx::set_symmetric_difference`
      * Computes the symmetric difference between two sets.
      * :cppreference-algorithm:`set_symmetric_difference`
-   * * :cpp:func:`hpx::set_union`
+   * * :hpx:func:`hpx::set_union`
      * Computes the union of two sets.
      * :cppreference-algorithm:`set_union`
 
@@ -1007,13 +1008,13 @@ Parallel algorithms
    * * Name
      * Description
      * C++ standard
-   * * :cpp:func:`hpx::is_heap`
+   * * :hpx:func:`hpx::is_heap`
      * Returns ``true`` if the range is max heap.
      * :cppreference-algorithm:`is_heap`
-   * * :cpp:func:`hpx::is_heap_until`
+   * * :hpx:func:`hpx::is_heap_until`
      * Returns the first element that breaks a max heap.
      * :cppreference-algorithm:`is_heap_until`
-   * * :cpp:func:`hpx::make_heap`
+   * * :hpx:func:`hpx::make_heap`
      * Constructs a max heap in the range [first, last).
      * :cppreference-algorithm:`make_heap`
 
@@ -1025,13 +1026,13 @@ Parallel algorithms
    * * Name
      * Description
      * C++ standard
-   * * :cpp:func:`hpx::max_element`
+   * * :hpx:func:`hpx::max_element`
      * Returns the largest element in a range.
      * :cppreference-algorithm:`max_element`
-   * * :cpp:func:`hpx::min_element`
+   * * :hpx:func:`hpx::min_element`
      * Returns the smallest element in a range.
      * :cppreference-algorithm:`min_element`
-   * * :cpp:func:`hpx::minmax_element`
+   * * :hpx:func:`hpx::minmax_element`
      * Returns the smallest and the largest element in a range.
      * :cppreference-algorithm:`minmax_element`
 
@@ -1043,19 +1044,19 @@ Parallel algorithms
    * * Name
      * Description
      * C++ standard
-   * * :cpp:func:`hpx::nth_element`
+   * * :hpx:func:`hpx::nth_element`
      * Partially sorts the given range making sure that it is partitioned by the given element
      * :cppreference-algorithm:`nth_element`
-   * * :cpp:func:`hpx::is_partitioned`
+   * * :hpx:func:`hpx::is_partitioned`
      * Returns ``true`` if each true element for a predicate precedes the false elements in a range.
      * :cppreference-algorithm:`is_partitioned`
-   * * :cpp:func:`hpx::partition`
+   * * :hpx:func:`hpx::partition`
      * Divides elements into two groups without preserving their relative order.
      * :cppreference-algorithm:`partition`
-   * * :cpp:func:`hpx::partition_copy`
+   * * :hpx:func:`hpx::partition_copy`
      * Copies a range dividing the elements into two groups.
      * :cppreference-algorithm:`partition_copy`
-   * * :cpp:func:`hpx::stable_partition`
+   * * :hpx:func:`hpx::stable_partition`
      * Divides elements into two groups while preserving their relative order.
      * :cppreference-algorithm:`stable_partition`
 
@@ -1067,25 +1068,25 @@ Parallel algorithms
    * * Name
      * Description
      * C++ standard
-   * * :cpp:func:`hpx::is_sorted`
+   * * :hpx:func:`hpx::is_sorted`
      * Returns ``true`` if each element in a range is sorted.
      * :cppreference-algorithm:`is_sorted`
-   * * :cpp:func:`hpx::is_sorted_until`
+   * * :hpx:func:`hpx::is_sorted_until`
      * Returns the first unsorted element.
      * :cppreference-algorithm:`is_sorted_until`
-   * * :cpp:func:`hpx::sort`
+   * * :hpx:func:`hpx::sort`
      * Sorts the elements in a range.
      * :cppreference-algorithm:`sort`
-   * * :cpp:func:`hpx::stable_sort`
+   * * :hpx:func:`hpx::stable_sort`
      * Sorts the elements in a range, maintain sequence of equal elements.
      * :cppreference-algorithm:`stable_sort`
-   * * :cpp:func:`hpx::partial_sort`
+   * * :hpx:func:`hpx::partial_sort`
      * Sorts the first elements in a range.
      * :cppreference-algorithm:`partial_sort`
-   * * :cpp:func:`hpx::partial_sort_copy`
+   * * :hpx:func:`hpx::partial_sort_copy`
      * Sorts the first elements in a range, storing the result in another range.
      * :cppreference-algorithm:`partial_sort_copy`
-   * * :cpp:func:`hpx::experimental::sort_by_key`
+   * * :hpx:func:`hpx::experimental::sort_by_key`
      * Sorts one range of data using keys supplied in another range.
      *
 
@@ -1097,25 +1098,25 @@ Parallel algorithms
    * * Name
      * Description
      * C++ standard
-   * * :cpp:func:`hpx::adjacent_difference`
+   * * :hpx:func:`hpx::adjacent_difference`
      * Calculates the difference between each element in an input range and the preceding element.
      * :cppreference-algorithm:`adjacent_difference`
-   * * :cpp:func:`hpx::exclusive_scan`
+   * * :hpx:func:`hpx::exclusive_scan`
      * Does an exclusive parallel scan over a range of elements.
      * :cppreference-algorithm:`exclusive_scan`
-   * * :cpp:func:`hpx::inclusive_scan`
+   * * :hpx:func:`hpx::inclusive_scan`
      * Does an inclusive parallel scan over a range of elements.
      * :cppreference-algorithm:`inclusive_scan`
-   * * :cpp:func:`hpx::reduce`
+   * * :hpx:func:`hpx::reduce`
      * Sums up a range of elements.
      * :cppreference-algorithm:`reduce`
-   * * :cpp:func:`hpx::transform_exclusive_scan`
+   * * :hpx:func:`hpx::transform_exclusive_scan`
      * Does an exclusive parallel scan over a range of elements after applying a function.
      * :cppreference-algorithm:`transform_exclusive_scan`
-   * * :cpp:func:`hpx::transform_inclusive_scan`
+   * * :hpx:func:`hpx::transform_inclusive_scan`
      * Does an inclusive parallel scan over a range of elements after applying a function.
      * :cppreference-algorithm:`transform_inclusive_scan`
-   * * :cpp:func:`hpx::transform_reduce`
+   * * :hpx:func:`hpx::transform_reduce`
      * Sums up a range of elements after applying a function. Also, accumulates the inner products of two input ranges.
      * :cppreference-algorithm:`transform_reduce`
 
@@ -1127,40 +1128,40 @@ Parallel algorithms
    * * Name
      * Description
      * C++ standard
-   * * :cpp:func:`hpx::destroy`
+   * * :hpx:func:`hpx::destroy`
      * Destroys a range of objects.
      * :cppreference-memory:`destroy`
-   * * :cpp:func:`hpx::destroy_n`
+   * * :hpx:func:`hpx::destroy_n`
      * Destroys a range of objects.
      * :cppreference-memory:`destroy_n`
-   * * :cpp:func:`hpx::uninitialized_copy`
+   * * :hpx:func:`hpx::uninitialized_copy`
      * Copies a range of objects to an uninitialized area of memory.
      * :cppreference-memory:`uninitialized_copy`
-   * * :cpp:func:`hpx::uninitialized_copy_n`
+   * * :hpx:func:`hpx::uninitialized_copy_n`
      * Copies a number of objects to an uninitialized area of memory.
      * :cppreference-memory:`uninitialized_copy_n`
-   * * :cpp:func:`hpx::uninitialized_default_construct`
+   * * :hpx:func:`hpx::uninitialized_default_construct`
      * Copies a range of objects to an uninitialized area of memory.
      * :cppreference-memory:`uninitialized_default_construct`
-   * * :cpp:func:`hpx::uninitialized_default_construct_n`
+   * * :hpx:func:`hpx::uninitialized_default_construct_n`
      * Copies a number of objects to an uninitialized area of memory.
      * :cppreference-memory:`uninitialized_default_construct_n`
-   * * :cpp:func:`hpx::uninitialized_fill`
+   * * :hpx:func:`hpx::uninitialized_fill`
      * Copies an object to an uninitialized area of memory.
      * :cppreference-memory:`uninitialized_fill`
-   * * :cpp:func:`hpx::uninitialized_fill_n`
+   * * :hpx:func:`hpx::uninitialized_fill_n`
      * Copies an object to an uninitialized area of memory.
      * :cppreference-memory:`uninitialized_fill_n`
-   * * :cpp:func:`hpx::uninitialized_move`
+   * * :hpx:func:`hpx::uninitialized_move`
      * Moves a range of objects to an uninitialized area of memory.
      * :cppreference-memory:`uninitialized_move`
-   * * :cpp:func:`hpx::uninitialized_move_n`
+   * * :hpx:func:`hpx::uninitialized_move_n`
      * Moves a number of objects to an uninitialized area of memory.
      * :cppreference-memory:`uninitialized_move_n`
-   * * :cpp:func:`hpx::uninitialized_value_construct`
+   * * :hpx:func:`hpx::uninitialized_value_construct`
      * Constructs objects in an uninitialized area of memory.
      * :cppreference-memory:`uninitialized_value_construct`
-   * * :cpp:func:`hpx::uninitialized_value_construct_n`
+   * * :hpx:func:`hpx::uninitialized_value_construct_n`
      * Constructs objects in an uninitialized area of memory.
      * :cppreference-memory:`uninitialized_value_construct_n`
 
@@ -1170,13 +1171,13 @@ Parallel algorithms
 
    * * Name
      * Description
-   * * :cpp:func:`hpx::experimental::for_loop`
+   * * :hpx:func:`hpx::experimental::for_loop`
      * Implements loop functionality over a range specified by integral or iterator bounds.
-   * * :cpp:func:`hpx::experimental::for_loop_strided`
+   * * :hpx:func:`hpx::experimental::for_loop_strided`
      * Implements loop functionality over a range specified by integral or iterator bounds.
-   * * :cpp:func:`hpx::experimental::for_loop_n`
+   * * :hpx:func:`hpx::experimental::for_loop_n`
      * Implements loop functionality over a range specified by integral or iterator bounds.
-   * * :cpp:func:`hpx::experimental::for_loop_n_strided`
+   * * :hpx:func:`hpx::experimental::for_loop_n_strided`
      * Implements loop functionality over a range specified by integral or iterator bounds.
 
 .. _executor_parameters:
@@ -1212,15 +1213,15 @@ The lambda function exposes a means of test-probing the execution of a single
 iteration for performance measurement purposes. The execution parameter type
 might dynamically determine the execution time of one or more tasks in order
 to calculate the chunk size; see
-:cpp:class:`hpx::execution::experimental::auto_chunk_size` for an example of
+:hpx:class:`hpx::execution::experimental::auto_chunk_size` for an example of
 this executor parameter type.
 
 Other functions in the interface exist to discover whether an executor parameter
 type should be invoked once (i.e., it returns a static chunk size; see
-:cpp:class:`hpx::execution::experimental::static_chunk_size`) or whether it
+:hpx:class:`hpx::execution::experimental::static_chunk_size`) or whether it
 should be invoked
 for each scheduled chunk of work (i.e., it returns a variable chunk size; for an
-example, see :cpp:class:`hpx::execution::experimental::guided_chunk_size`).
+example, see :hpx:class:`hpx::execution::experimental::guided_chunk_size`).
 
 Although this interface appears to require executor parameter type authors to
 implement all different basic operations, none are required. In
@@ -1229,26 +1230,26 @@ parameter types will naturally specialize all operations for maximum efficiency.
 
 |hpx|  implements the following executor parameter types:
 
-* :cpp:class:`hpx::execution::experimental::auto_chunk_size`: Loop iterations
+* :hpx:class:`hpx::execution::experimental::auto_chunk_size`: Loop iterations
   are divided into pieces and then assigned to threads. The number of loop
   iterations combined is
   determined based on measurements of how long the execution of 1% of the
   overall number of iterations takes. This executor parameter type makes sure
   that as many loop iterations are combined as necessary to run for the amount
   of time specified.
-* :cpp:class:`hpx::execution::experimental::static_chunk_size`: Loop iterations
+* :hpx:class:`hpx::execution::experimental::static_chunk_size`: Loop iterations
   are divided
   into pieces of a given size and then assigned to threads. If the size is not
   specified, the iterations are, if possible, evenly divided contiguously among
   the threads. This executor parameters type is equivalent to OpenMP's STATIC
   scheduling directive.
-* :cpp:class:`hpx::execution::experimental::dynamic_chunk_size`: Loop iterations
+* :hpx:class:`hpx::execution::experimental::dynamic_chunk_size`: Loop iterations
   are divided
   into pieces of a given size and then dynamically scheduled among the cores;
   when a core finishes one chunk, it is dynamically assigned another. If the
   size is not specified, the default chunk size is 1. This executor parameter
   type is equivalent to OpenMP's DYNAMIC scheduling directive.
-* :cpp:class:`hpx::execution::experimental::guided_chunk_size`: Iterations are
+* :hpx:class:`hpx::execution::experimental::guided_chunk_size`: Iterations are
   dynamically
   assigned to cores in blocks as cores request them until no blocks remain to be
   assigned. This is similar to ``dynamic_chunk_size`` except that the block size

--- a/docs/sphinx/releases/new_namespaces_1_9_0.rst
+++ b/docs/sphinx/releases/new_namespaces_1_9_0.rst
@@ -20,17 +20,17 @@ deprecated. Below is a comprehensive list of the namespace changes.
    ===========================================================  ==============================================================
    Old namespace                                                New namespace
    ===========================================================  ==============================================================
-   :cpp:func:`hpx::util::mem_fn`                                :cpp:func:`hpx::mem_fn`
-   :cpp:func:`hpx::util::invoke`                                :cpp:func:`hpx::invoke`
-   :cpp:func:`hpx::util::invoke_r`                              :cpp:func:`hpx::invoke_r`
-   :cpp:func:`hpx::util::invoke_fused`                          :cpp:func:`hpx::invoke_fused`
-   :cpp:func:`hpx::util::invoke_fused_r`                        :cpp:func:`hpx::invoke_fused_r`
-   :cpp:class:`hpx::util::unlock_guard`                         :cpp:class:`hpx::unlock_guard`
-   :cpp:func:`hpx::parallel::v1::reduce_by_key`                 :cpp:func:`hpx::experimental::reduce_by_key`
-   :cpp:func:`hpx::parallel::v1::sort_by_key`                   :cpp:func:`hpx::experimental::sort_by_key`
-   :cpp:class:`hpx::parallel::task_canceled_exception`          :cpp:class:`hpx::experimental::task_canceled_exception`
-   :cpp:class:`hpx::parallel::task_block`                       :cpp:class:`hpx::experimental::task_block`
-   :cpp:func:`hpx::parallel::define_task_block`                 :cpp:func:`hpx::experimental::define_task_block`                |
-   :cpp:func:`hpx::parallel::define_task_block_restore_thread`  :cpp:func:`hpx::experimental::define_task_block_restore_thread`
-   :cpp:class:`hpx::execution::experimental::task_group`        :cpp:class:`hpx::experimental::task_group`
+   :hpx:func:`hpx::util::mem_fn`                                :hpx:func:`hpx::mem_fn`
+   :hpx:func:`hpx::util::invoke`                                :hpx:func:`hpx::invoke`
+   :hpx:func:`hpx::util::invoke_r`                              :hpx:func:`hpx::invoke_r`
+   :hpx:func:`hpx::util::invoke_fused`                          :hpx:func:`hpx::invoke_fused`
+   :hpx:func:`hpx::util::invoke_fused_r`                        :hpx:func:`hpx::invoke_fused_r`
+   :hpx:class:`hpx::util::unlock_guard`                         :hpx:class:`hpx::unlock_guard`
+   :hpx:func:`hpx::parallel::v1::reduce_by_key`                 :hpx:func:`hpx::experimental::reduce_by_key`
+   :hpx:func:`hpx::parallel::v1::sort_by_key`                   :hpx:func:`hpx::experimental::sort_by_key`
+   :hpx:class:`hpx::parallel::task_canceled_exception`          :hpx:class:`hpx::experimental::task_canceled_exception`
+   :hpx:class:`hpx::parallel::task_block`                       :hpx:class:`hpx::experimental::task_block`
+   :hpx:func:`hpx::parallel::define_task_block`                 :hpx:func:`hpx::experimental::define_task_block`                |
+   :hpx:func:`hpx::parallel::define_task_block_restore_thread`  :hpx:func:`hpx::experimental::define_task_block_restore_thread`
+   :hpx:class:`hpx::execution::experimental::task_group`        :hpx:class:`hpx::experimental::task_group`
    ===========================================================  ==============================================================

--- a/docs/sphinx/releases/whats_new_0_8_0.rst
+++ b/docs/sphinx/releases/whats_new_0_8_0.rst
@@ -22,10 +22,10 @@ General changes
 * Implemented decrement merging logic to optimize the distributed reference
   counting system.
 * Restructured the LCO framework. Renamed ``hpx::lcos::eager_future<>`` and
-  ``hpx::lcos::lazy_future<>`` into :cpp:class:`hpx::lcos::packaged_task` and
-  :cpp:class:`hpx::lcos::deferred_packaged_task`. Split
-  :cpp:class:`hpx::lcos::promise` into :cpp:class:`hpx::lcos::packaged_task` and
-  :cpp:class:`hpx::lcos::future`. Added 'local' futures (in namespace
+  ``hpx::lcos::lazy_future<>`` into :hpx:class:`hpx::lcos::packaged_task` and
+  :hpx:class:`hpx::lcos::deferred_packaged_task`. Split
+  :hpx:class:`hpx::lcos::promise` into :hpx:class:`hpx::lcos::packaged_task` and
+  :hpx:class:`hpx::lcos::future`. Added 'local' futures (in namespace
   ``hpx::lcos::local``).
 * Improved the general performance of local and remote action invocations. This
   (under certain circumstances) drastically reduces the number of copies created
@@ -89,16 +89,16 @@ API changes
 
 * Moved all local LCOs into a separate namespace ``hpx::lcos::local`` (for
   instance, ``hpx::lcos::local_mutex`` is now
-  :cpp:class:`hpx::lcos::local::mutex`).
-* Replaced ``hpx::actions::function`` with :cpp:class:`hpx::util::function`.
+  :hpx:class:`hpx::lcos::local::mutex`).
+* Replaced ``hpx::actions::function`` with :hpx:class:`hpx::util::function`.
   Cleaned up related code.
 * Removed ``hpx::traits::handle_gid`` and moved handling of global reference
   counts into the corresponding serialization code.
 * Changed terminology: ``prefix`` is now called ``locality_id``, renamed the
   corresponding API functions (such as ``hpx::get_prefix``, which is now called
   ``hpx::get_locality_id``).
-* Adding :cpp:func:`hpx::find_remote_localities`, and
-  :cpp:func:`hpx::get_num_localities`.
+* Adding :hpx:func:`hpx::find_remote_localities`, and
+  :hpx:func:`hpx::get_num_localities`.
 * Changed performance counter naming scheme to make it more bash friendly.
   The new performance counter naming scheme is now
 

--- a/docs/sphinx/releases/whats_new_0_9_0.rst
+++ b/docs/sphinx/releases/whats_new_0_9_0.rst
@@ -19,49 +19,49 @@ General changes
 
 * Significant improvements made to the usability of |hpx| in large-scale,
   distributed environments.
-* Renamed :cpp:class:`hpx::lcos::packaged_task` to
-  :cpp:class:`hpx::lcos::packaged_action` to reflect the semantic differences to
+* Renamed :hpx:class:`hpx::lcos::packaged_task` to
+  :hpx:class:`hpx::lcos::packaged_action` to reflect the semantic differences to
   a packaged_task as defined by the |cpp11|_.
-* |hpx| now exposes :cpp:class:`hpx::thread` which is compliant to the C++11
+* |hpx| now exposes :hpx:class:`hpx::thread` which is compliant to the C++11
   std::thread type except that it (purely locally) represents an |hpx| thread.
   This new type does not expose any of the remote capabilities of the underlying
   |hpx|-thread implementation.
-* The type :cpp:class:`hpx::lcos::future` is now compliant to the C++11
+* The type :hpx:class:`hpx::lcos::future` is now compliant to the C++11
   std::future<> type. This type can be used to synchronize both, local and
   remote operations. In both cases the control flow will 'return' to the future
   in order to trigger any continuation.
-* The types :cpp:class:`hpx::lcos::local::promise` and
-  :cpp:class:`hpx::lcos::local::packaged_task` are now compliant to the C++11
+* The types :hpx:class:`hpx::lcos::local::promise` and
+  :hpx:class:`hpx::lcos::local::packaged_task` are now compliant to the C++11
   ``std::promise<>`` and ``std::packaged_task<>`` types. These can be used to
   create a future representing local work only. Use the types
-  :cpp:class:`hpx::lcos::promise` and :cpp:class:`hpx::lcos::packaged_action`
+  :hpx:class:`hpx::lcos::promise` and :hpx:class:`hpx::lcos::packaged_action`
   to wrap any (possibly remote) action into a future.
-* :cpp:class:`hpx::thread` and :cpp:class:`hpx::lcos::future` are now
+* :hpx:class:`hpx::thread` and :hpx:class:`hpx::lcos::future` are now
   cancelable.
 * Added support for sequential and logic composition of
-  :cpp:class:`hpx::lcos::future`\ s. The member function
-  :cpp:member:`hpx::lcos::future::when` permits futures to be sequentially
-  composed. The helper functions :cpp:func:`hpx::wait_all`,
-  :cpp:func:`hpx::wait_any`, and :cpp:func:`hpx::wait_n` can be used to wait for
+  :hpx:class:`hpx::lcos::future`\ s. The member function
+  :hpx:member:`hpx::lcos::future::when` permits futures to be sequentially
+  composed. The helper functions :hpx:func:`hpx::wait_all`,
+  :hpx:func:`hpx::wait_any`, and :hpx:func:`hpx::wait_n` can be used to wait for
   more than one future at a time.
-* |hpx| now exposes :cpp:func:`hpx::apply` and :cpp:func:`hpx::async` as the
+* |hpx| now exposes :hpx:func:`hpx::apply` and :hpx:func:`hpx::async` as the
   preferred way of creating (or invoking) any deferred work. These functions are
   usable with various types of functions, function objects, and actions and
   provide a uniform way to spawn deferred tasks.
-* |hpx| now utilizes :cpp:func:`hpx::util::bind` to (partially) bind local
+* |hpx| now utilizes :hpx:func:`hpx::util::bind` to (partially) bind local
   functions and function objects, and also actions. Remote bound actions can
   have placeholders as well.
 * |hpx| continuations are now fully polymorphic. The class
-  :cpp:class:`hpx::actions::forwarding_continuation` is an example of how the
+  :hpx:class:`hpx::actions::forwarding_continuation` is an example of how the
   user can write is own types of continuations. It can be used to execute any
   function as an continuation of a particular action.
 * Reworked the action invocation API to be fully conformant to normal functions.
-  Actions can now be invoked using :cpp:func:`hpx::apply`,
-  :cpp:func:`hpx::async`, or using the ``operator()`` implemented on actions.
+  Actions can now be invoked using :hpx:func:`hpx::apply`,
+  :hpx:func:`hpx::async`, or using the ``operator()`` implemented on actions.
   Actions themselves can now be cheaply instantiated as they do not have any
   members anymore.
 * Reworked the lazy action invocation API. Actions can now be directly bound
-  using :cpp:func:`hpx::util::bind` by passing an action instance as the first
+  using :hpx:func:`hpx::util::bind` by passing an action instance as the first
   argument.
 * A minimal |hpx| program now looks like this::
 
@@ -109,19 +109,19 @@ General changes
   the number of parcels sent and received, the number of bytes sent and
   received, the overall time required to send and receive data, and the overall
   time required to serialize and deserialize the data.
-* Added a new component: :cpp:class:`hpx::components::binpacking_factory` which
+* Added a new component: :hpx:class:`hpx::components::binpacking_factory` which
   is equivalent to the existing
-  :cpp:class:`hpx::components::distributing_factory` component, except that it
+  :hpx:class:`hpx::components::distributing_factory` component, except that it
   equalizes the overall population of the components to create. It exposes two
   factory methods, one based on the number of existing instances of the
   component type to create, and one based on an arbitrary performance counter
   which will be queried for all relevant localities.
 * Added API functions allowing to access elements of the diagnostic information
-  embedded in the given exception: :cpp:func:`hpx::get_locality_id`,
-  :cpp:func:`hpx::get_host_name`, :cpp:func:`hpx::get_process_id`,
-  :cpp:func:`hpx::get_function_name`, :cpp:func:`hpx::get_file_name`,
-  :cpp:func:`hpx::get_line_number`, :cpp:func:`hpx::get_os_thread`,
-  :cpp:func:`hpx::get_thread_id`, and :cpp:func:`hpx::get_thread_description`.
+  embedded in the given exception: :hpx:func:`hpx::get_locality_id`,
+  :hpx:func:`hpx::get_host_name`, :hpx:func:`hpx::get_process_id`,
+  :hpx:func:`hpx::get_function_name`, :hpx:func:`hpx::get_file_name`,
+  :hpx:func:`hpx::get_line_number`, :hpx:func:`hpx::get_os_thread`,
+  :hpx:func:`hpx::get_thread_id`, and :hpx:func:`hpx::get_thread_description`.
 
 Bug fixes (closed tickets)
 ==========================
@@ -130,7 +130,7 @@ Here is a list of the important tickets we closed for this release:
 
 * :hpx-issue:`71` - GIDs that are not serialized via ``handle_gid<>`` should
   raise an exception
-* :hpx-issue:`105` - Allow for :cpp:class:`hpx::util::function`\ s to be registered
+* :hpx-issue:`105` - Allow for :hpx:class:`hpx::util::function`\ s to be registered
   in the AGAS symbolic namespace
 * :hpx-issue:`107` - Nasty threadmanger race condition (reproducible in
   sheneos_test)
@@ -148,13 +148,13 @@ Here is a list of the important tickets we closed for this release:
   pool is unaware of this
 * :hpx-issue:`231` - Implement movable ``boost::bind``
 * :hpx-issue:`232` - Implement movable ``boost::function``
-* :hpx-issue:`236` - Allow binding :cpp:class:`hpx::util::function` to actions
+* :hpx-issue:`236` - Allow binding :hpx:class:`hpx::util::function` to actions
 * :hpx-issue:`239` - Replace ``hpx::function`` with
-  :cpp:class:`hpx::util::function`
+  :hpx:class:`hpx::util::function`
 * :hpx-issue:`240` - Can't specify RemoteResult with lcos::async
 * :hpx-issue:`242` - REGISTER_TEMPLATE support for plain actions
 * :hpx-issue:`243` - ``handle_gid<>`` support for
-  :cpp:class:`hpx::util::function`
+  :hpx:class:`hpx::util::function`
 * :hpx-issue:`245` - ``*_c_cache code`` throws an exception if the queried GID
   is not in the local cache
 * :hpx-issue:`246` - Undefined references in dataflow/adaptive1d example
@@ -171,7 +171,7 @@ Here is a list of the important tickets we closed for this release:
 * :hpx-issue:`270` - Compiler noise due to -Wcast-qual
 * :hpx-issue:`275` - Problem with configuration tests/include paths on Gentoo
 * :hpx-issue:`325` - Sheneos is 200-400 times slower than the fortran equivalent
-* :hpx-issue:`331` - :cpp:func:`hpx::init` and ``hpx_main()`` should not depend
+* :hpx-issue:`331` - :hpx:func:`hpx::init` and ``hpx_main()`` should not depend
   on program_options
 * :hpx-issue:`333` - Add doxygen support to CMake for doc toolchain
 * :hpx-issue:`340` - Performance counters for parcels
@@ -183,10 +183,10 @@ Here is a list of the important tickets we closed for this release:
 * :hpx-issue:`368` - Scalable alternative to rand() needed for |hpx|
 * :hpx-issue:`369` - IB over IP is substantially slower than just using standard
   TCP/IP
-* :hpx-issue:`374` - :cpp:func:`hpx::lcos::wait` should work with dataflows and
+* :hpx-issue:`374` - :hpx:func:`hpx::lcos::wait` should work with dataflows and
   arbitrary classes meeting the future interface
 * :hpx-issue:`375` - Conflicting/ambiguous overloads of
-  :cpp:func:`hpx::lcos::wait`
+  :hpx:func:`hpx::lcos::wait`
 * :hpx-issue:`376` - Find_HPX.cmake should set CMake variable HPX_FOUND for out
   of tree builds
 * :hpx-issue:`377` - ShenEOS interpolate bulk and interpolate_one_bulk are
@@ -215,4 +215,3 @@ Here is a list of the important tickets we closed for this release:
 * :hpx-issue:`425` - Breaking changes to ``traits::*result`` wrt
   ``std::vector<id_type>``
 * :hpx-issue:`426` - AUTOGLOB needs to be updated to support fortran
-

--- a/docs/sphinx/releases/whats_new_0_9_10.rst
+++ b/docs/sphinx/releases/whats_new_0_9_10.rst
@@ -64,8 +64,8 @@ compatibility:
 
 * Move to Variadics- All of the API now uses variadic templates. However, this
   change required to modify the argument sequence for some of the exiting API
-  functions (:cpp:func:`hpx::async_continue`, :cpp:func:`hpx::apply_continue`,
-  :cpp:func:`hpx::when_each`, :cpp:func:`hpx::wait_each`, synchronous invocation
+  functions (:hpx:func:`hpx::async_continue`, :hpx:func:`hpx::apply_continue`,
+  :hpx:func:`hpx::when_each`, :hpx:func:`hpx::wait_each`, synchronous invocation
   of actions).
 * Changes to Macros- We also removed the macros ``HPX_STD_FUNCTION`` and
   ``HPX_STD_TUPLE``. This shouldn't affect any user code as we replaced
@@ -76,7 +76,7 @@ compatibility:
   Similarly, ``HPX_STD_TUPLE`` was replaced by its default expansion as well:
   ``hpx::util::tuple``.
 * Changes to ``hpx::unique_future``- ``hpx::unique_future``, which was
-  deprecated in the previous release for :cpp:func:`hpx::future` is now
+  deprecated in the previous release for :hpx:func:`hpx::future` is now
   completely removed from |hpx|. This completes the transition to a completely
   standards conforming implementation of ``hpx::future``.
 * Changes to Supported Compilers. Finally, in order to utilize more C++11
@@ -233,4 +233,3 @@ Here is a list of the important tickets we closed for this release.
 * :hpx-issue:`504` - Refactor Dataflow LCO to work with futures
 * :hpx-issue:`196` - Don't store copies of the locality network metadata in the
   gva table
-

--- a/docs/sphinx/releases/whats_new_0_9_11.rst
+++ b/docs/sphinx/releases/whats_new_0_9_11.rst
@@ -37,8 +37,8 @@ General changes
 ===============
 
 * We are moving into the direction of unifying managed and simple components. As
-  such, the classes :cpp:class:`hpx::components::component` and
-  :cpp:class:`hpx::components::component_base` have been added which currently
+  such, the classes :hpx:class:`hpx::components::component` and
+  :hpx:class:`hpx::components::component_base` have been added which currently
   just forward to the currently existing simple component facilities. The
   examples have been converted to only use those two classes.
 * Added integration with the `CircleCI
@@ -50,23 +50,23 @@ General changes
   set of cmake scripts to determine the available language and library features
   supported by the used compiler.
 * The API for creating instances of components has been consolidated. All
-  component instances should be created using the :cpp:func:`hpx::new_` only. It
+  component instances should be created using the :hpx:func:`hpx::new_` only. It
   allows one to instantiate both, single component instances and multiple
   component instances. The placement of the created components can be controlled
   by special distribution policies. Please see the corresponding documentation
-  outlining the use of :cpp:func:`hpx::new_`.
+  outlining the use of :hpx:func:`hpx::new_`.
 * Introduced four new distribution policies which can be used with many API
   functions which traditionally expected to be used with a locality id. The new
   distribution policies are:
 
-  * :cpp:class:`hpx::components::default_distribution_policy` which tries to
+  * :hpx:class:`hpx::components::default_distribution_policy` which tries to
     place multiple component instances as evenly as possible.
-  * :cpp:class:`hpx::components::colocating_distribution_policy` which will
+  * :hpx:class:`hpx::components::colocating_distribution_policy` which will
     refer to the locality where a given component instance is currently placed.
-  * :cpp:class:`hpx::components::binpacking_distribution_policy` which will
+  * :hpx:class:`hpx::components::binpacking_distribution_policy` which will
     place multiple component instances as evenly as possible based on any
     performance counter.
-  * :cpp:class:`hpx::components::target_distribution_policy` which allows one to
+  * :hpx:class:`hpx::components::target_distribution_policy` which allows one to
     represent a given locality in the context of a distrwibution policy.
 * The new distribution policies can now be also used with ``hpx::async``. This
   change also deprecates ``hpx::async_colocated(id, ...)`` which now is replaced
@@ -74,10 +74,10 @@ General changes
 * The ``hpx::vector`` and ``hpx::unordered_map`` data structures can now be used
   with the new distribution policies as well.
 * The parallel facility ``hpx::parallel::task_region`` has been renamed to
-  :cpp:class:`hpx::parallel::task_block` based on the changes in the
+  :hpx:class:`hpx::parallel::task_block` based on the changes in the
   corresponding standardization proposal |cpp11_n4088|_.
 * Added extensions to the parallel facility
-  :cpp:class:`hpx::parallel::task_block` allowing to combine a task_block with
+  :hpx:class:`hpx::parallel::task_block` allowing to combine a task_block with
   an execution policy. This implies a minor breaking change as the
   ``hpx::parallel::task_block`` is now a template.
 * Added new LCOs: ``hpx::lcos::latch`` and ``hpx::lcos::local::latch`` which
@@ -113,8 +113,8 @@ Breaking changes
 * We are moving into the direction of unifying managed and simple components. In
   order to stop exposing the old facilities, all examples have been converted to
   use the new classes. The breaking change in this release is that performance
-  counters are now a :cpp:class:`hpx::components::component_base` instead of
-  :cpp:class:`hpx::components::managed_component_base`.
+  counters are now a :hpx:class:`hpx::components::component_base` instead of
+  :hpx:class:`hpx::components::managed_component_base`.
 * We removed the support for stackless threads. It turned out that there was no
   performance benefit when using stackless threads. As such, we decided to clean
   up our codebase. This feature was not documented.
@@ -126,21 +126,21 @@ Breaking changes
   instead. The old macro will be removed in the next release.
 * The obsolete distributing_factory and binpacking_factory components have been
   removed. The corresponding functionality is now provided by the
-  :cpp:func:`hpx::new_()` API function in conjunction with the
+  :hpx:func:`hpx::new_()` API function in conjunction with the
   ``hpx::default_layout`` and ``hpx::binpacking`` distribution policies
-  (:cpp:class:`hpx::components::default_distribution_policy` and
-  :cpp:class:`hpx::components::binpacking_distribution_policy`)
+  (:hpx:class:`hpx::components::default_distribution_policy` and
+  :hpx:class:`hpx::components::binpacking_distribution_policy`)
 * The API function ``hpx::new_colocated`` has been deprecated. Please use the
-  consolidated API :cpp:func:`hpx::new_` in conjunction with the new
+  consolidated API :hpx:func:`hpx::new_` in conjunction with the new
   ``hpx::colocated`` distribution policy
-  (:cpp:class:`hpx::components::colocating_distribution_policy`) instead. The
+  (:hpx:class:`hpx::components::colocating_distribution_policy`) instead. The
   old API function will still be available for at least one release of |hpx| if
   the configuration variable ``HPX_WITH_COLOCATED_BACKWARDS_COMPATIBILITY`` is
   enabled.
 * The API function ``hpx::async_colocated`` has been deprecated. Please use the
   consolidated API ``hpx::async`` in conjunction with the new ``hpx::colocated``
   distribution policy
-  (:cpp:class:`hpx::components::colocating_distribution_policy`) instead. The
+  (:hpx:class:`hpx::components::colocating_distribution_policy`) instead. The
   old API function will still be available for at least one release of |hpx| if
   the configuration variable ``HPX_WITH_COLOCATED_BACKWARDS_COMPATIBILITY`` is
   enabled.
@@ -664,4 +664,3 @@ Here is a list of the important tickets we closed for this release.
 * :hpx-issue:`1001` - Zero copy serialization raises assert
 * :hpx-issue:`721` - Make HPX usable for Xeon Phi
 * :hpx-issue:`524` - Extend scheduler to support threads which can't be stolen
-

--- a/docs/sphinx/releases/whats_new_1_2_0.rst
+++ b/docs/sphinx/releases/whats_new_1_2_0.rst
@@ -76,8 +76,8 @@ Breaking changes
   we now test is 1.58.
 * Our ``boost::format``\ -based formatting implementation has been revised and
   replaced with a custom implementation. This changes the formatting syntax and
-  requires changes if you are relying on :cpp:func:`hpx::util::format` or
-  :cpp:func:`hpx::util::format_to`. The pull request for this change contains
+  requires changes if you are relying on :hpx:func:`hpx::util::format` or
+  :hpx:func:`hpx::util::format_to`. The pull request for this change contains
   more information: :hpx-pr:`3266`.
 * The following deprecated options have now been completely removed:
   ``HPX_WITH_ASYNC_FUNCTION_COMPATIBILITY``, ``HPX_WITH_LOCAL_DATAFLOW``,
@@ -349,4 +349,3 @@ Closed pull requests
 * :hpx-pr:`3228` - Allow suspension also on static schedulers
 * :hpx-pr:`3163` - libfabric parcelport w/o HPX_PARCELPORT_LIBFABRIC_ENDPOINT_RDM
 * :hpx-pr:`3036` - Switching to CircleCI 2.0
-

--- a/docs/sphinx/releases/whats_new_1_4_0.rst
+++ b/docs/sphinx/releases/whats_new_1_4_0.rst
@@ -53,7 +53,7 @@ General changes
 * It is now possible to create standalone thread pools without starting the
   runtime. See the ``standalone_thread_pool_executor.cpp`` test in the
   ``execution`` module for an example.
-* Tasks annotated with :cpp:func:`hpx::util::annotated_function` now have their
+* Tasks annotated with :hpx:func:`hpx::util::annotated_function` now have their
   correct name when using APEX to generate OTF2 files.
 * Cloning of APEX was defective in previous releases (it required manual
   intervention to check out the correct tag or branch). This has been fixed.

--- a/docs/sphinx/releases/whats_new_1_6_0.rst
+++ b/docs/sphinx/releases/whats_new_1_6_0.rst
@@ -44,7 +44,7 @@ previous CUDA features to now be compiled with hipcc and run on AMD GPUs.
 * We have added experimental support for properties as proposed in |p2220|_.
   Currently the only supported property is the scheduling hint on
   ``parallel_executor``.
-* :cpp:func:`hpx::util::annotated_function` can now be passed a dynamically
+* :hpx:func:`hpx::util::annotated_function` can now be passed a dynamically
   generated ``std::string``.
 * In moving functionality to new namespaces, old names have been deprecated.  A
   deprecation warning will be issued if you are using deprecated functionality,

--- a/libs/core/allocator_support/docs/index.rst
+++ b/libs/core/allocator_support/docs/index.rst
@@ -12,7 +12,7 @@ allocator_support
 =================
 
 This module provides utilities for allocators. It contains
-:cpp:class:`hpx::util::internal_allocator` which directly forwards allocation
+:hpx:class:`hpx::util::internal_allocator` which directly forwards allocation
 calls to ``jemalloc``. This utility is is mainly useful on Windows.
 
 See the :ref:`API reference <modules_allocator_support_api>` of the module for more

--- a/libs/core/assertion/docs/index.rst
+++ b/libs/core/assertion/docs/index.rst
@@ -17,10 +17,10 @@ which are turned of during a release build.
 
 By default, the location and function where the assert has been called from are
 displayed when the assertion fires. This behavior can be modified by using
-:cpp:func:`hpx::assertion::set_assertion_handler`. When HPX initializes, it uses
+:hpx:func:`hpx::assertion::set_assertion_handler`. When HPX initializes, it uses
 this function to specify a more elaborate assertion handler. If your application
 needs to customize this, it needs to do so before calling
-:cpp:func:`hpx::init`, :ref:`hpx_main <starting_hpx>` or using the C-main
+:hpx:func:`hpx::init`, :ref:`hpx_main <starting_hpx>` or using the C-main
 wrappers.
 
 

--- a/libs/core/async_local/docs/index.rst
+++ b/libs/core/async_local/docs/index.rst
@@ -12,10 +12,9 @@ async_local
 ===========
 
 This module extends :ref:`modules_async_base` to provide local implementations of
-:cpp:func:`hpx::async`, :cpp:func:`hpx::post`, :cpp:func:`hpx::sync`, and
-:cpp:func:`hpx::dataflow`. The :ref:`modules_async_distributed` module extends the
+:hpx:func:`hpx::async`, :hpx:func:`hpx::post`, :hpx:func:`hpx::sync`, and
+:hpx:func:`hpx::dataflow`. The :ref:`modules_async_distributed` module extends the
 functionality in this module to work with :term:`action`\ s.
 
 See the :ref:`API reference <modules_async_local_api>` of this module for more
 details.
-

--- a/libs/core/cache/docs/index.rst
+++ b/libs/core/cache/docs/index.rst
@@ -13,8 +13,8 @@ cache
 
 This module provides two cache data structures:
 
-* :cpp:class:`hpx::util::cache::local_cache`
-* :cpp:class:`hpx::util::cache::lru_cache`
+* :hpx:class:`hpx::util::cache::local_cache`
+* :hpx:class:`hpx::util::cache::lru_cache`
 
 See the :ref:`API reference <modules_cache_api>` of the module for more
 details.

--- a/libs/core/concurrency/docs/index.rst
+++ b/libs/core/concurrency/docs/index.rst
@@ -14,9 +14,9 @@ concurrency
 This module provides concurrency primitives useful for multi-threaded
 programming such as:
 
-* :cpp:class:`hpx::barrier`
-* :cpp:class:`hpx::util::cache_line_data` and
-  :cpp:class:`hpx::util::cache_aligned_data`: wrappers for aligning and padding
+* :hpx:class:`hpx::barrier`
+* :hpx:class:`hpx::util::cache_line_data` and
+  :hpx:class:`hpx::util::cache_aligned_data`: wrappers for aligning and padding
   data to cache lines.
 * various lockfree queue data structures
 

--- a/libs/core/config_registry/docs/index.rst
+++ b/libs/core/config_registry/docs/index.rst
@@ -13,12 +13,11 @@ config_registry
 
 The config_registry module is a low level module providing helper functionality
 for registering configuration entries to a global registry from other modules.
-The :cpp:func:`hpx::config_registry::add_module_config` function is used to add
-configuration options, and :cpp:func:`hpx::config_registry::get_module_configs`
+The :hpx:func:`hpx::config_registry::add_module_config` function is used to add
+configuration options, and :hpx:func:`hpx::config_registry::get_module_configs`
 can be used to retrieve configuration entries registered so far.
-:cpp:class:`add_module_config_helper` can be used to register configuration
+:hpx:class:`add_module_config_helper` can be used to register configuration
 entries through static global options.
 
 See the :ref:`API reference <modules_config_registry_api>` of this module for more
 details.
-

--- a/libs/core/datastructures/docs/index.rst
+++ b/libs/core/datastructures/docs/index.rst
@@ -14,12 +14,12 @@ datastructures
 The datastructures module provides basic data structures (typically provided for
 compatibility with older C++ standards):
 
-* :cpp:class:`hpx::detail::small_vector`
-* :cpp:class:`hpx::util::basic_any`
-* :cpp:class:`hpx::util::member_pack`
-* :cpp:class:`hpx::optional`
-* :cpp:struct:`hpx::tuple`
-* :cpp:class:`hpx::variant`
+* :hpx:class:`hpx::detail::small_vector`
+* :hpx:class:`hpx::util::basic_any`
+* :hpx:class:`hpx::util::member_pack`
+* :hpx:class:`hpx::optional`
+* :hpx:struct:`hpx::tuple`
+* :hpx:class:`hpx::variant`
 
 See the :ref:`API reference <modules_datastructures_api>` of the module for more
 details.

--- a/libs/core/errors/docs/index.rst
+++ b/libs/core/errors/docs/index.rst
@@ -13,8 +13,8 @@ errors
 
 This module provides support for exceptions and error codes:
 
-* :cpp:class:`hpx::exception`
-* :cpp:class:`hpx::error_code`
-* :cpp:enum:`hpx::error`
+* :hpx:class:`hpx::exception`
+* :hpx:class:`hpx::error_code`
+* :hpx:enum:`hpx::error`
 
 See the :ref:`API reference <modules_errors_api>` of the module for more details.

--- a/libs/core/executors/docs/index.rst
+++ b/libs/core/executors/docs/index.rst
@@ -14,18 +14,17 @@ executors
 The executors module exposes executors and execution policies. Most importantly,
 it exposes the following classes and constants:
 
-* :cpp:class:`hpx::execution::sequenced_executor`
-* :cpp:class:`hpx::execution::parallel_executor`
-* :cpp:class:`hpx::execution::sequenced_policy`
-* :cpp:class:`hpx::execution::parallel_policy`
-* :cpp:class:`hpx::execution::parallel_unsequenced_policy`
-* :cpp:class:`hpx::execution::sequenced_task_policy`
-* :cpp:class:`hpx::execution::parallel_task_policy`
-* :cpp:var:`hpx::execution::seq`
-* :cpp:var:`hpx::execution::par`
-* :cpp:var:`hpx::execution::par_unseq`
-* :cpp:var:`hpx::execution::task`
+* :hpx:class:`hpx::execution::sequenced_executor`
+* :hpx:class:`hpx::execution::parallel_executor`
+* :hpx:class:`hpx::execution::sequenced_policy`
+* :hpx:class:`hpx::execution::parallel_policy`
+* :hpx:class:`hpx::execution::parallel_unsequenced_policy`
+* :hpx:class:`hpx::execution::sequenced_task_policy`
+* :hpx:class:`hpx::execution::parallel_task_policy`
+* :hpx:var:`hpx::execution::seq`
+* :hpx:var:`hpx::execution::par`
+* :hpx:var:`hpx::execution::par_unseq`
+* :hpx:var:`hpx::execution::task`
 
 See the :ref:`API reference <modules_executors_api>` of this module for more
 details.
-

--- a/libs/core/format/docs/index.rst
+++ b/libs/core/format/docs/index.rst
@@ -11,7 +11,7 @@
 format
 ======
 
-The format module exposes the :cpp:func:`format` and :cpp:func:`format_to`
+The format module exposes the :hpx:func:`format` and :hpx:func:`format_to`
 functions for formatting strings.
 
 See the :ref:`API reference <modules_format_api>` of the module for more details.

--- a/libs/core/functional/docs/index.rst
+++ b/libs/core/functional/docs/index.rst
@@ -14,26 +14,26 @@ functional
 This module provides function wrappers and helpers for managing functions and
 their arguments.
 
-* :cpp:class:`hpx::function`
-* :cpp:class:`hpx::function_ref`
-* :cpp:class:`hpx::move_only_function`
-* :cpp:func:`hpx::bind`
-* :cpp:func:`hpx::bind_back`
-* :cpp:func:`hpx::bind_front`
-* :cpp:func:`hpx::util::deferred_call`
-* :cpp:func:`hpx::invoke`
-* :cpp:func:`hpx::invoke_r`
-* :cpp:func:`hpx::invoke_fused`
-* :cpp:func:`hpx::invoke_fused_r`
-* :cpp:func:`hpx::mem_fn`
-* :cpp:func:`hpx::util::one_shot`
-* :cpp:func:`hpx::util::protect`
-* :cpp:class:`hpx::util::result_of`
+* :hpx:class:`hpx::function`
+* :hpx:class:`hpx::function_ref`
+* :hpx:class:`hpx::move_only_function`
+* :hpx:func:`hpx::bind`
+* :hpx:func:`hpx::bind_back`
+* :hpx:func:`hpx::bind_front`
+* :hpx:func:`hpx::util::deferred_call`
+* :hpx:func:`hpx::invoke`
+* :hpx:func:`hpx::invoke_r`
+* :hpx:func:`hpx::invoke_fused`
+* :hpx:func:`hpx::invoke_fused_r`
+* :hpx:func:`hpx::mem_fn`
+* :hpx:func:`hpx::util::one_shot`
+* :hpx:func:`hpx::util::protect`
+* :hpx:class:`hpx::util::result_of`
 
-* :cpp:var:`hpx::placeholders::_1`
-* :cpp:var:`hpx::placeholders::_2`
+* :hpx:var:`hpx::placeholders::_1`
+* :hpx:var:`hpx::placeholders::_2`
 * ...
-* :cpp:var:`hpx::placeholders::_9`
+* :hpx:var:`hpx::placeholders::_9`
 
 See the :ref:`API reference <modules_functional_api>` of the module for more
 details.

--- a/libs/core/futures/docs/index.rst
+++ b/libs/core/futures/docs/index.rst
@@ -11,13 +11,12 @@
 futures
 =======
 
-This module defines the :cpp:class:`hpx::future` and
-:cpp:class:`hpx::shared_future` classes corresponding to the C++ standard
+This module defines the :hpx:class:`hpx::future` and
+:hpx:class:`hpx::shared_future` classes corresponding to the C++ standard
 library classes :cppreference-generic:`thread,future` and
 :cppreference-generic:`thread,shared_future`. Note that the
-specializations of :cpp:func:`hpx::future::then` for executors and
+specializations of :hpx:func:`hpx::future::then` for executors and
 execution policies are defined in the :ref:`modules_execution` module.
 
 See the :ref:`API reference <modules_futures_api>` of this module for more
 details.
-

--- a/libs/core/hashing/docs/index.rst
+++ b/libs/core/hashing/docs/index.rst
@@ -13,8 +13,8 @@ hashing
 
 The hashing module provides two hashing implementations:
 
-* :cpp:func:`hpx::util::fibhash`
-* :cpp:class:`hpx::util::jenkins_hash`
+* :hpx:func:`hpx::util::fibhash`
+* :hpx:class:`hpx::util::jenkins_hash`
 
 See the :ref:`API reference <modules_hashing_api>` of the module for more
 details.

--- a/libs/core/io_service/docs/index.rst
+++ b/libs/core/io_service/docs/index.rst
@@ -13,12 +13,11 @@ io_service
 
 This module provides an abstraction over Boost.ASIO, combining multiple
 ``asio::io_context``\ s into a single pool.
-:cpp:class:`hpx::util::io_service_pool` provides a simple pool of
+:hpx:class:`hpx::util::io_service_pool` provides a simple pool of
 ``asio::io_context``\ s with an API similar to ``asio::io_context``.
-:cpp:class:`hpx::threads::detail::io_service_thread_pool` wraps
-:cpp:class:`hpx::util::io_service_pool` into an interface derived from
-:cpp:class:`hpx::threads::detail::thread_pool_base`.
+:hpx:class:`hpx::threads::detail::io_service_thread_pool` wraps
+:hpx:class:`hpx::util::io_service_pool` into an interface derived from
+:hpx:class:`hpx::threads::detail::thread_pool_base`.
 
 See the :ref:`API reference <modules_io_service_api>` of this module for more
 details.
-

--- a/libs/core/iterator_support/docs/index.rst
+++ b/libs/core/iterator_support/docs/index.rst
@@ -12,9 +12,9 @@ iterator_support
 ================
 
 This module provides helpers for iterators. It provides
-:cpp:class:`hpx::util::iterator_facade` and
-:cpp:class:`hpx::util::iterator_adaptor` for creating new iterators, and the
-trait :cpp:class:`hpx::util::is_iterator` along with more specific iterator
+:hpx:class:`hpx::util::iterator_facade` and
+:hpx:class:`hpx::util::iterator_adaptor` for creating new iterators, and the
+trait :hpx:class:`hpx::util::is_iterator` along with more specific iterator
 traits.
 
 See the :ref:`API reference <modules_iterator_support_api>` of the module for more

--- a/libs/core/lcos_local/docs/index.rst
+++ b/libs/core/lcos_local/docs/index.rst
@@ -13,19 +13,19 @@ lcos_local
 
 This module provides the following local :term:`LCO`\ s:
 
-* :cpp:class:`hpx::lcos::local::and_gate`
-* :cpp:class:`hpx::lcos::local::channel`
-* :cpp:class:`hpx::lcos::local::one_element_channel`
-* :cpp:class:`hpx::lcos::local::receive_channel`
-* :cpp:class:`hpx::lcos::local::send_channel`
-* :cpp:class:`hpx::lcos::local::guard`
-* :cpp:class:`hpx::lcos::local::guard_set`
-* :cpp:func:`hpx::lcos::local::run_guarded`
-* :cpp:class:`hpx::lcos::local::conditional_trigger`
-* :cpp:class:`hpx::packaged_task`
-* :cpp:class:`hpx::promise`
-* :cpp:class:`hpx::lcos::local::receive_buffer`
-* :cpp:class:`hpx::lcos::local::trigger`
+* :hpx:class:`hpx::lcos::local::and_gate`
+* :hpx:class:`hpx::lcos::local::channel`
+* :hpx:class:`hpx::lcos::local::one_element_channel`
+* :hpx:class:`hpx::lcos::local::receive_channel`
+* :hpx:class:`hpx::lcos::local::send_channel`
+* :hpx:class:`hpx::lcos::local::guard`
+* :hpx:class:`hpx::lcos::local::guard_set`
+* :hpx:func:`hpx::lcos::local::run_guarded`
+* :hpx:class:`hpx::lcos::local::conditional_trigger`
+* :hpx:class:`hpx::packaged_task`
+* :hpx:class:`hpx::promise`
+* :hpx:class:`hpx::lcos::local::receive_buffer`
+* :hpx:class:`hpx::lcos::local::trigger`
 
 See :ref:`modules_lcos_distributed` for distributed LCOs. Basic synchronization
 primitives for use in |hpx| threads can be found in :ref:`modules_synchronization`.
@@ -34,4 +34,3 @@ futures.
 
 See the :ref:`API reference <modules_lcos_local_api>` of this module for more
 details.
-

--- a/libs/core/pack_traversal/docs/index.rst
+++ b/libs/core/pack_traversal/docs/index.rst
@@ -12,11 +12,10 @@ pack_traversal
 ==============
 
 This module exposes the basic functionality for traversing various packs, both
-synchronously and asynchronously: :cpp:func:`hpx::util::traverse_pack` and
-:cpp:func:`hpx::util::traverse_pack_async`. It also exposes the higher level
-functionality of unwrapping nested futures: :cpp:func:`hpx::util::unwrap` and
-its function object form :cpp:class:`hpx::util::functional::unwrap`.
+synchronously and asynchronously: :hpx:func:`hpx::util::traverse_pack` and
+:hpx:func:`hpx::util::traverse_pack_async`. It also exposes the higher level
+functionality of unwrapping nested futures: :hpx:func:`hpx::util::unwrap` and
+its function object form :hpx:class:`hpx::util::functional::unwrap`.
 
 See the :ref:`API reference <modules_pack_traversal_api>` of this module for more
 details.
-

--- a/libs/core/resiliency/docs/index.rst
+++ b/libs/core/resiliency/docs/index.rst
@@ -31,27 +31,27 @@ by repeating a task multiple times.
 
 The following API functions are exposed:
 
-- :cpp:func:`hpx::resiliency::experimental::async_replay`: This version of task replay will
+- :hpx:func:`hpx::resiliency::experimental::async_replay`: This version of task replay will
   catch user-defined exceptions and automatically reschedule the task N times
-  before throwing an :cpp:func:`hpx::resiliency::experimental::abort_replay_exception` if no
+  before throwing an :hpx:struct:`hpx::resiliency::experimental::abort_replay_exception` if no
   task is able to complete execution without an exception.
 
-- :cpp:func:`hpx::resiliency::experimental::async_replay_validate`: This version of replay
+- :hpx:func:`hpx::resiliency::experimental::async_replay_validate`: This version of replay
   adds an argument to async replay which receives a user-provided validation
   function to test the result of the task against. If the task's output is
   validated, the result is returned. If the output fails the check or an
   exception is thrown, the task is replayed until no errors are encountered or
   the number of specified retries has been exceeded.
 
-- :cpp:func:`hpx::resiliency::experimental::async_replicate`: This is the most basic
+- :hpx:func:`hpx::resiliency::experimental::async_replicate`: This is the most basic
   implementation of the task replication. The API returns the first result that
   runs without detecting any errors.
 
-- :cpp:func:`hpx::resiliency::experimental::async_replicate_validate`: This API additionally
+- :hpx:func:`hpx::resiliency::experimental::async_replicate_validate`: This API additionally
   takes a validation function which evaluates the return values produced by the
   threads. The first task to compute a valid result is returned.
 
-- :cpp:func:`hpx::resiliency::experimental::async_replicate_vote`: This API adds a vote
+- :hpx:func:`hpx::resiliency::experimental::async_replicate_vote`: This API adds a vote
   function to the basic replicate function. Many hardware or software failures
   are silent errors which do not interrupt program flow. In order to detect
   errors of this kind, it is necessary to run the task several times and compare
@@ -60,20 +60,20 @@ The following API functions are exposed:
   consensus function to properly form a consensus. This voting function then
   returns the "correct"" answer.
 
-- :cpp:func:`hpx::resiliency::experimental::async_replicate_vote_validate`: This combines the
+- :hpx:func:`hpx::resiliency::experimental::async_replicate_vote_validate`: This combines the
   features of the previously discussed replicate set. Replicate vote validate
   allows a user to provide a validation function to filter results.
   Additionally, as described in replicate vote, the user can provide a "voting
   function" which returns the consensus formed by the voting logic.
 
-- :cpp:func:`hpx::resiliency::experimental::dataflow_replay`: This version of dataflow replay
+- :hpx:func:`hpx::resiliency::experimental::dataflow_replay`: This version of dataflow replay
   will catch user-defined exceptions and automatically reschedules the task N
-  times before throwing an :cpp:func:`hpx::resiliency::experimental::abort_replay_exception`
+  times before throwing an :hpx:struct:`hpx::resiliency::experimental::abort_replay_exception`
   if no task is able to complete execution without an exception. Any arguments
   for the executed task that are futures will cause the task invocation to be
   delayed until all of those futures have become ready.
 
-- :cpp:func:`hpx::resiliency::experimental::dataflow_replay_validate` : This version of replay
+- :hpx:func:`hpx::resiliency::experimental::dataflow_replay_validate` : This version of replay
   adds an argument to dataflow replay which receives a user-provided validation
   function to test the result of the task against. If the task's output is
   validated, the result is returned. If the output fails the check or an
@@ -82,19 +82,19 @@ The following API functions are exposed:
   executed task that are futures will cause the task invocation to be delayed
   until all of those futures have become ready.
 
-- :cpp:func:`hpx::resiliency::experimental::dataflow_replicate`: This is the most basic
+- :hpx:func:`hpx::resiliency::experimental::dataflow_replicate`: This is the most basic
   implementation of the task replication. The API returns the first result that
   runs without detecting any errors. Any arguments for the executed task that
   are futures will cause the task invocation to be delayed until all of those
   futures have become ready.
 
-- :cpp:func:`hpx::resiliency::experimental::dataflow_replicate_validate`: This API
+- :hpx:func:`hpx::resiliency::experimental::dataflow_replicate_validate`: This API
   additionally takes a validation function which evaluates the return values
   produced by the threads. The first task to compute a valid result is returned.
   Any arguments for the executed task that are futures will cause the task
   invocation to be delayed until all of those futures have become ready.
 
-- :cpp:func:`hpx::resiliency::experimental::dataflow_replicate_vote`: This API adds a vote
+- :hpx:func:`hpx::resiliency::experimental::dataflow_replicate_vote`: This API adds a vote
   function to the basic replicate function. Many hardware or software failures
   are silent errors which do not interrupt program flow. In order to detect
   errors of this kind, it is necessary to run the task several times and compare
@@ -105,7 +105,7 @@ The following API functions are exposed:
   futures will cause the task invocation to be delayed until all of those
   futures have become ready.
 
-- :cpp:func:`hpx::resiliency::experimental::dataflow_replicate_vote_validate`: This combines
+- :hpx:func:`hpx::resiliency::experimental::dataflow_replicate_vote_validate`: This combines
   the features of the previously discussed replicate set. Replicate vote
   validate allows a user to provide a validation function to filter results.
   Additionally, as described in replicate vote, the user can provide a "voting

--- a/libs/core/resource_partitioner/docs/index.rst
+++ b/libs/core/resource_partitioner/docs/index.rst
@@ -11,7 +11,7 @@
 resource_partitioner
 ====================
 
-The resource_partitioner module defines :cpp:class:`hpx::resource::partitioner`,
+The resource_partitioner module defines :hpx:class:`hpx::resource::partitioner`,
 the class used by the runtime and users to partition available hardware
 resources into thread pools. See :ref:`using_resource_partitioner` for more
 details on using the resource partitioner in applications.

--- a/libs/core/schedulers/docs/index.rst
+++ b/libs/core/schedulers/docs/index.rst
@@ -14,9 +14,9 @@ schedulers
 This module provides schedulers used by thread pools in the
 :ref:`modules_thread_pools` module. There are currently three main schedulers:
 
-* :cpp:class:`hpx::threads::policies::local_priority_queue_scheduler`
-* :cpp:class:`hpx::threads::policies::static_priority_queue_scheduler`
-* :cpp:class:`hpx::threads::policies::shared_priority_queue_scheduler`
+* :hpx:class:`hpx::threads::policies::local_priority_queue_scheduler`
+* :hpx:class:`hpx::threads::policies::static_priority_queue_scheduler`
+* :hpx:class:`hpx::threads::policies::shared_priority_queue_scheduler`
 
 Other schedulers are specializations or variations of the above schedulers. See
 the examples of the :ref:`modules_resource_partitioner` module for examples of
@@ -24,4 +24,3 @@ specifying a custom scheduler for a thread pool.
 
 See the :ref:`API reference <modules_schedulers_api>` of this module for more
 details.
-

--- a/libs/core/synchronization/docs/index.rst
+++ b/libs/core/synchronization/docs/index.rst
@@ -14,34 +14,33 @@ synchronization
 This module provides synchronization primitives that should be used rather than
 the C++ standard ones in |hpx| threads:
 
-* :cpp:class:`hpx::barrier`
-* :cpp:class:`hpx::binary_semaphore`
-* :cpp:class:`hpx::call_once`
-* :cpp:class:`hpx::condition_variable`
-* :cpp:class:`hpx::condition_variable_any`
-* :cpp:class:`hpx::counting_semaphore`
-* :cpp:class:`hpx::lcos::local::event`
-* :cpp:class:`hpx::latch`
-* :cpp:class:`hpx::mutex`
-* :cpp:class:`hpx::no_mutex`
-* :cpp:class:`hpx::once_flag`
-* :cpp:class:`hpx::recursive_mutex`
-* :cpp:class:`hpx::shared_mutex`
-* :cpp:class:`hpx::sliding_semaphore`
-* :cpp:class:`hpx::spinlock` (`std::mutex` compatible spinlock)
-* :cpp:class:`hpx::spinlock_no_backoff` (`boost::mutex` compatible spinlock)
-* :cpp:class:`hpx::spinlock_pool`
-* :cpp:class:`hpx::stop_callback`
-* :cpp:class:`hpx::stop_source`
-* :cpp:class:`hpx::stop_token`
-* :cpp:class:`hpx::in_place_stop_token`
-* :cpp:class:`hpx::timed_mutex`
-* :cpp:class:`hpx::upgrade_to_unique_lock`
-* :cpp:class:`hpx::upgrade_lock`
+* :hpx:class:`hpx::barrier`
+* :hpx:class:`hpx::binary_semaphore`
+* :hpx:func:`hpx::call_once`
+* :hpx:class:`hpx::condition_variable`
+* :hpx:class:`hpx::condition_variable_any`
+* :hpx:class:`hpx::counting_semaphore`
+* :hpx:class:`hpx::lcos::local::event`
+* :hpx:class:`hpx::latch`
+* :hpx:class:`hpx::mutex`
+* :hpx:class:`hpx::no_mutex`
+* :hpx:class:`hpx::once_flag`
+* :hpx:class:`hpx::recursive_mutex`
+* :hpx:class:`hpx::shared_mutex`
+* :hpx:class:`hpx::sliding_semaphore`
+* :hpx:class:`hpx::spinlock` (`std::mutex` compatible spinlock)
+* :hpx:class:`hpx::spinlock_no_backoff` (`boost::mutex` compatible spinlock)
+* :hpx:class:`hpx::spinlock_pool`
+* :hpx:class:`hpx::stop_callback`
+* :hpx:class:`hpx::stop_source`
+* :hpx:class:`hpx::stop_token`
+* :hpx:class:`hpx::in_place_stop_token`
+* :hpx:class:`hpx::timed_mutex`
+* :hpx:class:`hpx::upgrade_to_unique_lock`
+* :hpx:class:`hpx::upgrade_lock`
 
 See :ref:`modules_lcos_local`, :ref:`modules_async_combinators`, and
 :ref:`modules_async_distributed` for higher level synchronization facilities.
 
 See the :ref:`API reference <modules_synchronization_api>` of this module for more
 details.
-

--- a/libs/core/testing/docs/index.rst
+++ b/libs/core/testing/docs/index.rst
@@ -12,7 +12,7 @@ testing
 =======
 
 The testing module contains useful macros for testing. The results of tests can
-be printed with :cpp:func:`hpx::util::report_errors`. The following macros are
+be printed with :hpx:func:`hpx::util::report_errors`. The following macros are
 provided:
 
 * :c:macro:`HPX_TEST`

--- a/libs/core/thread_pools/docs/index.rst
+++ b/libs/core/thread_pools/docs/index.rst
@@ -13,10 +13,9 @@ thread_pools
 
 This module defines the thread pools and utilities used by the |hpx| runtime.
 The only thread pool implementation provided by this module is
-:cpp:class:`hpx::threads::detail::scheduled_thread_pool`, which is derived from
-:cpp:class:`hpx::threads::detail::thread_pool_base` defined in the
+:hpx:class:`hpx::threads::detail::scheduled_thread_pool`, which is derived from
+:hpx:class:`hpx::threads::detail::thread_pool_base` defined in the
 :ref:`modules_threading_base` module.
 
 See the :ref:`API reference <modules_thread_pools_api>` of this module for more
 details.
-

--- a/libs/core/threading/docs/index.rst
+++ b/libs/core/threading/docs/index.rst
@@ -14,9 +14,8 @@ threading
 This module provides the equivalents of ``std::thread`` and ``std::jthread``
 for lightweight |hpx| threads:
 
-* :cpp:class:`hpx::thread`
-* :cpp:class:`hpx::jthread`
+* :hpx:class:`hpx::thread`
+* :hpx:class:`hpx::jthread`
 
 See the :ref:`API reference <modules_threading_api>` of this module for more
 details.
-

--- a/libs/core/threading_base/docs/index.rst
+++ b/libs/core/threading_base/docs/index.rst
@@ -12,14 +12,13 @@ threading_base
 ==============
 
 This module contains the base class definition required for threads. The base
-class :cpp:class:`hpx::threads::thread_data` is inherited by two specializations
+class :hpx:class:`hpx::threads::thread_data` is inherited by two specializations
 for stackful and stackless threads:
-:cpp:class:`hpx::threads::thread_data_stackful` and
-:cpp:class:`hpx::threads::thread_data_stackless`. In addition, the module
+:hpx:class:`hpx::threads::thread_data_stackful` and
+:hpx:class:`hpx::threads::thread_data_stackless`. In addition, the module
 defines the base classes for schedulers and thread pools:
-:cpp:class:`hpx::threads::policies::scheduler_base` and
-:cpp:class:`hpx::threads::thread_pool_base`.
+:hpx:class:`hpx::threads::policies::scheduler_base` and
+:hpx:class:`hpx::threads::thread_pool_base`.
 
 See the :ref:`API reference <modules_thread_data_api>` of this module for more
 details.
-

--- a/libs/core/threadmanager/docs/index.rst
+++ b/libs/core/threadmanager/docs/index.rst
@@ -11,7 +11,7 @@
 thread_manager
 ==============
 
-This module defines the :cpp:class:`hpx::threads::threadmanager` class. This is
+This module defines the :hpx:class:`hpx::threads::threadmanager` class. This is
 used by the runtime to manage the creation and destruction of thread pools. The
 :ref:`modules_resource_partitioner` module handles the partitioning of resources
 into thread pools, but not the creation of thread pools.

--- a/libs/core/topology/docs/index.rst
+++ b/libs/core/topology/docs/index.rst
@@ -11,9 +11,9 @@
 topology
 ========
 
-This module provides the class :cpp:class:`hpx::threads::topology` which
+This module provides the class :hpx:class:`hpx::threads::topology` which
 represents the hardware resources available on a node. The class is a light
-wrapper around the |hwloc|_ library. The :cpp:class:`hpx::threads::cpu_mask` is
+wrapper around the |hwloc|_ library. The :hpx:class:`hpx::threads::cpu_mask` is
 a small companion class that represents a set of resources on a node.
 
 See the :ref:`API reference <modules_topology_api>` of the module for more details.

--- a/libs/full/async_distributed/docs/index.rst
+++ b/libs/full/async_distributed/docs/index.rst
@@ -12,9 +12,8 @@ async_distributed
 =================
 
 This module contains functionality for asynchronously launching work on remote
-localities: :cpp:func:`hpx::async`, :cpp:func:`hpx::post`. This module extends
+localities: :hpx:func:`hpx::async`, :hpx:func:`hpx::post`. This module extends
 the local-only functions in :ref:`libs_async_local`.
 
 See the :ref:`API reference <modules_async_api>` of this module for more
 details.
-

--- a/libs/full/collectives/docs/index.rst
+++ b/libs/full/collectives/docs/index.rst
@@ -15,39 +15,39 @@ The collectives module exposes a set of distributed collective operations. Those
 can be used to exchange data between participating sites in a coordinated way.
 At this point the module exposes the following collective primitives:
 
-* :cpp:func:`hpx::collectives::all_gather`: receives a set of values from all
+* :hpx:func:`hpx::collectives::all_gather`: receives a set of values from all
   participating sites.
-* :cpp:func:`hpx::collectives::all_reduce`: performs a reduction on data from
+* :hpx:func:`hpx::collectives::all_reduce`: performs a reduction on data from
   each participating site to each participating site.
-* :cpp:func:`hpx::collectives::all_to_all`: each participating site provides its
+* :hpx:func:`hpx::collectives::all_to_all`: each participating site provides its
   element of the data to collect while all participating sites receive the data
   from every other site.
-* :cpp:func:`hpx::collectives::broadcast_to` and
-  :cpp:func:`hpx::collectives::broadcast_from`: performs a broadcast operation
+* :hpx:func:`hpx::collectives::broadcast_to` and
+  :hpx:func:`hpx::collectives::broadcast_from`: performs a broadcast operation
   from a root site to all participating sites.
-* :cpp:func:`hpx::collectives::exclusive_scan`: performs an exclusive scan operation
+* :hpx:func:`hpx::collectives::exclusive_scan`: performs an exclusive scan operation
   on a set of values received from all call sites operating on the given base name.
-* :cpp:func:`hpx::collectives::gather_here` and
-  :cpp:func:`hpx::collectives::gather_there`: gathers values from all
+* :hpx:func:`hpx::collectives::gather_here` and
+  :hpx:func:`hpx::collectives::gather_there`: gathers values from all
   participating sites.
-* :cpp:func:`hpx::collectives::inclusive_scan`: performs an inclusive scan operation
+* :hpx:func:`hpx::collectives::inclusive_scan`: performs an inclusive scan operation
   on a set of values received from all call sites operating on the given base name.
-* :cpp:func:`hpx::collectives::reduce_here` and
-  :cpp:func:`hpx::collectives::reduce_there`: performs a reduction on data from each
+* :hpx:func:`hpx::collectives::reduce_here` and
+  :hpx:func:`hpx::collectives::reduce_there`: performs a reduction on data from each
   participating site to a root site.
-* :cpp:func:`hpx::collectives::scatter_to` and
-  :cpp:func:`hpx::collectives::scatter_from`: receives an element of a set of values
+* :hpx:func:`hpx::collectives::scatter_to` and
+  :hpx:func:`hpx::collectives::scatter_from`: receives an element of a set of values
   operating on the given base name.
 
-* :cpp:func:`hpx::lcos::broadcast`: performs a given action on all given global
+* :hpx:func:`hpx::lcos::broadcast`: performs a given action on all given global
   identifiers.
-* :cpp:class:`hpx::distributed::barrier`: distributed barrier.
-* :cpp:func:`hpx::lcos::fold`: performs a fold with a given action on all given
+* :hpx:class:`hpx::distributed::barrier`: distributed barrier.
+* :hpx:func:`hpx::lcos::fold`: performs a fold with a given action on all given
   global identifiers.
-* :cpp:class:`hpx::distributed::latch`: distributed latch.
-* :cpp:func:`hpx::lcos::reduce`: performs a reduction on data from each
+* :hpx:class:`hpx::distributed::latch`: distributed latch.
+* :hpx:func:`hpx::lcos::reduce`: performs a reduction on data from each
   given global identifiers.
-* :cpp:class:`hpx::lcos::spmd_block`: performs the same operation on a local
+* :hpx:class:`hpx::lcos::spmd_block`: performs the same operation on a local
   image while providing handles to the other images.
 
 See the :ref:`API reference <modules_collectives_api>` of the module for more
@@ -67,17 +67,17 @@ Generation model
 Hierarchical collectives use two internal generations for each user generation.
 For a user generation ``k``, the first internal phase uses ``2k - 1`` and the
 second uses ``2k``. Single-pass hierarchical operations and the inter-group
-exchange of :cpp:func:`hpx::collectives::all_to_all` advance the communicator by
+exchange of :hpx:func:`hpx::collectives::all_to_all` advance the communicator by
 two generations in one step so that shared hierarchical communicators stay
 aligned with two-phase collectives.
 
 When a hierarchical communicator instance is shared between collective
 operations, callers must pass explicit, strictly consecutive positive
 generation numbers. Two-phase hierarchical collectives, including
-:cpp:func:`hpx::collectives::all_gather`,
-:cpp:func:`hpx::collectives::all_reduce`,
-:cpp:func:`hpx::collectives::all_to_all`,
-:cpp:func:`hpx::collectives::inclusive_scan`,
-:cpp:func:`hpx::collectives::exclusive_scan`, and
-:cpp:class:`hpx::distributed::barrier`, reject the default generation because
+:hpx:func:`hpx::collectives::all_gather`,
+:hpx:func:`hpx::collectives::all_reduce`,
+:hpx:func:`hpx::collectives::all_to_all`,
+:hpx:func:`hpx::collectives::inclusive_scan`,
+:hpx:func:`hpx::collectives::exclusive_scan`, and
+:hpx:class:`hpx::distributed::barrier`, reject the default generation because
 their phase generations are derived from the explicit user generation.

--- a/libs/full/executors_distributed/docs/index.rst
+++ b/libs/full/executors_distributed/docs/index.rst
@@ -12,7 +12,7 @@ executors_distributed
 =====================
 
 This module provides the executor
-:cpp:class:`hpx::parallel::execution::disribution_policy_executor`. It allows
+:hpx:class:`hpx::execution::experimental::distribution_policy_executor`. It allows
 one to create work that is implicitly distributed over multiple localities.
 
 See the :ref:`API reference <modules_executors_distributed_api>` of this module for more

--- a/libs/full/lcos_distributed/docs/index.rst
+++ b/libs/full/lcos_distributed/docs/index.rst
@@ -12,7 +12,7 @@ lcos_distributed
 ================
 
 This module contains distributed :term:`LCO`\ s. Currently the only LCO provided
-is :cpp:class::`hpx::lcos::channel`, a construct for sending values from one
+is :hpx:class:`hpx::lcos::channel`, a construct for sending values from one
 :term:`locality` to another. See :ref:`libs_lcos_local` for local LCOs.
 
 See the :ref:`API reference <modules_lcos_distributed_api>` of this module for more details.

--- a/libs/full/resiliency_distributed/docs/index.rst
+++ b/libs/full/resiliency_distributed/docs/index.rst
@@ -20,7 +20,7 @@ now be replayed or replicated among different localities. The API exposed
 allows for an easy integration with the local only resiliency APIs as well.
 
 Distributed software resilience APIs have a similar function signature
-and lives under the same namespace of :cpp:func:`hpx::resiliency::experimental`.
+and lives under the same namespace of ``hpx::resiliency::experimental``.
 The difference arises in the formal parameters where distributed APIs takes
 the localities as the first argument, and an action as opposed to a function or
 a function object. The localities signify the order in which the API will either
@@ -32,4 +32,3 @@ defined in :ref:`local resiliency module <modules_resiliency_api>`.
 
 See the :ref:`API reference <modules_resiliency_distributed_api>` of this module
 for more details.
-


### PR DESCRIPTION
- Replace `:cpp:*:` references to matching `:hpx:*:` roles
- Fix unknown directive or role name: `hpx:*` warnings