### PR TITLE
tracing: Instrument background work zones and OS worker thread sleep events

### DIFF
--- a/examples/quickstart/CMakeLists.txt
+++ b/examples/quickstart/CMakeLists.txt
@@ -6,6 +6,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(example_programs
+    background_work_smoke
     causal_chain_smoke
     causal_exception_smoke
     barrier_docs
@@ -163,6 +164,7 @@ set(simple_future_continuation_PARAMETERS THREADS_PER_LOCALITY 4)
 set(timed_futures_PARAMETERS THREADS_PER_LOCALITY 4)
 set(vector_counting_dotproduct_PARAMETERS THREADS_PER_LOCALITY 4)
 set(vector_zip_dotproduct_PARAMETERS THREADS_PER_LOCALITY 4)
+set(work_stealing_smoke_PARAMETERS THREADS_PER_LOCALITY 4)
 set(custom_serialization_PARAMETERS LOCALITIES 2)
 
 # the following example fails compiling on someversions of MSVC

--- a/examples/quickstart/CMakeLists.txt
+++ b/examples/quickstart/CMakeLists.txt
@@ -205,6 +205,7 @@ if(HPX_WITH_CXX_MODULES
 )
   foreach(
     example
+    background_work_smoke
     barrier_docs
     customize_async
     component_ctors

--- a/examples/quickstart/background_work_smoke.cpp
+++ b/examples/quickstart/background_work_smoke.cpp
@@ -9,9 +9,9 @@
 // Simulates the three main background-work consumers present in a real HPX
 // distributed run:
 //
-//   parcel::tcp   - parcelport TCP I/O completion polling (frequent, ~10 µs)
-//   agas::resolve - AGAS global-address resolution (moderate, ~5 µs)
-//   cuda::poll    - GPU/MPI completion polling (rare, ~2 µs)
+//   parcel::tcp   - parcelport TCP I/O completion polling (frequent, ~10 us)
+//   agas::resolve - AGAS global-address resolution (moderate, ~5 us)
+//   cuda::poll    - GPU/MPI completion polling (rare, ~2 us)
 //
 // Each subsystem emits a Tracy mark_event zone on the background-fiber row
 // when it "finds" work, so the three event types are visible as distinct
@@ -45,7 +45,7 @@
 
 namespace {
 
-    // Parcel/TCP polling: fires every ~7 background calls, simulates ~10 µs of
+    // Parcel/TCP polling: fires every ~7 background calls, simulates ~10 us of
     // I/O completion processing.
     struct parcel_tcp_subsystem
     {
@@ -68,7 +68,7 @@ namespace {
         }
     } parcel_tcp;
 
-    // AGAS resolution: fires every ~23 background calls, simulates ~5 µs of
+    // AGAS resolution: fires every ~23 background calls, simulates ~5 us of
     // address-resolution work.
     struct agas_subsystem
     {
@@ -92,7 +92,7 @@ namespace {
     } agas;
 
     // CUDA/MPI completion polling: fires every ~41 background calls, simulates
-    // ~2 µs of completion-queue draining.
+    // ~2 us of completion-queue draining.
     struct cuda_subsystem
     {
         static constexpr std::size_t poll_interval = 41;

--- a/examples/quickstart/background_work_smoke.cpp
+++ b/examples/quickstart/background_work_smoke.cpp
@@ -140,7 +140,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
         std::vector<hpx::future<void>> futures;
         futures.reserve(8);
         for (std::size_t j = 0; j < 8; ++j)
-            futures.push_back(hpx::async([]() noexcept {}));
+            futures.push_back(hpx::async([] {}));
 
         hpx::wait_all(futures);
 

--- a/examples/quickstart/background_work_smoke.cpp
+++ b/examples/quickstart/background_work_smoke.cpp
@@ -155,14 +155,24 @@ int hpx_main(hpx::program_options::variables_map& vm)
         }
     }
 
-    std::cout << "OK: background_work_smoke - all " << iterations
-              << " iterations completed\n"
-              << "  parcel::tcp  polls=" << parcel_tcp.polls.load()
+    std::size_t const total_polls = parcel_tcp.polls.load();
+
+    std::cout << "  parcel::tcp  polls=" << parcel_tcp.polls.load()
               << "  work=" << parcel_tcp.work_done.load() << "\n"
               << "  agas         polls=" << agas.polls.load()
               << "  work=" << agas.work_done.load() << "\n"
               << "  cuda         polls=" << cuda.polls.load()
               << "  work=" << cuda.work_done.load() << "\n";
+
+    if (total_polls == 0)
+    {
+        std::cerr << "FAIL: background_poll was never invoked\n";
+        hpx::local::finalize();
+        return -1;
+    }
+
+    std::cout << "OK: background_work_smoke - all " << iterations
+              << " iterations completed\n";
 
     hpx::local::finalize();
     return 0;

--- a/examples/quickstart/background_work_smoke.cpp
+++ b/examples/quickstart/background_work_smoke.cpp
@@ -123,8 +123,6 @@ namespace {
         return did_work;
     }
 
-    void dummy_work() {}
-
 }    // namespace
 
 int hpx_main(hpx::program_options::variables_map& vm)
@@ -142,7 +140,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
         std::vector<hpx::future<void>> futures;
         futures.reserve(8);
         for (std::size_t j = 0; j < 8; ++j)
-            futures.push_back(hpx::async(&dummy_work));
+            futures.push_back(hpx::async([]() noexcept {}));
 
         hpx::wait_all(futures);
 

--- a/examples/quickstart/background_work_smoke.cpp
+++ b/examples/quickstart/background_work_smoke.cpp
@@ -1,0 +1,189 @@
+//  Copyright (c) 2026 Vansh Dobhal
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Background work smoke test with realistic multi-subsystem polling.
+//
+// Simulates the three main background-work consumers present in a real HPX
+// distributed run:
+//
+//   parcel::tcp   - parcelport TCP I/O completion polling (frequent, ~10 µs)
+//   agas::resolve - AGAS global-address resolution (moderate, ~5 µs)
+//   cuda::poll    - GPU/MPI completion polling (rare, ~2 µs)
+//
+// Each subsystem emits a Tracy mark_event zone on the background-fiber row
+// when it "finds" work, so the three event types are visible as distinct
+// sub-zones within the background fiber timeline.
+//
+// The outer OS-thread zone "hpx::background_work [Worker #N]" (teal, from
+// scheduling_loop.hpp) wraps every call to the combined poll function.
+//
+// TRACY USAGE:
+//   1. Build with HPX_WITH_TRACY=ON.
+//   2. Run:  TRACY_NO_EXIT=1 ./bin/background_work_smoke --iterations=20
+//   3. Connect Tracy GUI.
+//
+//   OS-thread row:     teal "hpx::background_work" bars, zone info shows
+//                      which worker thread drove the poll.
+//   Background fiber:  blue sub-zones: "parcel::tcp::recv", "agas::resolve",
+//                      "cuda::completion" appear when a subsystem finds work.
+//   Zone Statistics (Ctrl+Z):  search "background_work" or the subsystem name.
+
+#include <hpx/future.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/resource_partitioner.hpp>
+#include <hpx/modules/tracing.hpp>
+#include <hpx/thread.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <iostream>
+#include <vector>
+
+namespace {
+
+    // Parcel/TCP polling: fires every ~7 background calls, simulates ~10 µs of
+    // I/O completion processing.
+    struct parcel_tcp_subsystem
+    {
+        static constexpr std::size_t poll_interval = 7;
+        static constexpr std::chrono::microseconds work_time{10};
+
+        std::atomic<std::size_t> polls{0};
+        std::atomic<std::size_t> work_done{0};
+
+        bool poll(std::size_t) noexcept
+        {
+            if (++polls % poll_interval != 0)
+                return false;
+            ++work_done;
+            hpx::tracing::mark_event ev("parcel::tcp::recv");
+            auto const end = std::chrono::steady_clock::now() + work_time;
+            while (std::chrono::steady_clock::now() < end)
+                ;
+            return true;
+        }
+    } parcel_tcp;
+
+    // AGAS resolution: fires every ~23 background calls, simulates ~5 µs of
+    // address-resolution work.
+    struct agas_subsystem
+    {
+        static constexpr std::size_t poll_interval = 23;
+        static constexpr std::chrono::microseconds work_time{5};
+
+        std::atomic<std::size_t> polls{0};
+        std::atomic<std::size_t> work_done{0};
+
+        bool poll(std::size_t) noexcept
+        {
+            if (++polls % poll_interval != 0)
+                return false;
+            ++work_done;
+            hpx::tracing::mark_event ev("agas::resolve");
+            auto const end = std::chrono::steady_clock::now() + work_time;
+            while (std::chrono::steady_clock::now() < end)
+                ;
+            return true;
+        }
+    } agas;
+
+    // CUDA/MPI completion polling: fires every ~41 background calls, simulates
+    // ~2 µs of completion-queue draining.
+    struct cuda_subsystem
+    {
+        static constexpr std::size_t poll_interval = 41;
+        static constexpr std::chrono::microseconds work_time{2};
+
+        std::atomic<std::size_t> polls{0};
+        std::atomic<std::size_t> work_done{0};
+
+        bool poll(std::size_t) noexcept
+        {
+            if (++polls % poll_interval != 0)
+                return false;
+            ++work_done;
+            hpx::tracing::mark_event ev("cuda::completion");
+            auto const end = std::chrono::steady_clock::now() + work_time;
+            while (std::chrono::steady_clock::now() < end)
+                ;
+            return true;
+        }
+    } cuda;
+
+    bool background_poll(std::size_t num_thread) noexcept
+    {
+        bool did_work = false;
+        did_work |= parcel_tcp.poll(num_thread);
+        did_work |= agas.poll(num_thread);
+        did_work |= cuda.poll(num_thread);
+        return did_work;
+    }
+
+}    // namespace
+
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    std::size_t const iterations = vm["iterations"].as<std::size_t>();
+
+    std::cout << "background_work_smoke: starting (" << iterations
+              << " iterations)\n"
+              << std::flush;
+
+    for (std::size_t i = 0; i < iterations; ++i)
+    {
+        hpx::tracing::frame_mark("background_work_iteration");
+
+        std::vector<hpx::future<void>> futures;
+        futures.reserve(8);
+        for (std::size_t j = 0; j < 8; ++j)
+            futures.push_back(hpx::async([]() noexcept {}));
+
+        hpx::wait_all(futures);
+
+        // 50 ms idle gap: background subsystems fire repeatedly, each
+        // producing visible mark_event sub-zones on the fiber row.
+        hpx::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+        if (iterations >= 10 && i % (iterations / 10) == 0)
+        {
+            std::cout << "  iteration " << i << "/" << iterations << " OK\n"
+                      << std::flush;
+        }
+    }
+
+    std::cout << "OK: background_work_smoke - all " << iterations
+              << " iterations completed\n"
+              << "  parcel::tcp  polls=" << parcel_tcp.polls.load()
+              << "  work=" << parcel_tcp.work_done.load() << "\n"
+              << "  agas         polls=" << agas.polls.load()
+              << "  work=" << agas.work_done.load() << "\n"
+              << "  cuda         polls=" << cuda.polls.load()
+              << "  work=" << cuda.work_done.load() << "\n";
+
+    hpx::local::finalize();
+    return 0;
+}
+
+int main(int argc, char* argv[])
+{
+    hpx::program_options::options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+    desc_commandline.add_options()("iterations",
+        hpx::program_options::value<std::size_t>()->default_value(5),
+        "Number of test iterations to execute (default: 5 for fast CI)");
+
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = {"hpx.os_threads=4"};
+    init_args.rp_callback = [](hpx::resource::partitioner& rp,
+                                hpx::program_options::variables_map const&) {
+        rp.create_thread_pool("default",
+            hpx::resource::scheduling_policy::local_priority_fifo,
+            hpx::threads::policies::scheduler_mode::default_, &background_poll);
+    };
+    return hpx::local::init(hpx_main, argc, argv, init_args);
+}

--- a/examples/quickstart/background_work_smoke.cpp
+++ b/examples/quickstart/background_work_smoke.cpp
@@ -123,6 +123,8 @@ namespace {
         return did_work;
     }
 
+    void dummy_work() {}
+
 }    // namespace
 
 int hpx_main(hpx::program_options::variables_map& vm)
