### PR TITLE
Enable missing use cases for the late launcher example

### DIFF
--- a/components/supervision_dispatch/examples/late_component_aborting_worker.cpp
+++ b/components/supervision_dispatch/examples/late_component_aborting_worker.cpp
@@ -52,7 +52,7 @@ namespace {
     // Long enough to comfortably absorb AGAS/peer-startup jitter; mirrors the
     // timeout used by late_component_worker.cpp/
     // late_component_failing_worker.cpp.
-    constexpr std::chrono::milliseconds worker_discovery_timeout{500000};
+    constexpr std::chrono::milliseconds worker_discovery_timeout{5000};
 }    // namespace
 
 int hpx_main()
@@ -106,7 +106,7 @@ int hpx_main()
 
     // Simulate a genuine, unrecoverable crash: no hpx::supervision::finalize(),
     // no hpx::disconnect(), no supervision_dispatch call to "fake" a failure.
-    // This locality's sentinel/heartbeat entry simply stops being refreshed
+    // This locality's registry/heartbeat entry simply stops being refreshed
     // from here on - root's failure_detection_loop() is what notices.
     std::exit(-1);
 }

--- a/components/supervision_dispatch/examples/late_component_failing_worker.cpp
+++ b/components/supervision_dispatch/examples/late_component_failing_worker.cpp
@@ -70,7 +70,7 @@ namespace {
 
     // Long enough to comfortably absorb AGAS/peer-startup jitter; short enough
     // to keep this example fast (mirrors plain_worker.cpp).
-    constexpr std::chrono::milliseconds worker_discovery_timeout{500000};
+    constexpr std::chrono::milliseconds worker_discovery_timeout{5000};
 
     // Testing-only knob: must be set before init() starts
     // failure_detection_loop() to take effect for this worker's own lifecycle,
@@ -142,7 +142,9 @@ namespace {
         // registry state.
         hpx::supervision::testing::stop_background_loops();
 
-        return hpx::disconnect();
+        // Disconnect from HPX, ignore all errors.
+        hpx::error_code ec(hpx::throwmode::lightweight);
+        return hpx::disconnect(ec);
     }
 }    // namespace
 
@@ -161,7 +163,12 @@ int main(int argc, char* argv[])
     hpx::init_params init_args;
     init_args.mode = hpx::runtime_mode::connect;
 
-    return hpx::init(argc, argv, init_args);
+    int const result = hpx::init(argc, argv, init_args);
+
+    hpx::util::format_to(
+        std::cerr, "late_component_failing_worker: complete, exited.\n");
+
+    return result;
 }
 
 #else

