### PR TITLE
Dijkstra termination detection

### DIFF
--- a/libs/full/runtime_distributed/tests/regressions/CMakeLists.txt
+++ b/libs/full/runtime_distributed/tests/regressions/CMakeLists.txt
@@ -1,14 +1,37 @@
-# Copyright (c) 2020-2025 The STE||AR-Group
+# Copyright (c) 2020-2026 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests multiple_init multiple_init_2918 shutdown_hang_6699
-          unhandled_exception_582
+set(tests
+    multiple_init multiple_init_2918 shutdown_hang_6699 unhandled_exception_582
+    dijkstra_termination_disconnected_locality_7474
+    dijkstra_termination_disconnected_localities_7474
 )
 
 set(unhandled_exception_582_PARAMETERS THREADS_PER_LOCALITY 1)
+set(dijkstra_termination_disconnected_locality_7474_FLAGS DEPENDENCIES
+                                                          process_component
+)
+add_hpx_executable(
+  dijkstra_termination_disconnected_locality_7474_worker INTERNAL_FLAGS
+  SOURCES dijkstra_termination_disconnected_locality_7474_worker.cpp
+  EXCLUDE_FROM_ALL
+  HPX_PREFIX ${HPX_BUILD_PREFIX}
+  FOLDER "Tests/Regressions/Modules/Full/RuntimeDistributed"
+)
+set(dijkstra_termination_disconnected_locality_7474_PARAMETERS
+    RUN_SERIAL
+    --launch=$<TARGET_FILE:dijkstra_termination_disconnected_locality_7474_worker>
+)
+set(dijkstra_termination_disconnected_localities_7474_FLAGS DEPENDENCIES
+                                                            process_component
+)
+set(dijkstra_termination_disconnected_localities_7474_PARAMETERS
+    RUN_SERIAL
+    --launch=$<TARGET_FILE:dijkstra_termination_disconnected_locality_7474_worker>
+)
 
 foreach(test ${tests})
   set(sources ${test}.cpp)
@@ -27,4 +50,35 @@ foreach(test ${tests})
   add_hpx_regression_test(
     "modules.runtime_distributed" ${test} ${${test}_PARAMETERS}
   )
+
+  # MSVC V1951 and V1952 expose ICE compiling this in C++20 module mode
+  if(HPX_WITH_CXX_MODULES
+     AND (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+     AND (MSVC_VERSION LESS_EQUAL 1952)
+  )
+    target_compile_definitions(
+      ${test}_test PRIVATE HPX_HAVE_FORCE_NO_CXX_MODULES
+    )
+  endif()
 endforeach()
+
+add_dependencies(
+  dijkstra_termination_disconnected_locality_7474_test
+  dijkstra_termination_disconnected_locality_7474_worker
+)
+
+add_dependencies(
+  dijkstra_termination_disconnected_localities_7474_test
+  dijkstra_termination_disconnected_locality_7474_worker
+)
+
+# MSVC V1951 and V1952 expose ICE compiling this in C++20 module mode
+if(HPX_WITH_CXX_MODULES
+   AND (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+   AND (MSVC_VERSION LESS_EQUAL 1952)
+)
+  target_compile_definitions(
+    dijkstra_termination_disconnected_locality_7474_worker
+    PRIVATE HPX_HAVE_FORCE_NO_CXX_MODULES
+  )
+endif()

--- a/libs/full/runtime_distributed/tests/regressions/dijkstra_termination_disconnected_localities_7474.cpp
+++ b/libs/full/runtime_distributed/tests/regressions/dijkstra_termination_disconnected_localities_7474.cpp
@@ -1,0 +1,117 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/process.hpp>
+#include <hpx/modules/actions.hpp>
+#include <hpx/modules/naming_base.hpp>
+#include <hpx/modules/program_options.hpp>
+#include <hpx/modules/runtime_distributed.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace {
+
+    std::atomic<bool> consulted(false);
+}    // namespace
+
+void busy_work()
+{
+    consulted.store(true);
+    hpx::this_thread::suspend(std::chrono::milliseconds(200));
+}
+HPX_PLAIN_ACTION(busy_work, busy_work_action)
+
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    namespace process = hpx::components::process;
+
+    std::vector<hpx::id_type> workers;
+    std::vector<process::child> children;
+
+    for (std::size_t i = 0; i != 4; ++i)
+    {
+        std::vector<hpx::id_type> const localities_before =
+            hpx::find_remote_localities();
+
+        process::child child = process::launch_connecting_locality(
+            vm["launch"].as<std::string>(), {"--hpx:threads=1"}, {}, i);
+        child.wait();
+        HPX_TEST(child);
+
+        std::vector<hpx::id_type> const localities_after =
+            hpx::find_remote_localities();
+        auto const new_locality = std::ranges::find_if(localities_after,
+            [&localities_before](hpx::id_type const& candidate) {
+                return std::ranges::find(localities_before, candidate) ==
+                    localities_before.end();
+            });
+
+        HPX_TEST(new_locality != localities_after.end());
+        if (new_locality != localities_after.end())
+        {
+            workers.push_back(*new_locality);
+        }
+        children.push_back(HPX_MOVE(child));
+    }
+
+    HPX_TEST_EQ(workers.size(), static_cast<std::size_t>(4));
+    if (workers.size() != 4)
+    {
+        return hpx::finalize();
+    }
+
+    std::vector<hpx::future<void>> work;
+    work.reserve(workers.size());
+    for (hpx::id_type const& worker : workers)
+    {
+        work.push_back(hpx::async<busy_work_action>(worker));
+    }
+    hpx::wait_all(work);
+
+    for (hpx::id_type const& worker : workers)
+    {
+        HPX_TEST_EQ(hpx::force_disconnect(worker), 0);
+    }
+
+    // Regression test: termination detection must finish even when every
+    // late-connected locality has disconnected.
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    using hpx::program_options::options_description;
+    using hpx::program_options::value;
+
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    // clang-format off
+    desc_commandline.add_options()
+        ("launch", value<std::string>()->required(),
+        "worker executable to launch as a connecting locality")
+    ;
+    // clang-format on
+
+    std::vector<std::string> const cfg = {
+        "hpx.expect_connecting_localities!=1"};
+
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
+
+    return hpx::util::report_errors();
+}

