### PR TITLE
Restart the Dijkstra termination probe cursor for every probe

### DIFF
--- a/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
+++ b/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
@@ -443,11 +443,6 @@ namespace hpx::components::server {
 #if defined(HPX_HAVE_NETWORKING)
         std::uint32_t const initiating_locality_id = get_locality_id();
 
-        // send token to previous node
-        std::uint32_t target_id = initiating_locality_id;
-        if (0 == target_id)
-            target_id = num_localities;
-
         std::size_t count = 0;    // keep track of number of trials
 
         {
@@ -462,6 +457,16 @@ namespace hpx::components::server {
                 // and sending a white token to machine nr.N - 1.
                 dijkstra_color_ = false;    // start off with white
                 dijkstra_cond_ = std::make_unique<hpx::latch>(2);
+
+                // Start each probe at the initiator's predecessor in the ring.
+                // dijkstra_forward_token consumes target_id (it walks it
+                // backwards in-place), so it has to be re-initialized for every
+                // probe; reusing the value left over from the previous probe
+                // makes a repeated probe walk past the other localities and the
+                // initiator ends up handing the token to itself indefinitely.
+                std::uint32_t target_id = initiating_locality_id;
+                if (0 == target_id)
+                    target_id = num_localities;
 
                 {
                     // accommodate for disconnected localities

--- a/libs/full/runtime_distributed/tests/unit/dijkstra_termination_forwarding.cpp
+++ b/libs/full/runtime_distributed/tests/unit/dijkstra_termination_forwarding.cpp
@@ -185,6 +185,65 @@ void test_no_forwarding_when_already_at_initiator()
     HPX_TEST(send.succeeded_calls_.empty());
 }
 
+// 7. Regression for the --hpx:threads=1 termination-detection livelock
+//    (dijkstra_termination_detection). The retry loop restarts the ring cursor
+//    for every probe; dijkstra_forward_token consumes it (walks it backwards
+//    in-place), so a probe that resumes from the leftover value walks past the
+//    remaining localities and the initiator ends up handing the token to
+//    itself, which can never terminate. These cases pin the two-probe contract
+//    the loop must uphold, exercised through the real forwarding helper.
+void test_repeated_probe_restarts_cursor()
+{
+    constexpr std::uint32_t initiating_locality_id = 0;
+    constexpr std::uint32_t num_localities = 2;
+
+    // The initiator's predecessor in the ring, recomputed at the start of each
+    // probe (this mirrors dijkstra_termination_detection).
+    auto const probe_start = [](std::uint32_t const initiating,
+                                 std::uint32_t const n) {
+        std::uint32_t target = initiating;
+        if (0 == target)
+            target = n;
+        return target;
+    };
+
+    // Restarting the cursor for each of two probes reaches N-1 every time and
+    // never targets the initiator.
+    {
+        mock_send send({num_localities - 1});    // only the neighbor is alive
+        for (int probe = 0; probe != 2; ++probe)
+        {
+            std::uint32_t target =
+                probe_start(initiating_locality_id, num_localities);
+            HPX_TEST(
+                dijkstra_forward_token(target, initiating_locality_id, send));
+        }
+        std::vector<std::uint32_t> const expected_calls = {
+            num_localities - 1, num_localities - 1};
+        HPX_TEST(send.calls_ == expected_calls);
+        for (std::uint32_t const call : send.calls_)
+        {
+            HPX_TEST_NEQ(call, initiating_locality_id);
+        }
+    }
+
+    // The failure mode being guarded against: reusing the cursor consumed by
+    // the first probe makes the second walk fall straight through to the
+    // initiator, i.e. the token is handed to the initiator itself.
+    {
+        mock_send send({num_localities - 1});
+        std::uint32_t target =
+            probe_start(initiating_locality_id, num_localities);
+        HPX_TEST(dijkstra_forward_token(target, initiating_locality_id, send));
+        HPX_TEST_EQ(target, num_localities - 1);    // cursor consumed
+
+        bool const reused =
+            dijkstra_forward_token(target, initiating_locality_id, send);
+        HPX_TEST(!reused);
+        HPX_TEST_EQ(target, initiating_locality_id);
+    }
+}
+
 int main()
 {
     test_immediate_neighbor_alive();
@@ -193,6 +252,7 @@ int main()
     test_fallback_to_initiator_also_unreachable();
     test_wrap_around_before_forwarding();
     test_no_forwarding_when_already_at_initiator();
+    test_repeated_probe_restarts_cursor();
 
     return hpx::util::report_errors();
 }


### PR DESCRIPTION
## Proposed Changes

  - Restart the Dijkstra termination-detection probe cursor at the start of every probe instead of once before the loop.
  - Add a regression case for it to the `dijkstra_forward_token` unit tests.

## Any background context you want to provide?

`dijkstra_termination_detection` set `target_id` once, before the retry loop. `dijkstra_forward_token` consumes that cursor (it walks it backwards in place), so a repeated probe resumed from the leftover value instead of the initiator's predecessor. Once it reaches the initiator, every further probe hands the token to the initiator itself and termination never completes — the console just spins re-issuing probes.

It only shows up at `--hpx:threads=1` (what the CI runs); with more threads the first probe succeeds before a second is needed. When it hits, every distributed test on MPI/LCI/LCW hangs at the CTest timeout while TCP passes. Moving the cursor init inside the loop fixes it.

On testing: the hang can't be triggered reliably from a unit test — it needs a locality still non-passive when the first probe returns. I reproduced and git-bisected it on the cluster instead (10/10 hangs at `threads=1` from the commit that added `dijkstra_forward_token`, 0/10 on its parent; a live trace showed the console sending `target=0 initiating=0` on repeat). The added unit case pins the contract at the same layer as the existing tests: a restarted cursor reaches N-1 every probe and never the initiator, and reusing a consumed cursor falls through to the initiator.

Not fixed here: at `threads=1` there's a second, separate shutdown hang once termination completes — the console then spins in `runtime_support::stop()` on `is_busy()` because the `all_reduce` communicator doesn't drain (and `shutdown_timeout=-1` maps to no timeout). That's in the collectives/supervision path, so I left it out of this PR. This removes the termination-detection livelock but doesn't green `threads=1` CI on its own.

## Checklist

- [x] I have fixed a bug and have added a regression test.
