### PR TITLE
Fixing force_disconnect issue

### DIFF
--- a/libs/core/errors/include/hpx/errors/error.hpp
+++ b/libs/core/errors/include/hpx/errors/error.hpp
@@ -155,8 +155,10 @@ namespace hpx {
         locality_was_disconnected = 60,    ///< the requested target locality
                                            ///< was disconnected
 
+        future_uncompleted = 61,    ///< future was resumed while being empty
+
         /// \cond NOINTERNAL
-        last_error = 61,
+        last_error = 62,
 
         system_error_flag = 0x4000L,
 

--- a/libs/core/errors/src/error_code.cpp
+++ b/libs/core/errors/src/error_code.cpp
@@ -79,6 +79,7 @@ namespace hpx {
         /* 58 */ "target_fenced",
         /* 59 */ "future_wait_timed_out",
         /* 60 */ "locality_was_disconnected",
+        /* 61 */ "future_uncompleted",
 
         /*    */ ""};
     /// \endcond

--- a/libs/core/futures/src/future_data.cpp
+++ b/libs/core/futures/src/future_data.cpp
@@ -191,10 +191,9 @@ namespace hpx::lcos::detail {
 
         if (s == empty)
         {
-            // the value has already been moved out of this future
-            HPX_THROWS_IF(ec, hpx::error::no_state,
+            HPX_THROWS_IF(ec, hpx::error::future_uncompleted,
                 "future_data_base::get_result",
-                "this future has no valid shared state");
+                "this future was resumed while its state was 'empty'");
             return nullptr;
         }
 

--- a/libs/core/futures/tests/regressions/CMakeLists.txt
+++ b/libs/core/futures/tests/regressions/CMakeLists.txt
@@ -9,6 +9,7 @@ set(tests
     exception_from_continuation_1613
     future_2667
     future_790
+    future_uncompleted_7490
     future_unwrap_878
     future_unwrap_1182
     set_hpx_limit_798

--- a/libs/core/futures/tests/regressions/future_uncompleted_7490.cpp
+++ b/libs/core/futures/tests/regressions/future_uncompleted_7490.cpp
@@ -1,0 +1,86 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/modules/futures.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/modules/threading_base.hpp>
+
+#include <atomic>
+#include <string>
+
+void test_future_uncompleted_error()
+{
+    hpx::promise<void> p;
+    hpx::future<void> f = p.get_future();
+
+    hpx::threads::thread_id_type waiter_id;
+    std::atomic<bool> waiter_started{false};
+
+    // Spawn a thread that blocks on future::get() without the promise ever
+    // being satisfied.
+    hpx::thread waiter([&]() {
+        waiter_id = hpx::threads::get_self_id();
+        waiter_started.store(true, std::memory_order_release);
+
+        bool caught = false;
+        try
+        {
+            f.get();
+        }
+        catch (hpx::exception const& e)
+        {
+            caught = true;
+            HPX_TEST_EQ(e.get_error(), hpx::error::future_uncompleted);
+            HPX_TEST(
+                std::string(e.what()).find(
+                    "this future was resumed while its state was 'empty'") !=
+                std::string::npos);
+
+            // Must be distinct from no_state.
+            HPX_TEST_NEQ(e.get_error(), hpx::error::no_state);
+        }
+        HPX_TEST(caught);
+    });
+
+    // Wait until the waiter thread has actually registered itself and is about
+    // to suspend inside future_data_base::wait().
+    while (!waiter_started.load(std::memory_order_acquire))
+    {
+        hpx::this_thread::yield();
+    }
+
+    // Wait until the waiter thread has actually suspended inside wait() before
+    // forcing a resume; a fixed sleep is a race under load.
+    while (hpx::threads::get_thread_state(waiter_id).state() !=
+        hpx::threads::thread_schedule_state::suspended)
+    {
+        hpx::this_thread::yield();
+    }
+
+    // Force-resume the waiting HPX thread without ever calling p.set_value().
+    // This mimics an external resume that leaves the future's state as 'empty',
+    // which is exactly the scenario get_result_void() guards against.
+    hpx::threads::set_thread_state(
+        waiter_id, hpx::threads::thread_schedule_state::pending);
+
+    waiter.join();
+
+    // Clean up: satisfy the promise so its destructor doesn't assert/throw.
+    p.set_value();
+}
+
+int hpx_main()
+{
+    test_future_uncompleted_error();
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST(hpx::init(argc, argv) == 0);
+    return hpx::util::report_errors();
+}

--- a/libs/full/async_distributed/include/hpx/async_distributed/packaged_action.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/packaged_action.hpp
@@ -84,21 +84,25 @@ namespace hpx::lcos {
                 // object
                 if (ec)
                 {
-                    if (hpx::tolerate_node_faults() && is_asio_error(ec))
-                    {
-                        return;
-                    }
-
-                    if (parcelset::locality_was_disconnected(
+                    if ((hpx::tolerate_node_faults() && is_asio_error(ec)) ||
+                        parcelset::locality_was_disconnected(
                             p.destination_locality_id()))
                     {
-                        return;
+                        std::exception_ptr exception = HPX_GET_EXCEPTION(
+                            hpx::error_code(
+                                hpx::error::locality_was_disconnected,
+                                hpx::throwmode::lightweight),
+                            "packaged_action::parcel_write_handler",
+                            parcelset::dump_parcel(p));
+                        shared_state->set_exception(exception);
                     }
-
-                    std::exception_ptr exception = HPX_GET_EXCEPTION(ec,
-                        "packaged_action::parcel_write_handler_cb",
-                        parcelset::dump_parcel(p));
-                    shared_state->set_exception(exception);
+                    else
+                    {
+                        std::exception_ptr exception = HPX_GET_EXCEPTION(ec,
+                            "packaged_action::parcel_write_handler_cb",
+                            parcelset::dump_parcel(p));
+                        shared_state->set_exception(exception);
+                    }
                 }
 
                 // invoke user supplied callback


### PR DESCRIPTION
## Future error reporting and parcel callback handling

### Summary
This PR introduces a dedicated error code for futures resumed with an empty shared state and hardens the packaged action parcel write callback to record exceptions for tolerated/disconnected-locality failures before invoking the user callback.

### Changes

**Future error reporting**
- Added `hpx::error::future_uncompleted` (value `61`) to the `hpx::error` enum in `libs/core/errors/include/hpx/errors/error.hpp`, bumping `last_error` to `62`.
- Registered the corresponding error name `"future_uncompleted"` in `libs/core/errors/src/error_code.cpp`.
- Updated `future_data_base::get_result` (`libs/core/futures/src/future_data.cpp`) to throw `hpx::error::future_uncompleted` instead of `hpx::error::no_state` when a future is found in the `empty` state after being resumed, with a clarified diagnostic message ("this future was resumed while its state was 'empty'"). This distinguishes "resumed with empty state" from the genuine "no shared state" case.
- Added regression test `libs/core/futures/tests/regressions/future_uncompleted_7490.cpp`, which force-resumes a waiting HPX thread without ever satisfying its promise and verifies:
  - the correct exception type/error code (`future_uncompleted`) is thrown,
  - the diagnostic message content,
  - that this is distinct from `no_state`.
- Registered the new test in `libs/core/futures/tests/regressions/CMakeLists.txt`.

**Parcel callback error handling**
- Reworked `packaged_action::parcel_write_handler_cb` in `libs/full/async_distributed/include/hpx/async_distributed/packaged_action.hpp`:
  - Previously, tolerated node faults (asio errors) and disconnected-locality errors caused an early `return` with no exception recorded on the shared state.
  - Now, both cases construct and set an appropriate exception on the shared state (`locality_was_disconnected` for the tolerated/disconnected cases, the original error otherwise) before falling through to invoke the user-supplied callback, ensuring callers are always informed of the failure via the future/callback rather than being silently left in a pending/empty state.

### Testing
- New regression test `future_uncompleted_7490` validates the future error reporting path end-to-end.

