### PR TITLE
Used atomic work-time count to replace empty() check in thread_queue.hpp

### DIFF
--- a/libs/core/schedulers/include/hpx/schedulers/thread_queue.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/thread_queue.hpp
@@ -319,7 +319,8 @@ namespace hpx::threads::policies {
                             parameters_.min_add_new_count_,
                             parameters_.max_add_new_count_);
                 }
-                else if (work_items_.empty())
+                else if (work_items_count_.data_.load(
+                             std::memory_order_relaxed) == 0)
                 {
                     // add this number of threads
                     add_count = parameters_.min_add_new_count_;


### PR DESCRIPTION
Closes #7485 

## Description
Simple replacement for the `work_items_.empty()` in [thread_queue.hpp](https://github.com/TheHPXProject/hpx/blob/e08f1880d930e0dae687fa546ddbffd40a71dcf7/libs/core/schedulers/include/hpx/schedulers/thread_queue.hpp) with the atomic work-item count using relaxed load (see #7485).