@@ -140,7 +142,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
         std::vector<hpx::future<void>> futures;
         futures.reserve(8);
         for (std::size_t j = 0; j < 8; ++j)
-            futures.push_back(hpx::async([] {}));
+            futures.push_back(hpx::async(&dummy_work));
 
         hpx::wait_all(futures);
 

--- a/libs/core/thread_pools/include/hpx/thread_pools/scheduling_loop.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/scheduling_loop.hpp
@@ -487,7 +487,8 @@ namespace hpx::threads::detail {
 
                 if (do_background_work)
                 {
-                    hpx::tracing::background_work_region bg_zone(num_thread);
+                    [[maybe_unused]] hpx::tracing::background_work_region
+                        bg_zone(num_thread);
                     call_and_create_background_thread(background_thread,
                         next_thrd, scheduler, num_thread,
                         bg_work_exec_time_init, context_storage, params,
@@ -516,7 +517,8 @@ namespace hpx::threads::detail {
 
                 if (do_background_work)
                 {
-                    hpx::tracing::background_work_region bg_zone(num_thread);
+                    [[maybe_unused]] hpx::tracing::background_work_region
+                        bg_zone(num_thread);
                     call_and_create_background_thread(background_thread,
                         next_thrd, scheduler, num_thread,
                         bg_work_exec_time_init, context_storage, params,

--- a/libs/core/thread_pools/include/hpx/thread_pools/scheduling_loop.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/scheduling_loop.hpp
@@ -402,6 +402,8 @@ namespace hpx::threads::detail {
                         idle_loop_count, enable_stealing_staged, added,
                         &next_thrd))
                 {
+                    hpx::tracing::os_thread_sleep(num_thread);
+
                     // Clean up terminated threads before trying to exit
                     bool can_exit = !running &&
                         scheduler.SchedulingPolicy::cleanup_terminated(
@@ -485,7 +487,7 @@ namespace hpx::threads::detail {
 
                 if (do_background_work)
                 {
-                    // do background work in parcel layer and in agas
+                    hpx::tracing::background_work_region bg_zone(num_thread);
                     call_and_create_background_thread(background_thread,
                         next_thrd, scheduler, num_thread,
                         bg_work_exec_time_init, context_storage, params,
@@ -514,7 +516,7 @@ namespace hpx::threads::detail {
 
                 if (do_background_work)
                 {
-                    // do background work in parcel layer and in agas
+                    hpx::tracing::background_work_region bg_zone(num_thread);
                     call_and_create_background_thread(background_thread,
                         next_thrd, scheduler, num_thread,
                         bg_work_exec_time_init, context_storage, params,

--- a/libs/core/thread_pools/src/detail/background_thread.cpp
+++ b/libs/core/thread_pools/src/detail/background_thread.cpp
@@ -228,6 +228,7 @@ namespace hpx::threads::detail {
 
                 hpx::tracing::task_executing(thrdptr);
 
+                // invoke background thread
                 thrd_stat = (*thrdptr)(context_storage);
 
                 if (thread_id_ref_type next = thrd_stat.move_next_thread();

--- a/libs/core/thread_pools/src/detail/background_thread.cpp
+++ b/libs/core/thread_pools/src/detail/background_thread.cpp
@@ -228,7 +228,6 @@ namespace hpx::threads::detail {
 
                 hpx::tracing::task_executing(thrdptr);
 
-                // invoke background thread
                 thrd_stat = (*thrdptr)(context_storage);
 
                 if (thread_id_ref_type next = thrd_stat.move_next_thread();

--- a/libs/core/tracing/include/hpx/tracing/backends/apex.hpp
+++ b/libs/core/tracing/include/hpx/tracing/backends/apex.hpp
@@ -78,6 +78,12 @@ namespace hpx::tracing {
     };
 
     ////////////////////////////////////////////////////////////////////////////
+    HPX_CXX_CORE_EXPORT struct [[maybe_unused]] background_work_region
+    {
+        constexpr explicit background_work_region(std::size_t = 0) noexcept {}
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
     HPX_CXX_CORE_EXPORT struct [[maybe_unused]] lock_context
     {
         constexpr explicit lock_context(
@@ -282,6 +288,9 @@ namespace hpx::tracing {
         char const* = nullptr) noexcept
     {
     }
+
+    HPX_CXX_CORE_EXPORT constexpr void os_thread_sleep(std::size_t) noexcept {}
+
     HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void tracing_init(char const* name,
         int argc, char** argv, std::uint32_t rank = 0, std::uint32_t size = 1);
 

--- a/libs/core/tracing/include/hpx/tracing/backends/empty.hpp
+++ b/libs/core/tracing/include/hpx/tracing/backends/empty.hpp
@@ -80,6 +80,12 @@ namespace hpx::tracing {
     };
 
     ////////////////////////////////////////////////////////////////////////////
+    HPX_CXX_CORE_EXPORT struct [[maybe_unused]] background_work_region
+    {
+        constexpr explicit background_work_region(std::size_t = 0) noexcept {}
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
     HPX_CXX_CORE_EXPORT struct [[maybe_unused]] lock_context
     {
         constexpr explicit lock_context(
@@ -246,6 +252,8 @@ namespace hpx::tracing {
         char const* = nullptr) noexcept
     {
     }
+
+    HPX_CXX_CORE_EXPORT constexpr void os_thread_sleep(std::size_t) noexcept {}
 
     HPX_CXX_CORE_EXPORT constexpr void tracing_init(
         char const*, int, char**, std::uint32_t = 0, std::uint32_t = 1) noexcept

--- a/libs/core/tracing/include/hpx/tracing/backends/ittnotify.hpp
+++ b/libs/core/tracing/include/hpx/tracing/backends/ittnotify.hpp
@@ -100,6 +100,12 @@ namespace hpx::tracing {
     };
 
     ////////////////////////////////////////////////////////////////////////////
+    HPX_CXX_CORE_EXPORT struct [[maybe_unused]] background_work_region
+    {
+        constexpr explicit background_work_region(std::size_t = 0) noexcept {}
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
     HPX_CXX_CORE_EXPORT struct [[maybe_unused]] lock_context
     {
         explicit lock_context(
@@ -325,6 +331,9 @@ namespace hpx::tracing {
         char const* = nullptr) noexcept
     {
     }
+
+    HPX_CXX_CORE_EXPORT constexpr void os_thread_sleep(std::size_t) noexcept {}
+
     HPX_CXX_CORE_EXPORT constexpr void tracing_init(
         char const*, int, char**, std::uint32_t = 0, std::uint32_t = 1) noexcept
     {

--- a/libs/core/tracing/include/hpx/tracing/backends/tracy.hpp
+++ b/libs/core/tracing/include/hpx/tracing/backends/tracy.hpp
@@ -109,6 +109,20 @@ namespace hpx::tracing {
     };
 
     ////////////////////////////////////////////////////////////////////////////
+    HPX_CXX_CORE_EXPORT struct HPX_CORE_EXPORT background_work_region
+    {
+        explicit background_work_region(std::size_t num_thread) noexcept;
+        ~background_work_region();
+
+        background_work_region(background_work_region const&) = delete;
+        background_work_region& operator=(
+            background_work_region const&) = delete;
+
+    private:
+        hpx::tracy::background_work_region impl;
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
     HPX_CXX_CORE_EXPORT struct HPX_CORE_EXPORT [[maybe_unused]] lock_context
     {
         explicit lock_context(
@@ -274,6 +288,13 @@ namespace hpx::tracing {
     /// \param name  Optional name for the frame/stage.
     HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void frame_mark(
         char const* name = nullptr) noexcept;
+
+    /// \brief Point message emitted just before an OS worker thread suspends on
+    ///        its condition variable.
+    ///
+    /// \param num_thread  Index of the worker thread entering sleep.
+    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void os_thread_sleep(
+        std::size_t num_thread) noexcept;
 
     HPX_CXX_CORE_EXPORT constexpr void tracing_init(
         char const*, int, char**, std::uint32_t = 0, std::uint32_t = 1) noexcept

--- a/libs/core/tracing/include/hpx/tracing/tracing.hpp
+++ b/libs/core/tracing/include/hpx/tracing/tracing.hpp
@@ -259,12 +259,14 @@ namespace hpx::tracing {
         {
             if (stolen_thrd)
             {
-                auto* thrd_data = get_thread_id_data(stolen_thrd);
-                using thread_data_type =
-                    std::remove_pointer_t<decltype(thrd_data)>;
-                work_stolen(thief_id, victim_id, thrd_data,
-                    thread_data_type::get_safe_description(
-                        thrd_data->get_description(), "thread"));
+                if (auto* thrd_data = get_thread_id_data(stolen_thrd))
+                {
+                    using thread_data_type =
+                        std::remove_pointer_t<decltype(thrd_data)>;
+                    work_stolen(thief_id, victim_id, thrd_data,
+                        thread_data_type::get_safe_description(
+                            thrd_data->get_description(), "thread"));
+                }
             }
         }
 #endif

--- a/libs/core/tracing/src/backends/tracy.cpp
+++ b/libs/core/tracing/src/backends/tracy.cpp
@@ -86,6 +86,17 @@ namespace hpx::tracing {
     fiber_suspend_region::~fiber_suspend_region() = default;
 
     ////////////////////////////////////////////////////////////////////////////
+    // background_work_region
+
+    background_work_region::background_work_region(
+        std::size_t const num_thread) noexcept
+      : impl(num_thread)
+    {
+    }
+
+    background_work_region::~background_work_region() = default;
+
+    ////////////////////////////////////////////////////////////////////////////
     // lock_context
 
     lock_context::lock_context(
@@ -411,6 +422,15 @@ namespace hpx::tracing {
     void frame_mark(char const* name) noexcept
     {
         hpx::tracy::frame_mark(name);
+    }
+
+    void os_thread_sleep(std::size_t num_thread) noexcept
+    {
+        char buffer[64];
+        std::snprintf(buffer, sizeof(buffer),
+            "OS Worker #%zu entering sleep on CV", num_thread);
+        // Blue-grey: cold/inactive state
+        hpx::tracy::message(buffer, std::strlen(buffer), 0x546E7Au);
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/libs/core/tracy/include/hpx/tracy/tracy_tls.hpp
+++ b/libs/core/tracy/include/hpx/tracy/tracy_tls.hpp
@@ -29,6 +29,10 @@ namespace hpx::tracy {
 
         HPX_CORE_EXPORT region_data start_region(
             char const*, std::size_t = 0, std::size_t = 0) noexcept;
+        HPX_CORE_EXPORT region_data start_named_region(
+            char const* name, std::uint32_t color) noexcept;
+        HPX_CORE_EXPORT void add_worker_thread_text(
+            region_data const& r, std::size_t num_thread) noexcept;
         HPX_CORE_EXPORT char const* rename_region(char const*) noexcept;
         HPX_CORE_EXPORT std::uint64_t push_zone(char const*) noexcept;
         HPX_CORE_EXPORT void pop_zone(std::uint64_t) noexcept;
@@ -120,6 +124,28 @@ namespace hpx::tracy {
         }
 
         region_data suspended_region;
+    };
+
+    HPX_CXX_CORE_EXPORT struct background_work_region
+    {
+        explicit background_work_region(std::size_t num_thread) noexcept
+          : surrounding_region(
+                detail::start_named_region("hpx::background_work", 0x008080u))
+        {
+            detail::add_worker_thread_text(surrounding_region, num_thread);
+        }
+
+        ~background_work_region() noexcept
+        {
+            detail::stop_region(surrounding_region);
+        }
+
+        background_work_region(background_work_region const&) = delete;
+        background_work_region& operator=(
+            background_work_region const&) = delete;
+
+    private:
+        region_data surrounding_region;
     };
 
     HPX_CXX_CORE_EXPORT struct mark_event

--- a/libs/core/tracy/src/tracy_tls.cpp
+++ b/libs/core/tracy/src/tracy_tls.cpp
@@ -275,9 +275,11 @@ namespace hpx::tracy {
 
             // Pre-formatted "Worker #N" strings for common thread indices.
             // Eliminates snprintf overhead in the hot background-polling path.
+            // Capacity covers up to 256 threads for high-core-count HPC systems.
+            // Thread counts exceeding capacity safely fall back to per-call snprintf.
             struct worker_label_cache
             {
-                static constexpr std::size_t capacity = 64;
+                static constexpr std::size_t capacity = 256;
 
                 worker_label_cache() noexcept
                 {
@@ -320,6 +322,7 @@ namespace hpx::tracy {
             }
             else
             {
+                // Fallback for thread counts > 256 (e.g. massive multi-socket systems)
                 int const n =
                     std::snprintf(tmp, sizeof(tmp), "Worker #%zu", num_thread);
                 text = tmp;

--- a/libs/core/tracy/src/tracy_tls.cpp
+++ b/libs/core/tracy/src/tracy_tls.cpp
@@ -12,6 +12,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
 #include <cstring>
 
 #include <tracy/TracyC.h>
@@ -117,6 +118,26 @@ namespace hpx::tracy {
             region.data = data.value;
             region.color = static_cast<std::uint32_t>(thread_num);
             region.phase = static_cast<std::uint32_t>(phase);
+
+            return prev_region;
+        }
+
+        HPX_CORE_EXPORT region_data start_named_region(
+            char const* name, std::uint32_t const color) noexcept
+        {
+            TracyCZoneC(ctx, color, 1);
+            TracyCZoneName(ctx, name, std::strlen(name));
+
+            tracy_context data;
+            data.context = ctx;
+
+            region_data& region = current_region();
+            region_data const prev_region = region;
+
+            region.name = name;
+            region.data = data.value;
+            region.color = color;
+            region.phase = 0;
 
             return prev_region;
         }
@@ -248,6 +269,69 @@ namespace hpx::tracy {
             data.value = fz.ctx_value;
             // TracyCZoneText sends the text via the zone validation protocol.
             TracyCZoneText(data.context, txt, size);
+        }
+
+        namespace {
+
+            // Pre-formatted "Worker #N" strings for common thread indices.
+            // Eliminates snprintf overhead in the hot background-polling path.
+            struct worker_label_cache
+            {
+                static constexpr std::size_t capacity = 64;
+
+                worker_label_cache() noexcept
+                {
+                    for (std::size_t i = 0; i < capacity; ++i)
+                    {
+                        int const n = std::snprintf(
+                            storage[i], sizeof(storage[i]), "Worker #%zu", i);
+                        lengths[i] = n > 0 ? static_cast<std::size_t>(n) :
+                                             std::size_t{0};
+                    }
+                }
+
+                char storage[capacity][24];
+                std::size_t lengths[capacity];
+            };
+
+            worker_label_cache const& get_worker_labels() noexcept
+            {
+                static worker_label_cache const cache;
+                return cache;
+            }
+
+        }    // namespace
+
+        HPX_CORE_EXPORT void add_worker_thread_text(
+            region_data const& r, std::size_t const num_thread) noexcept
+        {
+            if (r.data == 0)
+                return;
+
+            auto const& cache = get_worker_labels();
+            char const* text;
+            std::size_t len;
+
+            char tmp[32];
+            if (num_thread < worker_label_cache::capacity)
+            {
+                text = cache.storage[num_thread];
+                len = cache.lengths[num_thread];
+            }
+            else
+            {
+                int const n =
+                    std::snprintf(tmp, sizeof(tmp), "Worker #%zu", num_thread);
+                text = tmp;
+                len = n > 0 ? static_cast<std::size_t>(n) : std::size_t{0};
+            }
+
+            if (len > 0)
+            {
+                tracy_context data;
+                data.value = r.data;
+                TracyCZoneText(data.context, text, len);
+            }
         }
 
         HPX_CORE_EXPORT char const* rename_region(


### PR DESCRIPTION
> [!IMPORTANT]
> **Dependency:** This PR is built on top of **PR #7450** (Work-stealing instrumentation for Tracy profiler). Please review and merge #7450 first.


## Proposed Changes

- **Background Work Timeline Zones:** Wrapped parcel, AGAS, MPI, and CUDA polling calls (`call_and_create_background_thread`) in `scheduling_loop.hpp` with an `hpx::background_work` timeline zone, visually rendered in **Teal (`#008080`)**.
- **Zero-Allocation Worker Label Cache:** Added a static `worker_label_cache` in `tracy_tls.cpp` pre-formatting `"Worker #N"` label strings (up to 64 threads) to eliminate `snprintf` string-formatting overhead on the hot background-polling path.
- **OS Thread Sleep Event Messages:** Instrument OS worker thread suspension (`suspend(num_thread)`) in `scheduling_loop.hpp` with point messages (`"OS Worker #<num_thread> entering sleep on CV"`) styled in blue-grey (`#546E7A`) representing inactive states.
- **Profiling Backend Parity:** Implemented clean `constexpr` no-op stubs across all non-Tracy backends (`empty.hpp`, `apex.hpp`, and `ittnotify.hpp`), ensuring zero memory or binary overhead in non-tracing builds.

## Any background context you want to provide?

In complex HPX workloads, worker threads spend time polling network parcels, processing AGAS requests, executing background tasks, or spinning idle when work queues are empty. 

Before this change, active background polling and idle spinning were indistinguishable on the Tracy profiler timeline. This PR cleanly demarcates worker thread activity:
1. **Background Polling:** Displayed in **Teal (`#008080`)** with worker thread indexing.
2. **Idle Spinning:** Preserved as clean empty timeline gaps to accurately depict core utilization.
3. **OS CV Sleep:** Marked with point messages right before condition variable suspension.

## Checklist

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