--- a/libs/full/runtime_distributed/tests/regressions/dijkstra_termination_disconnected_locality_7474.cpp
+++ b/libs/full/runtime_distributed/tests/regressions/dijkstra_termination_disconnected_locality_7474.cpp
@@ -1,0 +1,133 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/process.hpp>
+#include <hpx/modules/actions.hpp>
+#include <hpx/modules/naming_base.hpp>
+#include <hpx/modules/program_options.hpp>
+#include <hpx/modules/runtime_distributed.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace {
+
+    std::atomic<bool> consulted(false);
+}    // namespace
+
+bool was_consulted()
+{
+    return consulted.load();
+}
+HPX_PLAIN_ACTION(was_consulted, was_consulted_action)
+
+// Keep the thread-manager non-passive briefly so termination detection has to
+// do real round-trips instead of resolving on the very first pass.
+void busy_work()
+{
+    consulted.store(true);
+    hpx::this_thread::suspend(std::chrono::milliseconds(200));
+}
+HPX_PLAIN_ACTION(busy_work, busy_work_action)
+
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    namespace process = hpx::components::process;
+
+    std::vector<hpx::id_type> workers;
+    std::vector<process::child> children;
+
+    for (std::size_t i = 0; i != 4; ++i)
+    {
+        std::vector<hpx::id_type> const localities_before =
+            hpx::find_remote_localities();
+
+        process::child child = process::launch_connecting_locality(
+            vm["launch"].as<std::string>(), {"--hpx:threads=1"}, {}, i);
+        child.wait();
+        HPX_TEST(child);
+
+        std::vector<hpx::id_type> const localities_after =
+            hpx::find_remote_localities();
+        auto const new_locality = std::ranges::find_if(localities_after,
+            [&localities_before](hpx::id_type const& candidate) {
+                return std::ranges::find(localities_before, candidate) ==
+                    localities_before.end();
+            });
+
+        HPX_TEST(new_locality != localities_after.end());
+        if (new_locality != localities_after.end())
+        {
+            workers.push_back(*new_locality);
+        }
+        children.push_back(HPX_MOVE(child));
+    }
+
+    HPX_TEST_EQ(workers.size(), static_cast<std::size_t>(4));
+    if (workers.size() != 4)
+    {
+        return hpx::finalize();
+    }
+
+    std::vector<hpx::future<void>> work;
+    work.reserve(workers.size());
+    for (hpx::id_type const& worker : workers)
+    {
+        work.push_back(hpx::async<busy_work_action>(worker));
+    }
+    hpx::wait_all(work);
+
+    // In the ring [root, worker 0, worker 1, worker 2, worker 3], worker 1 is
+    // neither the initiator nor its immediate neighbour.
+    std::size_t constexpr victim = 1;
+    HPX_TEST_EQ(hpx::force_disconnect(workers[victim]), 0);
+
+    hpx::this_thread::suspend(std::chrono::milliseconds(500));
+
+    for (std::size_t i = 0; i != workers.size(); ++i)
+    {
+        if (i != victim)
+        {
+            HPX_TEST(hpx::async<was_consulted_action>(workers[i]).get());
+        }
+    }
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    using hpx::program_options::options_description;
+    using hpx::program_options::value;
+
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    // clang-format off
+    desc_commandline.add_options()
+        ("launch", value<std::string>()->required(),
+        "worker executable to launch as a connecting locality")
+    ;
+    // clang-format on
+
+    std::vector<std::string> const cfg = {
+        "hpx.expect_connecting_localities!=1"};
+
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
+
+    return hpx::util::report_errors();
+}

