### PR TITLE
Set SLURM_MPI_TYPE=pmix for the rostam CIs

### DIFF
--- a/.jenkins/lsu/env-common.sh
+++ b/.jenkins/lsu/env-common.sh
@@ -17,6 +17,12 @@ fi
 # These tests only make sense if hpx is being installed
 configure_extra_options+=" -DHPX_WITH_TESTS_EXTERNAL_BUILD=OFF"
 
+# Slurm on rostam has MpiDefault=none, so a bare srun (as issued by hpxrun.py)
+# does not provide a PMIx bootstrap and every rank starts as its own
+# single-rank MPI job. Distributed tests then hang in finalization waiting for
+# peers that never show up. Select PMIx explicitly for all srun invocations.
+export SLURM_MPI_TYPE=pmix
+
 ctest_extra_args+=" --verbose "
 
 hostname


### PR DESCRIPTION
slurm.conf on rostam has MpiDefault=none, and hpxrun.py calls srun with no --mpi flag, so each rank starts as its own single rank MPI job and the distributed tests hang in finalization until ctest kills them at 300s. That's why MPI, LCI and LCW hang while TCP passes.

Checked with a two rank MPI hello on marvin03/04: plain srun gives size=1 twice, with SLURM_MPI_TYPE=pmix it gives size=2 and finishes clean. This exports that in env-common.sh so every srun the CI issues picks it up.