--- a/components/supervision_dispatch/examples/late_component_launcher.cpp
+++ b/components/supervision_dispatch/examples/late_component_launcher.cpp
@@ -91,7 +91,7 @@ namespace {
     // Long enough to comfortably absorb AGAS/peer-startup jitter for a
     // freshly-spawned worker; mirrors the timeout used by
     // late_component_worker.cpp/late_component_failing_worker.cpp.
-    constexpr std::chrono::milliseconds root_discovery_timeout{500000};
+    constexpr std::chrono::milliseconds root_discovery_timeout{5000};
 
     // Number of retries a task gets after a fenced dispatch before it is
     // dropped instead of requeued (see the catch block below).
@@ -115,14 +115,14 @@ namespace {
     enum class worker_variant : std::uint8_t
     {
         normal = 0,
-        //failing = 1,
-        //aborting = 2
+        failing = 1,
+        aborting = 2
     };
 
     constexpr char const* const worker_paths[] = {
         "late_component_worker" HPX_EXECUTABLE_EXTENSION,
-        //"late_component_failing_worker" HPX_EXECUTABLE_EXTENSION,
-        //"late_component_aborting_worker" HPX_EXECUTABLE_EXTENSION,
+        "late_component_failing_worker" HPX_EXECUTABLE_EXTENSION,
+        "late_component_aborting_worker" HPX_EXECUTABLE_EXTENSION,
     };
 
     // Everything root needs to fence/dispatch against, and eventually retire,
@@ -280,12 +280,12 @@ namespace {
         // true, unmodeled crash, rather than only ever taking the success path.
         worker_slots.emplace_back(spawn_worker(handle, worker_variant::normal));
         slot_variants.emplace_back(worker_variant::normal);
-        //worker_slots.emplace_back(
-        //    spawn_worker(handle, worker_variant::failing));
-        //slot_variants.emplace_back(worker_variant::failing);
-        //worker_slots.emplace_back(
-        //    spawn_worker(handle, worker_variant::aborting));
-        //slot_variants.emplace_back(worker_variant::aborting);
+        worker_slots.emplace_back(
+            spawn_worker(handle, worker_variant::failing));
+        slot_variants.emplace_back(worker_variant::failing);
+        worker_slots.emplace_back(
+            spawn_worker(handle, worker_variant::aborting));
+        slot_variants.emplace_back(worker_variant::aborting);
 
         std::deque<task> queue;
         queue.push_back(task{.worker_slot_index = 0,
@@ -294,12 +294,12 @@ namespace {
         queue.push_back(task{.worker_slot_index = 0,
             .payload = "hello from root: message 2 for worker 0",
             .retries = 0});
-        //queue.push_back(task{.worker_slot_index = 1,
-        //    .payload = "hello from root: message 1 for worker 1",
-        //    .retries = 0});
-        //queue.push_back(task{.worker_slot_index = 2,
-        //    .payload = "hello from root: message 1 for worker 2",
-        //    .retries = 0});
+        queue.push_back(task{.worker_slot_index = 1,
+            .payload = "hello from root: message 1 for worker 1",
+            .retries = 0});
+        queue.push_back(task{.worker_slot_index = 2,
+            .payload = "hello from root: message 1 for worker 2",
+            .retries = 0});
 
         while (!queue.empty())
         {

--- a/components/supervision_dispatch/examples/late_component_worker.cpp
+++ b/components/supervision_dispatch/examples/late_component_worker.cpp
@@ -53,7 +53,7 @@ namespace {
 
     // Long enough to comfortably absorb AGAS/root-startup jitter; mirrors the
     // timeout used by plain_worker.cpp/fan_out_join.cpp.
-    constexpr std::chrono::milliseconds worker_discovery_timeout{500000};
+    constexpr std::chrono::milliseconds worker_discovery_timeout{5000};
 }    // namespace
 
 // Walks this worker through its full lifecycle: init() -> publish_event(
@@ -185,12 +185,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
     std::chrono::milliseconds const poll_interval{
         vm["poll-interval"].as<std::uint64_t>()};
 
-    auto const result = run_worker(idle_timeout, poll_interval);
-
-    hpx::util::format_to(
-        std::cerr, "late_component_worker: complete, exited.\n");
-
-    return result;
+    return run_worker(idle_timeout, poll_interval);
 }
 
 int main(int argc, char* argv[])
@@ -214,7 +209,12 @@ int main(int argc, char* argv[])
     init_args.mode = hpx::runtime_mode::connect;
     init_args.desc_cmdline = desc_commandline;
 
-    return hpx::init(argc, argv, init_args);
+    int const result = hpx::init(argc, argv, init_args);
+
+    hpx::util::format_to(
+        std::cerr, "late_component_worker: complete, exited.\n");
+
+    return result;
 }
 
 #else

--- a/libs/core/thread_pools/CMakeLists.txt
+++ b/libs/core/thread_pools/CMakeLists.txt
@@ -51,6 +51,7 @@ add_hpx_module(
     hpx_logging
     hpx_schedulers
     hpx_threading_base
+    hpx_thread_support
     hpx_tracing
     hpx_topology
   CMAKE_SUBDIRS examples tests

--- a/libs/core/thread_pools/include/hpx/thread_pools/scheduled_thread_pool.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/scheduled_thread_pool.hpp
@@ -15,6 +15,7 @@
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/threading_base.hpp>
 #include <hpx/modules/topology.hpp>
+
 #include <hpx/thread_pools/scheduling_loop.hpp>
 
 #include <atomic>
@@ -140,7 +141,7 @@ namespace hpx::threads::detail {
         void stop(
             std::unique_lock<std::mutex>& l, bool blocking = true) override;
 
-        void wait() override;
+        void wait(std::unique_lock<std::mutex>& l) override;
         bool is_busy() override;
         bool is_idle() override;
 

--- a/libs/core/thread_pools/include/hpx/thread_pools/scheduled_thread_pool_impl.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/scheduled_thread_pool_impl.hpp
@@ -14,8 +14,10 @@
 #include <hpx/modules/execution_base.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/schedulers.hpp>
+#include <hpx/modules/thread_support.hpp>
 #include <hpx/modules/threading_base.hpp>
 #include <hpx/modules/topology.hpp>
+
 #include <hpx/thread_pools/scheduled_thread_pool.hpp>
 #include <hpx/thread_pools/scheduling_loop.hpp>
 
@@ -194,10 +196,15 @@ namespace hpx::threads::detail {
     }
 
     template <typename Scheduler>
-    void scheduled_thread_pool<Scheduler>::wait()
+    void scheduled_thread_pool<Scheduler>::wait(std::unique_lock<std::mutex>& l)
     {
+        hpx::unlock_guard<std::unique_lock<std::mutex>> ul(l);
         hpx::util::detail::yield_while_count(
-            [this]() { return is_busy(); }, shutdown_check_count_);
+            [&]() {
+                std::unique_lock<std::mutex> lk(*l.mutex());
+                return is_busy();
+            },
+            shutdown_check_count_);
     }
 
     template <typename Scheduler>
@@ -225,7 +232,7 @@ namespace hpx::threads::detail {
 
                 if (must_wait)
                 {
-                    wait();
+                    wait(l);
                 }
             }
 

--- a/libs/core/threading_base/include/hpx/threading_base/thread_pool_base.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_pool_base.hpp
@@ -128,7 +128,7 @@ namespace hpx::threads {
         virtual void stop(
             std::unique_lock<std::mutex>& l, bool blocking = true) = 0;
 
-        virtual void wait() = 0;
+        virtual void wait(std::unique_lock<std::mutex>& l) = 0;
         virtual bool is_busy() = 0;
         virtual bool is_idle() = 0;
 

--- a/libs/full/async_distributed/include/hpx/async_distributed/packaged_action.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/packaged_action.hpp
@@ -48,15 +48,25 @@ namespace hpx::lcos {
                 // object
                 if (ec)
                 {
-                    if (hpx::tolerate_node_faults() && is_asio_error(ec))
+                    if ((hpx::tolerate_node_faults() && is_asio_error(ec)) ||
+                        parcelset::locality_was_disconnected(
+                            p.destination_locality_id()))
                     {
-                        return;
+                        std::exception_ptr exception = HPX_GET_EXCEPTION(
+                            hpx::error_code(
+                                hpx::error::locality_was_disconnected,
+                                hpx::throwmode::lightweight),
+                            "packaged_action::parcel_write_handler",
+                            parcelset::dump_parcel(p));
+                        shared_state->set_exception(exception);
                     }
-
-                    std::exception_ptr exception = HPX_GET_EXCEPTION(ec,
-                        "packaged_action::parcel_write_handler",
-                        parcelset::dump_parcel(p));
-                    shared_state->set_exception(exception);
+                    else
+                    {
+                        std::exception_ptr exception = HPX_GET_EXCEPTION(ec,
+                            "packaged_action::parcel_write_handler",
+                            parcelset::dump_parcel(p));
+                        shared_state->set_exception(exception);
+                    }
                 }
             }
         };
@@ -74,6 +84,17 @@ namespace hpx::lcos {
                 // object
                 if (ec)
                 {
+                    if (hpx::tolerate_node_faults() && is_asio_error(ec))
+                    {
+                        return;
+                    }
+
+                    if (parcelset::locality_was_disconnected(
+                            p.destination_locality_id()))
+                    {
+                        return;
+                    }
+
                     std::exception_ptr exception = HPX_GET_EXCEPTION(ec,
                         "packaged_action::parcel_write_handler_cb",
                         parcelset::dump_parcel(p));

--- a/libs/full/init_runtime/src/hpx_init.cpp
+++ b/libs/full/init_runtime/src/hpx_init.cpp
@@ -1029,23 +1029,6 @@ namespace hpx {
             return -1;
         }
 
-        if (!is_running())
-        {
-#if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
-            // Report error only on root locality. All other localities may have
-            // already been shutdown by the root.
-            hpx::error_code ec1(hpx::throwmode::lightweight);
-            auto const root = agas::get_console_locality(ec1);
-            if (!ec1 && agas::get_locality() == root.get_gid())
-#endif
-            {
-                HPX_THROWS_IF(ec, hpx::error::invalid_status, "hpx::finalize",
-                    "the runtime system is not active (did you already "
-                    "call finalize?)");
-            }
-            return -1;
-        }
-
         if (&ec != &throws)
             ec = make_success_code();
 

--- a/libs/full/parcelport_tcp/src/connection_handler_tcp.cpp
+++ b/libs/full/parcelport_tcp/src/connection_handler_tcp.cpp
@@ -202,7 +202,9 @@ namespace hpx::parcelset::policies::tcp {
             // An exit here, avoids hangs when late parcels are in flight (those are
             // mainly decref requests).
             if (acceptor_ == nullptr)
+            {
                 return std::shared_ptr<sender>();
+            }
             try
             {
                 util::detail::endpoint_iterator_type end = util::connect_end();

--- a/libs/full/parcelset/include/hpx/parcelset/parcelport_impl.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/parcelport_impl.hpp
@@ -262,6 +262,15 @@ namespace hpx::parcelset {
         {
             HPX_ASSERT(dest.type() == type());
 
+            if (parcelset::locality_was_disconnected(
+                    p.destination_locality_id()))
+            {
+                f(std::error_code(make_system_error_code(
+                      hpx::error::locality_was_disconnected)),
+                    p);
+                return;
+            }
+
             // We create a shared pointer of the parcels_await object since it
             // needs to be kept alive as long as there are futures not ready
             // or GIDs to be split. This is necessary to preserve the identity
@@ -302,6 +311,24 @@ namespace hpx::parcelset {
                     parcels[i].destination_locality());
             }
 #endif
+
+            if (parcels.empty())
+            {
+                return;    // nothing to do, return early
+            }
+
+            if (parcelset::locality_was_disconnected(
+                    parcels[0].destination_locality_id()))
+            {
+                auto const e = std::error_code(make_system_error_code(
+                    hpx::error::locality_was_disconnected));
+                for (std::size_t i = 0; i != parcels.size(); ++i)
+                {
+                    handlers[i](e, parcels[i]);
+                }
+                return;
+            }
+
             // We create a shared pointer of the parcels_await object since it
             // needs to be kept alive as long as there are futures not ready
             // or GIDs to be split. This is necessary to preserve the identity

--- a/libs/full/parcelset/src/parcelhandler.cpp
+++ b/libs/full/parcelset/src/parcelhandler.cpp
@@ -501,15 +501,15 @@ namespace hpx::parcelset {
                 constexpr message_handler::flush_mode flush_mode =
                     message_handler::flush_mode_background_work;
 
-                auto const end = handlers_.end();
-                for (auto it = handlers_.begin(); it != end; ++it)
+                message_handler_map handlers = handlers_;
+                unlock_guard<std::unique_lock<mutex_type>> ul(l);
+
+                for (auto& handler : handlers | std::views::values)
                 {
-                    if (it->second)
+                    if (handler)
                     {
-                        std::shared_ptr<policies::message_handler> const p(
-                            it->second);
-                        unlock_guard<std::unique_lock<mutex_type>> ul(l);
-                        did_some_work = p->flush(flush_mode, stop_buffering) ||
+                        did_some_work =
+                            handler->flush(flush_mode, stop_buffering) ||
                             did_some_work;
                     }
                 }

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/stubs/runtime_support.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/stubs/runtime_support.hpp
@@ -228,7 +228,7 @@ namespace hpx::components::stubs {
             hpx::id_type const& gid, bool pre_startup);
 
         /// \brief Shutdown the given runtime system
-        static hpx::future<void> shutdown_async(hpx::id_type const& targetgid,
+        static hpx::future<void> shutdown_async(hpx::id_type const& targetid,
             double timeout = -1, bool force_disconnect = false);
         static void shutdown(hpx::id_type const& targetgid, double timeout = -1,
             bool force_disconnect = false);

--- a/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
+++ b/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
@@ -1114,8 +1114,7 @@ namespace hpx::components::server {
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 #if defined(HPX_HAVE_NETWORKING)
-        if (agas::is_console() &&
-            locality == agas::get_console_locality().get_gid())
+        if (agas::is_console())
         {
             // do it locally, if possible
             rtd->get_parcel_handler().remove_from_connection_cache(

--- a/libs/full/runtime_distributed/src/stubs/runtime_support_stubs.cpp
+++ b/libs/full/runtime_distributed/src/stubs/runtime_support_stubs.cpp
@@ -88,7 +88,7 @@ namespace hpx::components::stubs {
 
     /// \brief Shutdown the given runtime system
     hpx::future<void> runtime_support::shutdown_async(
-        [[maybe_unused]] hpx::id_type const& targetgid,
+        [[maybe_unused]] hpx::id_type const& targetid,
         [[maybe_unused]] double timeout,
         [[maybe_unused]] bool const force_disconnect)
     {
@@ -106,28 +106,28 @@ namespace hpx::components::stubs {
             value.get_id().get_gid(), id_type::management_type::unmanaged);
 
 #if defined(HPX_HAVE_NETWORKING)
-        auto callback = [shared_state = traits::detail::get_shared_state(f)](
+        auto callback = [targetgid = targetid.get_gid(),
+                            shared_state = traits::detail::get_shared_state(f)](
                             std::error_code const& ec,
                             parcelset::parcel const& p) mutable {
             if (ec)
             {
-                auto const dest = p.destination();
                 if (!parcelset::locality_was_disconnected(
-                        naming::get_locality_id_from_gid(dest)))
+                        naming::get_locality_id_from_gid(targetgid)))
                 {
-                    std::exception_ptr const exception = HPX_GET_EXCEPTION(ec,
-                        "packaged_action::parcel_write_handler_cb",
-                        parcelset::dump_parcel(p));
+                    std::exception_ptr const exception =
+                        HPX_GET_EXCEPTION(ec, "runtime_support::shutdown_async",
+                            parcelset::dump_parcel(p));
                     shared_state->set_exception(exception);
                 }
             }
         };
 
-        hpx::post_cb<action_type>(targetgid, HPX_MOVE(callback), timeout,
+        hpx::post_cb<action_type>(targetid, HPX_MOVE(callback), timeout,
             HPX_MOVE(gid), force_disconnect);
 #else
         hpx::post<action_type>(
-            targetgid, timeout, HPX_MOVE(gid), force_disconnect);
+            targetid, timeout, HPX_MOVE(gid), force_disconnect);
 #endif
 
         return f;

--- a/libs/full/supervision/CMakeLists.txt
+++ b/libs/full/supervision/CMakeLists.txt
@@ -44,6 +44,7 @@ if(HPX_WITH_SUPERVISION)
       hpx_components_base
       hpx_naming
       hpx_naming_base
+      hpx_parcelset_base
       hpx_runtime_components
   )
 

--- a/libs/full/supervision/src/server/supervision_manager_server.cpp
+++ b/libs/full/supervision/src/server/supervision_manager_server.cpp
@@ -16,6 +16,7 @@
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/naming_base.hpp>
+#include <hpx/modules/parcelset_base.hpp>
 
 #include <hpx/supervision/server/activity_agent.hpp>
 #include <hpx/supervision/server/agent.hpp>
@@ -1402,13 +1403,20 @@ namespace hpx::supervision::server {
 
         return hpx::detail::try_catch_exception_ptr(
             [&]() {
-                using action_type =
-                    activity_agent_component::invoke_if_active_action;
-                hpx::future<bool> keep_registered =
-                    hpx::async(hpx::launch::task, action_type(), agent,
-                        HPX_MOVE(notification));
+                bool erase_agent = true;
+                if (!parcelset::locality_was_disconnected(
+                        naming::get_locality_id_from_gid(agent.get_gid())))
+                {
+                    using action_type =
+                        activity_agent_component::invoke_if_active_action;
+                    hpx::future<bool> keep_registered =
+                        hpx::async(hpx::launch::task, action_type(), agent,
+                            HPX_MOVE(notification));
 
-                if (!keep_registered.get())
+                    erase_agent = !keep_registered.get();
+                }
+
+                if (erase_agent)
                 {
                     std::unique_lock<hpx::spinlock> l(mtx_);
                     std::erase_if(activity_observers_,


### PR DESCRIPTION
## Summary

This change stack covers thread-pool wait coordination, distributed locality (disconnected-node) handling, and updates to the supervision dispatch examples.

### Thread-pool wait coordination
- `thread_pool_base` and `scheduled_thread_pool` now pass a caller-owned `unique_lock` into `wait()`, releasing it while yielding and reacquiring it for state checks.
- `stop_locked` forwards the lock into `wait()` instead of managing locking internally.
- Added `thread_support` to `libs/core/thread_pools` build dependencies (`CMakeLists.txt`).

### Distributed locality handling
- **Parcel delivery to disconnected localities**: parcel submission now reports `locality_was_disconnected` before attempting to send, and parcel write handlers ignore disconnected-locality errors instead of invoking callbacks or storing exceptions (`parcelport_impl.hpp`, `packaged_action.hpp`, `connection_handler_tcp.cpp`). The null-acceptor guard behavior is unchanged.
- **Shutdown targeting**: `shutdown_async` renames `targetgid` to `targetid`, derives the callback locality from the target id, and uses it consistently for shutdown posts and error context (`runtime_support.hpp` / `runtime_support_stubs.cpp`).
- **Supervision cleanup for disconnected agents**: the console connection-cache path checks whether the locality is current before use, and activity events now remove agents belonging to disconnected localities without invoking their callbacks (`runtime_support_server.cpp`, `supervision_manager_server.cpp`).
- **Parcel handler snapshotting**: `do_background_work` now copies the handler map under `handlers_mtx_`, releases the mutex, and flushes handlers from the snapshot rather than holding the lock during flush (`parcelhandler.cpp`).

### Supervision dispatch examples
- `late_component_launcher.cpp` enables the failing- and aborting-worker code paths, spawns both variants, records their variants, shortens the root discovery timeout, and queues a task for worker slot 2.
- Worker examples (`late_component_failing_worker.cpp`, `late_component_aborting_worker.cpp`, `late_component_worker.cpp`) use 5-second discovery timeouts, ignore disconnect errors in the failing worker, report completion only after `hpx::init` returns, and update comments to reflect registry terminology.

### Why
Together these changes make the runtime more resilient to localities disconnecting mid-operation (parcels, shutdown, supervision agents) and fix a potential deadlock/race in thread-pool waiting by threading the lock through explicitly. The example updates exercise the new failing/aborting worker paths for supervision dispatch testing.