--- a/libs/full/runtime_distributed/tests/regressions/dijkstra_termination_disconnected_locality_7474_worker.cpp
+++ b/libs/full/runtime_distributed/tests/regressions/dijkstra_termination_disconnected_locality_7474_worker.cpp
@@ -1,0 +1,45 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/modules/actions.hpp>
+
+#include <atomic>
+#include <chrono>
+
+namespace {
+
+    std::atomic<bool> consulted(false);
+}    // namespace
+
+bool was_consulted()
+{
+    return consulted.load();
+}
+HPX_PLAIN_ACTION(was_consulted, was_consulted_action)
+
+void busy_work()
+{
+    consulted.store(true);
+    hpx::this_thread::suspend(std::chrono::milliseconds(200));
+}
+HPX_PLAIN_ACTION(busy_work, busy_work_action)
+
+int hpx_main()
+{
+    // The console locality disconnects this late-connected worker or shuts the
+    // complete application down.
+    return 0;
+}
+
+int main(int argc, char* argv[])
+{
+    hpx::init_params init_args;
+    init_args.mode = hpx::runtime_mode::connect;
+
+    return hpx::init(argc, argv, init_args);
+}


### PR DESCRIPTION
##  Add regression test for Dijkstra termination detection after locality disconnect (#7474)

## Dijkstra termination detection: regression tests for locality disconnect (#7474)

### Summary
Adds two new distributed regression tests (plus a small worker executable) that exercise termination detection when connecting localities disconnect mid-flight. These guard against regressions in the Dijkstra-style termination algorithm when a late-connected locality drops out before or during a global quiescence check.

### What's added
- **`dijkstra_termination_disconnected_locality_7474.cpp`** — Launches 4 connecting localities in a chain (ring topology: root → worker0 → worker1 → worker2 → worker3), runs a short "busy" action on each worker to keep the thread-manager active long enough that termination detection must actually round-trip, then force-disconnects a single "victim" locality (worker 1, chosen because it is neither the initiator nor an immediate ring neighbor). The test asserts the remaining workers were consulted during termination detection and that `hpx::finalize()` still completes cleanly.
- **`dijkstra_termination_disconnected_localities_7474.cpp`** — Same setup with 4 connecting localities, but disconnects *all* of them after the busy work completes, verifying that termination detection still resolves and shutdown finishes even when every late-connected locality has dropped.
- **`dijkstra_termination_disconnected_locality_7474_worker.cpp`** — Minimal worker executable (runtime mode `connect`) used by both tests as the process launched via `process::launch_connecting_locality`. Exposes `was_consulted_action`/`busy_work_action` plain actions used to observe locality consultation state during the delayed work window.
- **`CMakeLists.txt`** — Registers both new regression tests, builds the worker executable (`EXCLUDE_FROM_ALL`, depends on `process_component`), wires up `RUN_SERIAL` + `--launch=$<TARGET_FILE:...>` launch parameters, adds explicit `add_dependencies` so each test target waits on the worker executable, and applies the existing MSVC C++20-modules ICE workaround (`HPX_HAVE_FORCE_NO_CXX_MODULES`) to the new worker target as well.

### Motivation
Reproduces and locks in the fix/behavior for issue #7474, where termination detection could hang or misbehave after connected localities disconnect from the network. Both single- and all-locality disconnect scenarios are covered.

### Testing
- New tests are run serially (`RUN_SERIAL`) since they spawn real child processes and manipulate the distributed runtime's locality membership.
- No changes to production runtime code — this PR is test-only.
