### PR TITLE
Make force_disconnect claim a locality before removing it

### DIFF
--- a/libs/full/agas/include/hpx/agas/addressing_service.hpp
+++ b/libs/full/agas/include/hpx/agas/addressing_service.hpp
@@ -105,9 +105,22 @@ namespace hpx::agas {
         std::atomic<hpx::state> state_;
         naming::gid_type locality_;
 
+        enum class resolved_locality_state : std::uint8_t
+        {
+            connected,
+            connecting,
+            disconnecting
+        };
+
+        struct resolved_locality
+        {
+            parcelset::endpoints_type endpoints;
+            resolved_locality_state state;
+        };
+
         mutable hpx::shared_mutex resolved_localities_mtx_;
-        using resolved_localities_type = std::map<naming::gid_type,
-            std::pair<parcelset::endpoints_type, bool>>;
+        using resolved_localities_type =
+            std::map<naming::gid_type, resolved_locality>;
         resolved_localities_type resolved_localities_;
 
         explicit addressing_service(util::runtime_configuration const& ini_);
@@ -172,8 +185,18 @@ namespace hpx::agas {
         ///                 return the connecting status of the calling
         ///                 locality.
         ///
-        /// \returns `true` if the locality is marked as connecting.
+        /// \returns `true` if the locality joined while connecting and has not
+        ///          been removed.
         bool is_connecting(hpx::naming::gid_type const& locality) const;
+
+        /// \brief Atomically claim a connecting locality for disconnection.
+        ///
+        /// \param locality The locality GID to claim.
+        ///
+        /// \returns `true` if this call changed the locality state from
+        ///          connecting to disconnecting, and `false` otherwise.
+        bool mark_connecting_locality_as_disconnecting(
+            hpx::naming::gid_type const& locality);
 
         bool resolve_locally_known_addresses(
             naming::gid_type const& id, naming::address& addr) const;

--- a/libs/full/agas/include/hpx/agas/addressing_service.hpp
+++ b/libs/full/agas/include/hpx/agas/addressing_service.hpp
@@ -284,6 +284,11 @@ namespace hpx::agas {
         bool was_object_migrated_locked(naming::gid_type const& id) const;
 
     private:
+        /// Move a locality from one state to another under the resolved
+        /// localities lock. Returns `false` if it is unknown or not in \a from.
+        bool transition_resolved_locality(hpx::naming::gid_type const& locality,
+            resolved_locality_state from, resolved_locality_state to);
+
         /// Assumes that \a refcnt_requests_mtx_ is locked.
         void send_refcnt_requests(
             std::unique_lock<mutex_type>& l, error_code& ec = throws);

--- a/libs/full/agas/include/hpx/agas/addressing_service.hpp
+++ b/libs/full/agas/include/hpx/agas/addressing_service.hpp
@@ -105,13 +105,23 @@ namespace hpx::agas {
         std::atomic<hpx::state> state_;
         naming::gid_type locality_;
 
+        /// How a locality became known to this instance, which decides whether
+        /// hpx::force_disconnect may remove it.
         enum class resolved_locality_state : std::uint8_t
         {
+            /// Started with the application, or learned about by resolving
+            /// its address. hpx::force_disconnect rejects it.
             connected,
+            /// Connected after the application started and registered as
+            /// such here, which only the console does. hpx::force_disconnect
+            /// accepts it.
             connecting,
+            /// Claimed by an hpx::force_disconnect call that is still removing
+            /// it. Further claims are rejected until the entry is erased.
             disconnecting
         };
 
+        /// What this instance knows about one locality.
         struct resolved_locality
         {
             parcelset::endpoints_type endpoints;

--- a/libs/full/agas/include/hpx/agas/addressing_service.hpp
+++ b/libs/full/agas/include/hpx/agas/addressing_service.hpp
@@ -208,6 +208,16 @@ namespace hpx::agas {
         bool mark_connecting_locality_as_disconnecting(
             hpx::naming::gid_type const& locality);
 
+        /// \brief Release a claim made by
+        ///        mark_connecting_locality_as_disconnecting.
+        ///
+        /// \param locality The locality GID to release.
+        ///
+        /// \returns `true` if this call changed the locality state from
+        ///          disconnecting back to connecting, and `false` otherwise.
+        bool mark_disconnecting_locality_as_connecting(
+            hpx::naming::gid_type const& locality);
+
         bool resolve_locally_known_addresses(
             naming::gid_type const& id, naming::address& addr) const;
 

--- a/libs/full/agas/include/hpx/agas/addressing_service.hpp
+++ b/libs/full/agas/include/hpx/agas/addressing_service.hpp
@@ -195,8 +195,9 @@ namespace hpx::agas {
         ///                 return the connecting status of the calling
         ///                 locality.
         ///
-        /// \returns `true` if the locality joined while connecting and has not
-        ///          been removed.
+        /// \returns `true` if the locality connected late, also while it is
+        ///          being removed and after it was disconnected, and `false`
+        ///          for a locality that started with the application.
         bool is_connecting(hpx::naming::gid_type const& locality) const;
 
         /// \brief Atomically claim a connecting locality for disconnection.

--- a/libs/full/agas/src/addressing_service.cpp
+++ b/libs/full/agas/src/addressing_service.cpp
@@ -291,6 +291,26 @@ namespace hpx::agas {
         return true;
     }
 
+    bool addressing_service::mark_disconnecting_locality_as_connecting(
+        hpx::naming::gid_type const& locality)
+    {
+        if (!locality)
+        {
+            return false;
+        }
+
+        std::lock_guard<hpx::shared_mutex> l(resolved_localities_mtx_);
+        auto const it = resolved_localities_.find(locality);
+        if (it == resolved_localities_.end() ||
+            it->second.state != resolved_locality_state::disconnecting)
+        {
+            return false;
+        }
+
+        it->second.state = resolved_locality_state::connecting;
+        return true;
+    }
+
     void addressing_service::register_console(
         parcelset::endpoints_type const& eps)
     {

--- a/libs/full/agas/src/addressing_service.cpp
+++ b/libs/full/agas/src/addressing_service.cpp
@@ -376,8 +376,8 @@ namespace hpx::agas {
         {
             if (HPX_UNLIKELY(!util::insert_checked(
                     resolved_localities_.emplace(gid,
-                        resolved_locality{
-                            endpoints, resolved_locality_state::connected}),
+                        resolved_locality{HPX_MOVE(endpoints),
+                            resolved_locality_state::connected}),
                     it)))
             {
                 l.unlock();

--- a/libs/full/agas/src/addressing_service.cpp
+++ b/libs/full/agas/src/addressing_service.cpp
@@ -217,8 +217,11 @@ namespace hpx::agas {
 
             {
                 std::unique_lock<hpx::shared_mutex> l(resolved_localities_mtx_);
+                resolved_locality_state const state = is_connecting ?
+                    resolved_locality_state::connecting :
+                    resolved_locality_state::connected;
                 auto const [it, inserted] = resolved_localities_.emplace(
-                    prefix, std::make_pair(endpoints, is_connecting));
+                    prefix, resolved_locality{endpoints, state});
 
                 if (!inserted)
                 {
@@ -252,7 +255,9 @@ namespace hpx::agas {
             if (auto const it = resolved_localities_.find(locality);
                 it != resolved_localities_.end())
             {
-                return it->second.second;
+                resolved_locality_state const state = it->second.state;
+                return state == resolved_locality_state::connecting ||
+                    state == resolved_locality_state::disconnecting;
             }
         }
 
@@ -266,13 +271,33 @@ namespace hpx::agas {
 #endif
     }
 
+    bool addressing_service::mark_connecting_locality_as_disconnecting(
+        hpx::naming::gid_type const& locality)
+    {
+        if (!locality)
+        {
+            return false;
+        }
+
+        std::lock_guard<hpx::shared_mutex> l(resolved_localities_mtx_);
+        auto const it = resolved_localities_.find(locality);
+        if (it == resolved_localities_.end() ||
+            it->second.state != resolved_locality_state::connecting)
+        {
+            return false;
+        }
+
+        it->second.state = resolved_locality_state::disconnecting;
+        return true;
+    }
+
     void addressing_service::register_console(
         parcelset::endpoints_type const& eps)
     {
         std::lock_guard<hpx::shared_mutex> l(resolved_localities_mtx_);
         [[maybe_unused]] auto const [it, inserted] =
             resolved_localities_.emplace(naming::get_gid_from_locality_id(0),
-                std::make_pair(eps, false));
+                resolved_locality{eps, resolved_locality_state::connected});
         HPX_ASSERT(inserted);
     }
 
@@ -292,7 +317,8 @@ namespace hpx::agas {
         {
             resolved_localities_.emplace(
                 naming::get_gid_from_locality_id(locality_id),
-                std::make_pair(endpoint, false));
+                resolved_locality{
+                    endpoint, resolved_locality_state::connected});
             ++locality_id;
         }
     }
@@ -304,9 +330,10 @@ namespace hpx::agas {
         {
             std::shared_lock<hpx::shared_mutex> l(resolved_localities_mtx_);
             it = resolved_localities_.find(gid);
-            if (it != resolved_localities_.end() && !it->second.first.empty())
+            if (it != resolved_localities_.end() &&
+                !it->second.endpoints.empty())
             {
-                return it->second.first;
+                return it->second.endpoints;
             }
         }
 
@@ -331,10 +358,11 @@ namespace hpx::agas {
         it = resolved_localities_.find(gid);
         if (it == resolved_localities_.end())
         {
-            if (HPX_UNLIKELY(
-                    !util::insert_checked(resolved_localities_.emplace(gid,
-                                              std::make_pair(endpoints, false)),
-                        it)))
+            if (HPX_UNLIKELY(!util::insert_checked(
+                    resolved_localities_.emplace(gid,
+                        resolved_locality{
+                            endpoints, resolved_locality_state::connected}),
+                    it)))
             {
                 l.unlock();
 
@@ -347,12 +375,11 @@ namespace hpx::agas {
                 return empty_endpoints;
             }
         }
-        else if (it->second.first.empty() && !endpoints.empty())
+        else if (it->second.endpoints.empty() && !endpoints.empty())
         {
-            resolved_localities_[gid] =
-                std::make_pair(HPX_MOVE(endpoints), false);
+            it->second.endpoints = HPX_MOVE(endpoints);
         }
-        return it->second.first;
+        return it->second.endpoints;
     }
 
     bool addressing_service::unregister_locality(

--- a/libs/full/agas/src/addressing_service.cpp
+++ b/libs/full/agas/src/addressing_service.cpp
@@ -271,8 +271,9 @@ namespace hpx::agas {
 #endif
     }
 
-    bool addressing_service::mark_connecting_locality_as_disconnecting(
-        hpx::naming::gid_type const& locality)
+    bool addressing_service::transition_resolved_locality(
+        hpx::naming::gid_type const& locality,
+        resolved_locality_state const from, resolved_locality_state const to)
     {
         if (!locality)
         {
@@ -281,34 +282,29 @@ namespace hpx::agas {
 
         std::lock_guard<hpx::shared_mutex> l(resolved_localities_mtx_);
         auto const it = resolved_localities_.find(locality);
-        if (it == resolved_localities_.end() ||
-            it->second.state != resolved_locality_state::connecting)
+        if (it == resolved_localities_.end() || it->second.state != from)
         {
             return false;
         }
 
-        it->second.state = resolved_locality_state::disconnecting;
+        it->second.state = to;
         return true;
+    }
+
+    bool addressing_service::mark_connecting_locality_as_disconnecting(
+        hpx::naming::gid_type const& locality)
+    {
+        return transition_resolved_locality(locality,
+            resolved_locality_state::connecting,
+            resolved_locality_state::disconnecting);
     }
 
     bool addressing_service::mark_disconnecting_locality_as_connecting(
         hpx::naming::gid_type const& locality)
     {
-        if (!locality)
-        {
-            return false;
-        }
-
-        std::lock_guard<hpx::shared_mutex> l(resolved_localities_mtx_);
-        auto const it = resolved_localities_.find(locality);
-        if (it == resolved_localities_.end() ||
-            it->second.state != resolved_locality_state::disconnecting)
-        {
-            return false;
-        }
-
-        it->second.state = resolved_locality_state::connecting;
-        return true;
+        return transition_resolved_locality(locality,
+            resolved_locality_state::disconnecting,
+            resolved_locality_state::connecting);
     }
 
     void addressing_service::register_console(

--- a/libs/full/init_runtime/include/hpx/init_runtime/finalize.hpp
+++ b/libs/full/init_runtime/include/hpx/init_runtime/finalize.hpp
@@ -211,6 +211,11 @@ namespace hpx {
     /// used by a locality to disconnect itself (use \a hpx::disconnect()
     /// without the locality argument for this purpose).
     ///
+    /// Only a locality that connected late can be removed this way. The
+    /// function fails with \a hpx::error::bad_parameter if the given locality
+    /// started with the application, was already disconnected, or is being
+    /// disconnected by another call.
+    ///
     /// \param locality The locality to remove from the distributed connection
     ///        caches
     /// \param ec [in,out] this represents the error status on exit, if this
@@ -224,9 +229,10 @@ namespace hpx {
     ///           parameter \a ec. Otherwise, it throws an instance of
     ///           hpx::exception.
     ///
-    /// This function will block and wait for this locality to finish executing
-    /// before returning to the caller. It should be the last HPX-function
-    /// called by any locality being disconnected.
+    /// This function blocks until the locality has been removed from AGAS and
+    /// from the connection caches of the remaining localities. It waits a
+    /// bounded time for the locality to acknowledge its shutdown, so an
+    /// unreachable locality does not block the caller indefinitely.
     ///
     HPX_CXX_EXPORT HPX_EXPORT int force_disconnect(
         hpx::id_type const& locality, hpx::error_code& ec = throws);

--- a/libs/full/init_runtime/src/hpx_init.cpp
+++ b/libs/full/init_runtime/src/hpx_init.cpp
@@ -1176,15 +1176,6 @@ namespace hpx {
             return -1;
         }
 
-        if (!agas::is_connecting(locality.get_gid()))
-        {
-            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
-                "hpx::force_disconnect",
-                "hpx::force_disconnect can be called to disconnect only a "
-                "locality that was connecting late.");
-            return -1;
-        }
-
         auto* p = static_cast<components::server::runtime_support*>(
             get_runtime_distributed().get_runtime_support_lva());
 

--- a/libs/full/init_runtime/tests/unit/force_disconnect.cpp
+++ b/libs/full/init_runtime/tests/unit/force_disconnect.cpp
@@ -11,9 +11,9 @@
 // caches while leaving the remaining localities unaffected. Calling
 // force_disconnect a second time on an already-disconnected locality does not
 // hang. Once a locality has been removed, its gid no longer reports
-// is_connecting() == true, so the eligibility check in force_disconnect fails
-// fast with hpx::error::bad_parameter rather than attempting a second removal
-// or blocking.
+// is_connecting() == true, so the atomic claim in force_disconnect fails fast
+// with hpx::error::bad_parameter rather than attempting a second removal or
+// blocking.
 //
 // Beyond that baseline, this test also covers: disconnecting a locality while
 // an action is still in flight to it; repeated connect/disconnect cycles across
@@ -40,6 +40,7 @@
 #include <hpx/modules/prefix.hpp>
 #include <hpx/modules/runtime_distributed.hpp>
 #include <hpx/modules/runtime_local.hpp>
+#include <hpx/modules/synchronization.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <chrono>
@@ -283,7 +284,7 @@ std::pair<hpx::id_type, hpx::id_type> test_force_disconnect_removes_locality()
 
 // Calling force_disconnect a second time on an already-disconnected
 // locality does not hang. Once a locality has been removed, its gid no
-// longer reports is_connecting() == true, so the eligibility check in
+// longer reports is_connecting() == true, so the atomic claim in
 // force_disconnect fails fast with hpx::error::bad_parameter rather than
 // attempting a second removal or blocking.
 void test_double_disconnect_should_fail(hpx::id_type const& target)
@@ -418,8 +419,8 @@ void test_repeated_connect_disconnect_cycles(fs::path const& exe,
 }
 
 // Two concurrent hpx::force_disconnect calls targeting the same locality
-// must not corrupt state or hang: at most one may succeed, and the losing
-// call must fail cleanly instead of duplicating the removal.
+// must not corrupt state or hang: exactly one succeeds, and the losing call is
+// rejected with hpx::error::bad_parameter before it duplicates the removal.
 void test_concurrent_double_disconnect_race(hpx::id_type const& target)
 {
     if (!target)
@@ -429,11 +430,18 @@ void test_concurrent_double_disconnect_race(hpx::id_type const& target)
 
     hpx::error_code ec1(hpx::throwmode::lightweight);
     hpx::error_code ec2(hpx::throwmode::lightweight);
+    hpx::latch start(3);
 
-    hpx::future<int> f1 = hpx::async(
-        [&target, &ec1]() { return hpx::force_disconnect(target, ec1); });
-    hpx::future<int> f2 = hpx::async(
-        [&target, &ec2]() { return hpx::force_disconnect(target, ec2); });
+    hpx::future<int> f1 = hpx::async([&target, &ec1, &start]() {
+        start.arrive_and_wait();
+        return hpx::force_disconnect(target, ec1);
+    });
+    hpx::future<int> f2 = hpx::async([&target, &ec2, &start]() {
+        start.arrive_and_wait();
+        return hpx::force_disconnect(target, ec2);
+    });
+
+    start.arrive_and_wait();
 
     int const r1 = f1.get();
     int const r2 = f2.get();
@@ -441,6 +449,17 @@ void test_concurrent_double_disconnect_race(hpx::id_type const& target)
     bool const succeeded1 = (r1 == 0) && !ec1;
     bool const succeeded2 = (r2 == 0) && !ec2;
     HPX_TEST(succeeded1 != succeeded2);
+
+    if (succeeded1)
+    {
+        HPX_TEST_EQ(r2, -1);
+        HPX_TEST_EQ(ec2.value(), static_cast<int>(hpx::error::bad_parameter));
+    }
+    else if (succeeded2)
+    {
+        HPX_TEST_EQ(r1, -1);
+        HPX_TEST_EQ(ec1.value(), static_cast<int>(hpx::error::bad_parameter));
+    }
 }
 
 // Force-disconnecting a locality whose process has already been killed (rather

--- a/libs/full/init_runtime/tests/unit/force_disconnect.cpp
+++ b/libs/full/init_runtime/tests/unit/force_disconnect.cpp
@@ -10,10 +10,9 @@
 // remote locality succeeds and actually removes it from AGAS/the connection
 // caches while leaving the remaining localities unaffected. Calling
 // force_disconnect a second time on an already-disconnected locality does not
-// hang. Once a locality has been removed, its gid no longer reports
-// is_connecting() == true, so the atomic claim in force_disconnect fails fast
-// with hpx::error::bad_parameter rather than attempting a second removal or
-// blocking.
+// hang. Once a locality has been removed, the parcel layer remembers it as
+// disconnected, so force_disconnect rejects the gid with
+// hpx::error::bad_parameter before it attempts a second removal or blocks.
 //
 // Beyond that baseline, this test also covers: disconnecting a locality while
 // an action is still in flight to it; repeated connect/disconnect cycles across
@@ -283,10 +282,9 @@ std::pair<hpx::id_type, hpx::id_type> test_force_disconnect_removes_locality()
 }
 
 // Calling force_disconnect a second time on an already-disconnected
-// locality does not hang. Once a locality has been removed, its gid no
-// longer reports is_connecting() == true, so the atomic claim in
-// force_disconnect fails fast with hpx::error::bad_parameter rather than
-// attempting a second removal or blocking.
+// locality does not hang. Once a locality has been removed, the parcel layer
+// remembers it as disconnected, so force_disconnect rejects the gid with
+// hpx::error::bad_parameter before it attempts a second removal or blocks.
 void test_double_disconnect_should_fail(hpx::id_type const& target)
 {
     if (!target)

--- a/libs/full/init_runtime/tests/unit/force_disconnect.cpp
+++ b/libs/full/init_runtime/tests/unit/force_disconnect.cpp
@@ -416,6 +416,33 @@ void test_repeated_connect_disconnect_cycles(fs::path const& exe,
     }
 }
 
+// A claimed locality is rejected by force_disconnect until the claim is
+// released, which is what remove_locality does when a removal throws. The
+// claim and its release each succeed exactly once, and the locality reports
+// is_connecting() throughout.
+void test_claim_and_release(hpx::id_type const& target)
+{
+    if (!target)
+    {
+        return;
+    }
+
+    hpx::agas::addressing_service& agas_client = hpx::naming::get_agas_client();
+    hpx::naming::gid_type const gid = target.get_gid();
+
+    HPX_TEST(agas_client.mark_connecting_locality_as_disconnecting(gid));
+    HPX_TEST(!agas_client.mark_connecting_locality_as_disconnecting(gid));
+    HPX_TEST(hpx::agas::is_connecting(gid));
+
+    hpx::error_code ec(hpx::throwmode::lightweight);
+    HPX_TEST_EQ(hpx::force_disconnect(target, ec), -1);
+    HPX_TEST_EQ(ec.value(), static_cast<int>(hpx::error::bad_parameter));
+
+    HPX_TEST(agas_client.mark_disconnecting_locality_as_connecting(gid));
+    HPX_TEST(!agas_client.mark_disconnecting_locality_as_connecting(gid));
+    HPX_TEST(hpx::agas::is_connecting(gid));
+}
+
 // Two concurrent hpx::force_disconnect calls targeting the same locality
 // must not corrupt state or hang: exactly one succeeds, and the losing call is
 // rejected with hpx::error::bad_parameter before it duplicates the removal.
@@ -559,9 +586,11 @@ int hpx_main(hpx::program_options::variables_map& vm)
         << "Repeated connect/disconnect cycles across distinct localities.\n";
     test_repeated_connect_disconnect_cycles(exe, 2, 4);
 
-    std::cout << "Concurrent double force_disconnect on the same locality.\n";
+    std::cout << "Claiming a locality, releasing it, and racing two "
+                 "force_disconnect calls on it.\n";
     {
         auto [w6, id6] = launch_worker(exe, 6);
+        test_claim_and_release(id6);
         test_concurrent_double_disconnect_race(id6);
         int const exit_code6 = w6.wait_for_exit(hpx::launch::sync);
         HPX_TEST_EQ(exit_code6, 0);

--- a/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
+++ b/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
@@ -899,9 +899,11 @@ namespace hpx::components::server {
             return false;
         }
 
-        // A removal that throws must not leave the locality claimed forever.
-        // If it fails without throwing, the console connection cache removal
-        // below still erases the entry.
+        // A removal that throws must not leave the locality claimed forever,
+        // so hand it back as connecting. A retry then repeats the shutdown
+        // notification and the cache removal broadcasts, which are idempotent.
+        // A removal that fails without throwing needs nothing, because the
+        // console connection cache removal below still erases the entry.
         auto release_claim = hpx::experimental::scope_fail([&]() noexcept {
             agas_client.mark_disconnecting_locality_as_connecting(
                 locality.get_gid());

--- a/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
+++ b/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
@@ -17,6 +17,7 @@
 #include <hpx/modules/execution_base.hpp>
 #include <hpx/modules/filesystem.hpp>
 #include <hpx/modules/format.hpp>
+#include <hpx/modules/functional.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/ini.hpp>
 #include <hpx/modules/logging.hpp>
@@ -897,6 +898,14 @@ namespace hpx::components::server {
                 "disconnected.");
             return false;
         }
+
+        // A removal that throws must not leave the locality claimed forever.
+        // If it fails without throwing, the console connection cache removal
+        // below still erases the entry.
+        auto release_claim = hpx::experimental::scope_fail([&]() noexcept {
+            agas_client.mark_disconnecting_locality_as_connecting(
+                locality.get_gid());
+        });
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE) && defined(HPX_HAVE_NETWORKING)
         // try to inform the locality that it has been disconnected (ignore any

--- a/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
+++ b/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
@@ -892,7 +892,7 @@ namespace hpx::components::server {
                 locality.get_gid()))
         {
             HPX_THROWS_IF(ec, hpx::error::bad_parameter,
-                "hpx::force_disconnect",
+                "runtime_support::remove_locality",
                 "hpx::force_disconnect can be called to disconnect only a "
                 "locality that was connecting late and is not already being "
                 "disconnected.");

--- a/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
+++ b/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
@@ -886,6 +886,18 @@ namespace hpx::components::server {
     bool runtime_support::remove_locality(
         hpx::id_type const& locality, error_code& ec)
     {
+        agas::addressing_service& agas_client = naming::get_agas_client();
+        if (!agas_client.mark_connecting_locality_as_disconnecting(
+                locality.get_gid()))
+        {
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "hpx::force_disconnect",
+                "hpx::force_disconnect can be called to disconnect only a "
+                "locality that was connecting late and is not already being "
+                "disconnected.");
+            return false;
+        }
+
 #if !defined(HPX_COMPUTE_DEVICE_CODE) && defined(HPX_HAVE_NETWORKING)
         // try to inform the locality that it has been disconnected (ignore any
         // errors)
@@ -910,7 +922,6 @@ namespace hpx::components::server {
 
         remove_locality_from_connection_cache(locality.get_gid(), true);
 
-        agas::addressing_service& agas_client = naming::get_agas_client();
         bool const result =
             agas_client.unregister_locality(locality.get_gid(), ec);
 


### PR DESCRIPTION
Fixes #7468.

`force_disconnect` checks `agas::is_connecting()` and then calls `remove_locality()`, with no lock held across the two. Two concurrent calls on the same locality both pass the check, so both notify the target, both wait out the 5 second timeout, and both broadcast the cache removals. The loser returns -1 with no error code set.

`remove_locality()` now claims the locality first, under the same lock `is_connecting()` reads, flipping it from connecting to disconnecting. A second caller gets `bad_parameter` immediately and does no work. That needs `resolved_localities_` to hold a three state enum instead of a bool. The old eligibility check in `hpx_init.cpp` goes away because the claim replaces it, and `remove_locality()` has no other caller.

The concurrency test now releases both calls from a latch and asserts the loser was really rejected. Without the fix it fails at `ec2.value() == bad_parameter` with 0 != 13.


Update after review. The claim is released through a `scope_fail` if the removal throws, so a failed removal cannot leave the locality claimed forever; a retry then repeats the shutdown notification and the cache broadcasts, which are idempotent. `is_connecting(gid)` now also reports `true` while a claimed locality is being removed, so it reads as "joined late and not yet gone". Its only callers outside AGAS are the asserts in this test, and the no-argument overload checks the runtime mode and is unaffected. The `locality_was_disconnected` check in `hpx_init.cpp` stays outside the lock; it is monotonic, so a race there only changes which `bad_parameter` message the loser sees. Nothing outside can make `unregister_locality` throw, so `test_claim_and_release` exercises the claim and its release directly instead.
