### PR TITLE
tracing: skip Tracy work when no profiler is connected

### DIFF
--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -518,6 +518,10 @@ if(HPX_WITH_ITTNOTIFY)
   target_link_libraries(hpx_core PUBLIC Amplifier::amplifier)
 endif()
 
+if(HPX_WITH_TRACY)
+  target_link_libraries(hpx_core PUBLIC tracy::tracy)
+endif()
+
 if(TARGET STDEXEC::stdexec)
   target_link_libraries(hpx_core INTERFACE STDEXEC::stdexec)
 endif()

--- a/libs/core/tracing/include/hpx/tracing/backends/tracy.hpp
+++ b/libs/core/tracing/include/hpx/tracing/backends/tracy.hpp
@@ -17,6 +17,8 @@
 
 #include <hpx/modules/tracy.hpp>
 
+#include <tracy/TracyC.h>
+
 #include <hpx/config/warnings_prefix.hpp>
 
 namespace hpx::tracing {
@@ -34,11 +36,7 @@ namespace hpx::tracing {
 
     // Inline connection-gate. When no Tracy client is attached, the per-task
     // hot-path entries below short-circuit at the call site to a single
-    // atomic load. Forward-declared instead of including <tracy/TracyC.h>
-    // so the ~60 TUs that transitively include hpx/tracing don't pick up
-    // Tracy's C API header; the symbol resolves at link time.
-    extern "C" std::int32_t ___tracy_connected(void);
-
+    // atomic load.
     namespace detail {
         inline bool is_profiler_connected() noexcept
         {

--- a/libs/core/tracing/include/hpx/tracing/backends/tracy.hpp
+++ b/libs/core/tracing/include/hpx/tracing/backends/tracy.hpp
@@ -9,6 +9,7 @@
 
 #include <hpx/config.hpp>
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -151,7 +152,7 @@ namespace hpx::tracing {
     // are safe whether Tracy is connected or not, so we gate only the four
     // take/release member functions. The ctor snapshots the connected state
     // so that a lock announced while disconnected keeps skipping its
-    // per-cycle events even if a client connects mid-lifetime — announce
+    // per-cycle events even if a client connects mid-lifetime -- announce
     // and per-cycle events stay consistent.
     HPX_CXX_CORE_EXPORT struct HPX_CORE_EXPORT [[maybe_unused]] lock_context
     {
@@ -192,6 +193,7 @@ namespace hpx::tracing {
     }    // namespace detail
 
     ////////////////////////////////////////////////////////////////////////////
+    /// \brief Set the OS thread name in the profiler timeline.
     HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void set_thread_name(
         char const* name) noexcept;
 
@@ -201,6 +203,8 @@ namespace hpx::tracing {
             char const* name) noexcept;
     }    // namespace detail
 
+    /// \brief Rename the currently active region on this thread; returns
+    ///        the previous name, or the caller's input if no rename occurred.
     // Disconnected path returns the caller's input, mirroring the underlying
     // `hpx::tracy::detail::rename_region`'s in-fiber no-op. Returning nullptr
     // would risk a strlen(nullptr) if a caller later restored a saved name.
@@ -283,6 +287,12 @@ namespace hpx::tracing {
     // Inline gate wrappers. When the profiler is not connected, the whole
     // per-task snprintf/message/log-string chain is short-circuited at the
     // call site; only a single atomic load runs.
+
+    /// \brief Task-lifecycle signal: task description registered before the
+    ///        thread object exists.
+    ///
+    /// \param parent_task_id  Optional pointer to the spawning task, for
+    ///                        parent-child correlation.
     inline void task_staged(
         char const* description, void const* parent_task_id = nullptr) noexcept
     {
@@ -291,6 +301,10 @@ namespace hpx::tracing {
         detail::task_staged_impl(description, parent_task_id);
     }
 
+    /// \brief Task-lifecycle signal: thread object fully constructed.
+    ///
+    /// \param parent_task_id  Optional pointer to the spawning task, for
+    ///                        parent-child correlation.
     inline void task_created(char const* description, void const* task_id,
         void const* parent_task_id = nullptr) noexcept
     {
@@ -299,6 +313,9 @@ namespace hpx::tracing {
         detail::task_created_impl(description, task_id, parent_task_id);
     }
 
+    /// \brief Task-lifecycle signal: task begins executing on a worker thread.
+    ///
+    /// \param worker_thread  Index of the worker executing this task.
     inline void task_executing(void const* task_id, char const* description,
         std::size_t worker_thread) noexcept
     {
@@ -307,6 +324,7 @@ namespace hpx::tracing {
         detail::task_executing_impl(task_id, description, worker_thread);
     }
 
+    /// \brief Task-lifecycle signal: task voluntarily yielded to the scheduler.
     inline void task_yielded(
         void const* task_id, char const* description) noexcept
     {
@@ -315,6 +333,9 @@ namespace hpx::tracing {
         detail::task_yielded_impl(task_id, description);
     }
 
+    /// \brief Task-lifecycle signal: task blocked on an external resource.
+    ///
+    /// \param reason  Optional description of what the task is waiting on.
     inline void task_suspended(void const* task_id, char const* description,
         char const* reason = nullptr) noexcept
     {
@@ -323,6 +344,10 @@ namespace hpx::tracing {
         detail::task_suspended_impl(task_id, description, reason);
     }
 
+    /// \brief Task-lifecycle signal: task unblocked and returned to a
+    ///        pending state.
+    ///
+    /// \param wake_reason  Optional description of what unblocked the task.
     inline void task_resumed(void const* task_id, char const* description,
         char const* wake_reason = nullptr) noexcept
     {
@@ -331,6 +356,7 @@ namespace hpx::tracing {
         detail::task_resumed_impl(task_id, description, wake_reason);
     }
 
+    /// \brief Task-lifecycle signal: task finished its execution loop.
     inline void task_completed(
         void const* task_id, char const* description) noexcept
     {
@@ -339,6 +365,7 @@ namespace hpx::tracing {
         detail::task_completed_impl(task_id, description);
     }
 
+    /// \brief Task-lifecycle signal: task identity removed from scheduler maps.
     inline void task_deleted(void const* task_id) noexcept
     {
         if (!detail::is_profiler_connected())
@@ -368,11 +395,21 @@ namespace hpx::tracing {
         HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void future_exception_set_impl(
             void const* future_id, char const* desc = nullptr) noexcept;
 
-        HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void continuation_run_impl(
-            void const* task_id = nullptr) noexcept;
+        // Active-continuations counter. Updated unconditionally by the
+        // continuation_run / continuation_finished inline wrappers below,
+        // even when no profiler is attached, so the tally stays consistent
+        // across connect/disconnect transitions. Only the Tracy emission
+        // (message + sample_value + fiber text) is gated. If both sides
+        // were gated instead, a run that started disconnected and finished
+        // connected would decrement without a matching increment (and the
+        // reverse would leak a permanent positive drift).
+        HPX_CORE_EXPORT extern std::atomic<std::int64_t> g_active_continuations;
 
-        HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void continuation_finished_impl(
-            void const* task_id = nullptr) noexcept;
+        HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void continuation_run_emit(
+            void const* task_id, std::int64_t current_active) noexcept;
+
+        HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void continuation_finished_emit(
+            std::int64_t current_active) noexcept;
 
         HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void handle_on_completed_fired_impl(
             void const* task_id = nullptr) noexcept;
@@ -420,18 +457,27 @@ namespace hpx::tracing {
     ///        executing, correlated with the source future state.
     inline void continuation_run(void const* task_id = nullptr) noexcept
     {
+        // Counter update runs unconditionally so the tally stays consistent
+        // across connect/disconnect transitions -- see g_active_continuations.
+        auto const current_active = detail::g_active_continuations.fetch_add(
+                                        1, std::memory_order_relaxed) +
+            1;
         if (!detail::is_profiler_connected())
             return;
-        detail::continuation_run_impl(task_id);
+        detail::continuation_run_emit(task_id, current_active);
     }
 
     /// \brief Consumer-side signal: a continuation has finished
     ///        executing.
-    inline void continuation_finished(void const* task_id = nullptr) noexcept
+    inline void continuation_finished(
+        void const* /* task_id */ = nullptr) noexcept
     {
+        auto const current_active = detail::g_active_continuations.fetch_sub(
+                                        1, std::memory_order_relaxed) -
+            1;
         if (!detail::is_profiler_connected())
             return;
-        detail::continuation_finished_impl(task_id);
+        detail::continuation_finished_emit(current_active);
     }
 
     /// \brief Consumer-side signal: handle_on_completed fired,

--- a/libs/core/tracing/include/hpx/tracing/backends/tracy.hpp
+++ b/libs/core/tracing/include/hpx/tracing/backends/tracy.hpp
@@ -403,13 +403,19 @@ namespace hpx::tracing {
         // were gated instead, a run that started disconnected and finished
         // connected would decrement without a matching increment (and the
         // reverse would leak a permanent positive drift).
+        //
+        // The plot value is loaded inside each _emit body rather than
+        // snapshotted at the fetch_add/fetch_sub call site, so that Tracy
+        // records the counter's value at emit time rather than at update
+        // time. This avoids the reordering artefact where two concurrent
+        // continuations could publish stale snapshots to the plot.
         HPX_CORE_EXPORT extern std::atomic<std::int64_t> g_active_continuations;
 
         HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void continuation_run_emit(
-            void const* task_id, std::int64_t current_active) noexcept;
+            void const* task_id) noexcept;
 
-        HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void continuation_finished_emit(
-            std::int64_t current_active) noexcept;
+        HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void
+        continuation_finished_emit() noexcept;
 
         HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void handle_on_completed_fired_impl(
             void const* task_id = nullptr) noexcept;
@@ -459,12 +465,10 @@ namespace hpx::tracing {
     {
         // Counter update runs unconditionally so the tally stays consistent
         // across connect/disconnect transitions -- see g_active_continuations.
-        auto const current_active = detail::g_active_continuations.fetch_add(
-                                        1, std::memory_order_relaxed) +
-            1;
+        detail::g_active_continuations.fetch_add(1, std::memory_order_relaxed);
         if (!detail::is_profiler_connected())
             return;
-        detail::continuation_run_emit(task_id, current_active);
+        detail::continuation_run_emit(task_id);
     }
 
     /// \brief Consumer-side signal: a continuation has finished
@@ -472,12 +476,10 @@ namespace hpx::tracing {
     inline void continuation_finished(
         void const* /* task_id */ = nullptr) noexcept
     {
-        auto const current_active = detail::g_active_continuations.fetch_sub(
-                                        1, std::memory_order_relaxed) -
-            1;
+        detail::g_active_continuations.fetch_sub(1, std::memory_order_relaxed);
         if (!detail::is_profiler_connected())
             return;
-        detail::continuation_finished_emit(current_active);
+        detail::continuation_finished_emit();
     }
 
     /// \brief Consumer-side signal: handle_on_completed fired,

--- a/libs/core/tracing/include/hpx/tracing/backends/tracy.hpp
+++ b/libs/core/tracing/include/hpx/tracing/backends/tracy.hpp
@@ -31,6 +31,20 @@ namespace hpx::tracing {
         return name;
     }
 
+    // Inline connection-gate. When no Tracy client is attached, the per-task
+    // hot-path entries below short-circuit at the call site to a single
+    // atomic load. Forward-declared instead of including <tracy/TracyC.h>
+    // so the ~60 TUs that transitively include hpx/tracing don't pick up
+    // Tracy's C API header; the symbol resolves at link time.
+    extern "C" std::int32_t ___tracy_connected(void);
+
+    namespace detail {
+        inline bool is_profiler_connected() noexcept
+        {
+            return ___tracy_connected() != 0;
+        }
+    }    // namespace detail
+
     ////////////////////////////////////////////////////////////////////////////
     HPX_CXX_CORE_EXPORT struct region_init_data
     {
@@ -51,6 +65,10 @@ namespace hpx::tracing {
     };
 
     ////////////////////////////////////////////////////////////////////////////
+    // RAII correctness: instances constructed while disconnected must not
+    // emit on destruction, even if a client connects mid-lifetime. The
+    // inner `hpx::tracy::*` impl captures the connected state at ctor and
+    // honours it in its own dtor; the outer wrapper defers to that byte.
     HPX_CXX_CORE_EXPORT struct HPX_CORE_EXPORT region
     {
         explicit region(loop_context&, region_init_data const& init_data,
@@ -105,6 +123,12 @@ namespace hpx::tracing {
         ~fiber_suspend_region();
 
     private:
+        // Private delegating ctor so `is_profiler_connected()` is queried
+        // exactly once, then the snapshotted `active` flag is passed twice
+        // into `impl`'s ctor without a second atomic load that could race
+        // with a mid-lifetime client connect.
+        explicit fiber_suspend_region(char const* desc, bool active) noexcept;
+
         hpx::tracy::fiber_suspend_region impl;
     };
 
@@ -123,6 +147,12 @@ namespace hpx::tracing {
     };
 
     ////////////////////////////////////////////////////////////////////////////
+    // lock_context: TracyCLockAnnounce / TracyCLockTerminate in ctor/dtor
+    // are safe whether Tracy is connected or not, so we gate only the four
+    // take/release member functions. The ctor snapshots the connected state
+    // so that a lock announced while disconnected keeps skipping its
+    // per-cycle events even if a client connects mid-lifetime — announce
+    // and per-cycle events stay consistent.
     HPX_CXX_CORE_EXPORT struct HPX_CORE_EXPORT [[maybe_unused]] lock_context
     {
         explicit lock_context(
@@ -142,6 +172,7 @@ namespace hpx::tracing {
         void after_unlock() const noexcept;
 
     private:
+        bool active_;
         hpx::tracy::lock_data impl;
     };
 
@@ -165,8 +196,20 @@ namespace hpx::tracing {
         char const* name) noexcept;
 
     ////////////////////////////////////////////////////////////////////////////
-    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT char const* rename_region(
-        char const* name) noexcept;
+    namespace detail {
+        HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT char const* rename_region_impl(
+            char const* name) noexcept;
+    }    // namespace detail
+
+    // Disconnected path returns the caller's input, mirroring the underlying
+    // `hpx::tracy::detail::rename_region`'s in-fiber no-op. Returning nullptr
+    // would risk a strlen(nullptr) if a caller later restored a saved name.
+    inline char const* rename_region(char const* name) noexcept
+    {
+        if (!detail::is_profiler_connected())
+            return name;
+        return detail::rename_region_impl(name);
+    }
 
     ////////////////////////////////////////////////////////////////////////////
     HPX_CXX_CORE_EXPORT struct [[maybe_unused]] task_timer_data
@@ -206,30 +249,102 @@ namespace hpx::tracing {
         }
     };
 
-    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void task_staged(
-        char const* description, void const* parent_task_id = nullptr) noexcept;
+    namespace detail {
+        HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void task_staged_impl(
+            char const* description,
+            void const* parent_task_id = nullptr) noexcept;
 
-    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void task_created(
-        char const* description, void const* task_id,
-        void const* parent_task_id = nullptr) noexcept;
+        HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void task_created_impl(
+            char const* description, void const* task_id,
+            void const* parent_task_id = nullptr) noexcept;
 
-    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void task_executing(void const* task_id,
-        char const* description, std::size_t worker_thread) noexcept;
+        HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void task_executing_impl(
+            void const* task_id, char const* description,
+            std::size_t worker_thread) noexcept;
 
-    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void task_yielded(
-        void const* task_id, char const* description) noexcept;
+        HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void task_yielded_impl(
+            void const* task_id, char const* description) noexcept;
 
-    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void task_suspended(void const* task_id,
-        char const* description, char const* reason = nullptr) noexcept;
+        HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void task_suspended_impl(
+            void const* task_id, char const* description,
+            char const* reason = nullptr) noexcept;
 
-    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void task_resumed(void const* task_id,
-        char const* description, char const* wake_reason = nullptr) noexcept;
+        HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void task_resumed_impl(
+            void const* task_id, char const* description,
+            char const* wake_reason = nullptr) noexcept;
 
-    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void task_completed(
-        void const* task_id, char const* description) noexcept;
+        HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void task_completed_impl(
+            void const* task_id, char const* description) noexcept;
 
-    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void task_deleted(
-        void const* task_id) noexcept;
+        HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void task_deleted_impl(
+            void const* task_id) noexcept;
+    }    // namespace detail
+
+    // Inline gate wrappers. When the profiler is not connected, the whole
+    // per-task snprintf/message/log-string chain is short-circuited at the
+    // call site; only a single atomic load runs.
+    inline void task_staged(
+        char const* description, void const* parent_task_id = nullptr) noexcept
+    {
+        if (!detail::is_profiler_connected())
+            return;
+        detail::task_staged_impl(description, parent_task_id);
+    }
+
+    inline void task_created(char const* description, void const* task_id,
+        void const* parent_task_id = nullptr) noexcept
+    {
+        if (!detail::is_profiler_connected())
+            return;
+        detail::task_created_impl(description, task_id, parent_task_id);
+    }
+
+    inline void task_executing(void const* task_id, char const* description,
+        std::size_t worker_thread) noexcept
+    {
+        if (!detail::is_profiler_connected())
+            return;
+        detail::task_executing_impl(task_id, description, worker_thread);
+    }
+
+    inline void task_yielded(
+        void const* task_id, char const* description) noexcept
+    {
+        if (!detail::is_profiler_connected())
+            return;
+        detail::task_yielded_impl(task_id, description);
+    }
+
+    inline void task_suspended(void const* task_id, char const* description,
+        char const* reason = nullptr) noexcept
+    {
+        if (!detail::is_profiler_connected())
+            return;
+        detail::task_suspended_impl(task_id, description, reason);
+    }
+
+    inline void task_resumed(void const* task_id, char const* description,
+        char const* wake_reason = nullptr) noexcept
+    {
+        if (!detail::is_profiler_connected())
+            return;
+        detail::task_resumed_impl(task_id, description, wake_reason);
+    }
+
+    inline void task_completed(
+        void const* task_id, char const* description) noexcept
+    {
+        if (!detail::is_profiler_connected())
+            return;
+        detail::task_completed_impl(task_id, description);
+    }
+
+    inline void task_deleted(void const* task_id) noexcept
+    {
+        if (!detail::is_profiler_connected())
+            return;
+        detail::task_deleted_impl(task_id);
+    }
 
     ////////////////////////////////////////////////////////////////////////////
     // Causal tracing: future fulfillment signals.
@@ -246,55 +361,119 @@ namespace hpx::tracing {
     // newly-woken consumer) and before `cond_.notify_one()` fires (so the
     // producer message precedes the consumer wake-up in wall-clock order).
 
+    namespace detail {
+        HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void future_fulfilled_impl(
+            void const* future_id, char const* desc = nullptr) noexcept;
+
+        HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void future_exception_set_impl(
+            void const* future_id, char const* desc = nullptr) noexcept;
+
+        HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void continuation_run_impl(
+            void const* task_id = nullptr) noexcept;
+
+        HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void continuation_finished_impl(
+            void const* task_id = nullptr) noexcept;
+
+        HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void handle_on_completed_fired_impl(
+            void const* task_id = nullptr) noexcept;
+
+        HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void work_stolen_impl(
+            std::size_t thief_id, std::size_t victim_id, void const* task_id,
+            char const* desc = nullptr) noexcept;
+
+        HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void frame_mark_impl(
+            char const* name = nullptr) noexcept;
+
+        HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void os_thread_sleep_impl(
+            std::size_t num_thread) noexcept;
+    }    // namespace detail
+
     /// \brief Producer-side signal: a future shared state was set to a value.
     ///
-    /// \param future_id  Pointer to the `future_data` shared state. Used as a
-    ///                   stable identifier to correlate producer and consumer
-    ///                   events in the Tracy message log.
+    /// \param future_id  Pointer to the `future_data` shared state. Used
+    ///                   as a stable identifier to correlate producer and
+    ///                   consumer events in the Tracy message log.
     /// \param desc       Optional description of the producing context
     ///                   (e.g. the name of the promise or task).
-    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void future_fulfilled(
-        void const* future_id, char const* desc = nullptr) noexcept;
+    inline void future_fulfilled(
+        void const* future_id, char const* desc = nullptr) noexcept
+    {
+        if (!detail::is_profiler_connected())
+            return;
+        detail::future_fulfilled_impl(future_id, desc);
+    }
 
     /// \brief Producer-side signal: a future shared state was set with an
     ///        exception.
     ///
     /// \param future_id  Pointer to the `future_data` shared state.
     /// \param desc       Optional description of the producing context.
-    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void future_exception_set(
-        void const* future_id, char const* desc = nullptr) noexcept;
+    inline void future_exception_set(
+        void const* future_id, char const* desc = nullptr) noexcept
+    {
+        if (!detail::is_profiler_connected())
+            return;
+        detail::future_exception_set_impl(future_id, desc);
+    }
 
-    /// \brief Consumer-side signal: a continuation has started executing,
-    ///        correlated with the source future state.
-    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void continuation_run(
-        void const* task_id = nullptr) noexcept;
+    /// \brief Consumer-side signal: a continuation has started
+    ///        executing, correlated with the source future state.
+    inline void continuation_run(void const* task_id = nullptr) noexcept
+    {
+        if (!detail::is_profiler_connected())
+            return;
+        detail::continuation_run_impl(task_id);
+    }
 
-    /// \brief Consumer-side signal: a continuation has finished executing.
-    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void continuation_finished(
-        void const* task_id = nullptr) noexcept;
+    /// \brief Consumer-side signal: a continuation has finished
+    ///        executing.
+    inline void continuation_finished(void const* task_id = nullptr) noexcept
+    {
+        if (!detail::is_profiler_connected())
+            return;
+        detail::continuation_finished_impl(task_id);
+    }
 
-    /// \brief Consumer-side signal: handle_on_completed fired, dispatching
-    ///        registered continuations.
-    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void handle_on_completed_fired(
-        void const* task_id = nullptr) noexcept;
+    /// \brief Consumer-side signal: handle_on_completed fired,
+    ///        dispatching registered continuations.
+    inline void handle_on_completed_fired(
+        void const* task_id = nullptr) noexcept
+    {
+        if (!detail::is_profiler_connected())
+            return;
+        detail::handle_on_completed_fired_impl(task_id);
+    }
 
-    /// \brief Signal emitted when a worker thread steals a task from another worker.
-    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void work_stolen(std::size_t thief_id,
-        std::size_t victim_id, void const* task_id,
-        char const* desc = nullptr) noexcept;
+    /// \brief Signal emitted when a worker thread steals a task from
+    ///        another worker.
+    inline void work_stolen(std::size_t thief_id, std::size_t victim_id,
+        void const* task_id, char const* desc = nullptr) noexcept
+    {
+        if (!detail::is_profiler_connected())
+            return;
+        detail::work_stolen_impl(thief_id, victim_id, task_id, desc);
+    }
 
     /// \brief Emit a frame/stage boundary marker in Tracy timeline.
     ///
     /// \param name  Optional name for the frame/stage.
-    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void frame_mark(
-        char const* name = nullptr) noexcept;
+    inline void frame_mark(char const* name = nullptr) noexcept
+    {
+        if (!detail::is_profiler_connected())
+            return;
+        detail::frame_mark_impl(name);
+    }
 
-    /// \brief Point message emitted just before an OS worker thread suspends on
-    ///        its condition variable.
+    /// \brief Point message emitted just before an OS worker thread suspends
+    ///        on its condition variable.
     ///
     /// \param num_thread  Index of the worker thread entering sleep.
-    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void os_thread_sleep(
-        std::size_t num_thread) noexcept;
+    inline void os_thread_sleep(std::size_t num_thread) noexcept
+    {
+        if (!detail::is_profiler_connected())
+            return;
+        detail::os_thread_sleep_impl(num_thread);
+    }
 
     HPX_CXX_CORE_EXPORT constexpr void tracing_init(
         char const*, int, char**, std::uint32_t = 0, std::uint32_t = 1) noexcept

--- a/libs/core/tracing/src/backends/tracy.cpp
+++ b/libs/core/tracing/src/backends/tracy.cpp
@@ -372,8 +372,7 @@ namespace hpx::tracing {
         // Tracy is connected or not.
         HPX_CORE_EXPORT std::atomic<std::int64_t> g_active_continuations{0};
 
-        void continuation_run_emit(
-            void const* task_id, std::int64_t const current_active) noexcept
+        void continuation_run_emit(void const* task_id) noexcept
         {
             char buffer[256];
             if (task_id)
@@ -391,16 +390,20 @@ namespace hpx::tracing {
             // Embed directly into active fiber visual zone text
             hpx::tracy::detail::add_zone_text_to_fiber(buffer, len);
 
-            // Update live time-series plot graph for Active Continuations
-            hpx::tracy::sample_value(
-                "Active Continuations", static_cast<double>(current_active));
+            // Sample the counter at emit time so Tracy's plot records the
+            // value as of this timestamp, not the snapshot taken at the
+            // fetch_add call site. Two concurrent emits can still see
+            // slightly different reads, but neither is stale.
+            hpx::tracy::sample_value("Active Continuations",
+                static_cast<double>(
+                    g_active_continuations.load(std::memory_order_relaxed)));
         }
 
-        void continuation_finished_emit(
-            std::int64_t const current_active) noexcept
+        void continuation_finished_emit() noexcept
         {
-            hpx::tracy::sample_value(
-                "Active Continuations", static_cast<double>(current_active));
+            hpx::tracy::sample_value("Active Continuations",
+                static_cast<double>(
+                    g_active_continuations.load(std::memory_order_relaxed)));
         }
 
         void handle_on_completed_fired_impl(void const* task_id) noexcept

--- a/libs/core/tracing/src/backends/tracy.cpp
+++ b/libs/core/tracing/src/backends/tracy.cpp
@@ -12,11 +12,11 @@
 #include <hpx/modules/tracy.hpp>
 #include <hpx/tracing/tracing.hpp>
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
-#include <mutex>
 #include <string>
 
 namespace hpx::tracing {
@@ -80,7 +80,7 @@ namespace hpx::tracing {
     fiber_region::~fiber_region() = default;
 
     ////////////////////////////////////////////////////////////////////////////
-    // fiber_suspend_region — inner impl runs suspend/resume unconditionally,
+    // fiber_suspend_region -- inner impl runs suspend/resume unconditionally,
     // so we only construct it when active. When not active, we pass nullptr
     // (see the inline ctor in tracy_tls.hpp, which gates on active).
 
@@ -98,7 +98,7 @@ namespace hpx::tracing {
     fiber_suspend_region::~fiber_suspend_region() = default;
 
     ////////////////////////////////////////////////////////////////////////////
-    // background_work_region — inner impl always emits start/stop_region, so
+    // background_work_region -- inner impl always emits start/stop_region, so
     // we forward the connected state explicitly.
 
     background_work_region::background_work_region(
@@ -110,7 +110,7 @@ namespace hpx::tracing {
     background_work_region::~background_work_region() = default;
 
     ////////////////////////////////////////////////////////////////////////////
-    // lock_context — see rationale in header.
+    // lock_context -- see rationale in header.
 
     lock_context::lock_context(
         char const* name, void const* /* addr */) noexcept
@@ -367,12 +367,13 @@ namespace hpx::tracing {
             hpx::tracy::detail::add_zone_text_to_fiber(buffer, len);
         }
 
-        namespace {
-            std::int64_t g_active_continuations{0};
-            std::mutex g_active_continuations_mtx;
-        }    // namespace
+        // Definition of the atomic counter declared extern in tracy.hpp.
+        // Updated by the inline continuation_{run,finished} wrappers whether
+        // Tracy is connected or not.
+        HPX_CORE_EXPORT std::atomic<std::int64_t> g_active_continuations{0};
 
-        void continuation_run_impl(void const* task_id) noexcept
+        void continuation_run_emit(
+            void const* task_id, std::int64_t const current_active) noexcept
         {
             char buffer[256];
             if (task_id)
@@ -390,25 +391,16 @@ namespace hpx::tracing {
             // Embed directly into active fiber visual zone text
             hpx::tracy::detail::add_zone_text_to_fiber(buffer, len);
 
-            // Update live time-series plot graph for Active Continuations in Tracy
-            std::int64_t current_active = 0;
-            {
-                std::lock_guard<std::mutex> lock(g_active_continuations_mtx);
-                current_active = ++g_active_continuations;
-                hpx::tracy::sample_value("Active Continuations",
-                    static_cast<double>(current_active));
-            }
+            // Update live time-series plot graph for Active Continuations
+            hpx::tracy::sample_value(
+                "Active Continuations", static_cast<double>(current_active));
         }
 
-        void continuation_finished_impl(void const* /* task_id */) noexcept
+        void continuation_finished_emit(
+            std::int64_t const current_active) noexcept
         {
-            std::int64_t current_active = 0;
-            {
-                std::lock_guard<std::mutex> lock(g_active_continuations_mtx);
-                current_active = --g_active_continuations;
-                hpx::tracy::sample_value("Active Continuations",
-                    static_cast<double>(current_active));
-            }
+            hpx::tracy::sample_value(
+                "Active Continuations", static_cast<double>(current_active));
         }
 
         void handle_on_completed_fired_impl(void const* task_id) noexcept

--- a/libs/core/tracing/src/backends/tracy.cpp
+++ b/libs/core/tracing/src/backends/tracy.cpp
@@ -34,7 +34,9 @@ namespace hpx::tracing {
 
     region::region(loop_context&, region_init_data const& data,
         std::size_t const num_thread) noexcept
-      : impl(create_tracy_region(data, num_thread))
+      : impl(detail::is_profiler_connected() ?
+                create_tracy_region(data, num_thread) :
+                hpx::tracy::region(nullptr, 0, 0, false))
     {
     }
 
@@ -44,7 +46,7 @@ namespace hpx::tracing {
     // mark_event
 
     mark_event::mark_event(char const* name) noexcept
-      : impl(name)
+      : impl(name, detail::is_profiler_connected())
     {
     }
 
@@ -69,45 +71,58 @@ namespace hpx::tracing {
 
     fiber_region::fiber_region(fiber_region_init_data const& data,
         std::size_t const num_thread) noexcept
-      : impl(create_tracy_fiber_region(data, num_thread))
+      : impl(detail::is_profiler_connected() ?
+                create_tracy_fiber_region(data, num_thread) :
+                hpx::tracy::fiber_region(nullptr, nullptr, 0, false))
     {
     }
 
     fiber_region::~fiber_region() = default;
 
     ////////////////////////////////////////////////////////////////////////////
-    // fiber_suspend_region
+    // fiber_suspend_region — inner impl runs suspend/resume unconditionally,
+    // so we only construct it when active. When not active, we pass nullptr
+    // (see the inline ctor in tracy_tls.hpp, which gates on active).
 
     fiber_suspend_region::fiber_suspend_region(char const* desc) noexcept
-      : impl(desc)
+      : fiber_suspend_region(desc, detail::is_profiler_connected())
+    {
+    }
+
+    fiber_suspend_region::fiber_suspend_region(
+        char const* desc, bool const active) noexcept
+      : impl(active ? desc : nullptr, active)
     {
     }
 
     fiber_suspend_region::~fiber_suspend_region() = default;
 
     ////////////////////////////////////////////////////////////////////////////
-    // background_work_region
+    // background_work_region — inner impl always emits start/stop_region, so
+    // we forward the connected state explicitly.
 
     background_work_region::background_work_region(
         std::size_t const num_thread) noexcept
-      : impl(num_thread)
+      : impl(num_thread, detail::is_profiler_connected())
     {
     }
 
     background_work_region::~background_work_region() = default;
 
     ////////////////////////////////////////////////////////////////////////////
-    // lock_context
+    // lock_context — see rationale in header.
 
     lock_context::lock_context(
         char const* name, void const* /* addr */) noexcept
-      : impl(hpx::tracy::create(name))
+      : active_(detail::is_profiler_connected())
+      , impl(hpx::tracy::create(name))
     {
     }
 
     lock_context::lock_context(
         char const* prefix, char const* suffix, void const* /* addr */) noexcept
-      : impl(hpx::tracy::create(std::string(prefix) + suffix))
+      : active_(detail::is_profiler_connected())
+      , impl(hpx::tracy::create(std::string(prefix) + suffix))
     {
     }
 
@@ -118,16 +133,22 @@ namespace hpx::tracing {
 
     bool lock_context::before_lock() const noexcept
     {
+        if (!active_)
+            return false;
         return hpx::tracy::lock_prepare(impl);
     }
 
     void lock_context::after_lock() const noexcept
     {
+        if (!active_)
+            return;
         hpx::tracy::lock_acquired(impl);
     }
 
     void lock_context::after_try_lock(bool acquired) const noexcept
     {
+        if (!active_)
+            return;
         hpx::tracy::lock_acquired(impl, acquired);
     }
 
@@ -135,6 +156,8 @@ namespace hpx::tracing {
 
     void lock_context::after_unlock() const noexcept
     {
+        if (!active_)
+            return;
         hpx::tracy::lock_released(impl);
     }
 
@@ -147,17 +170,18 @@ namespace hpx::tracing {
     }
 
     ////////////////////////////////////////////////////////////////////////////
-    // rename_region
-
-    char const* rename_region(char const* name) noexcept
-    {
-        return hpx::tracy::detail::rename_region(name);
-    }
-
-    ////////////////////////////////////////////////////////////////////////////
     // task lifecycle tracking
 
     namespace detail {
+        ////////////////////////////////////////////////////////////////////////
+        // rename_region body (inline gate wrapper lives in the header)
+
+        char const* rename_region_impl(char const* name) noexcept
+        {
+            return hpx::tracy::detail::rename_region(name);
+        }
+
+        ////////////////////////////////////////////////////////////////////////
         enum class color : std::uint32_t
         {
             staged = 0x808080,
@@ -176,262 +200,273 @@ namespace hpx::tracing {
         }
     }    // namespace detail
 
-    void task_staged(
-        char const* description, void const* parent_task_id) noexcept
-    {
-        char buffer[256];
-        if (parent_task_id)
+    namespace detail {
+
+        void task_staged_impl(
+            char const* description, void const* parent_task_id) noexcept
         {
+            char buffer[256];
+            if (parent_task_id)
+            {
+                std::snprintf(buffer, sizeof(buffer),
+                    "Task Staged: %s (Parent: %p)", safe_str(description),
+                    const_cast<void*>(parent_task_id));
+            }
+            else
+            {
+                std::snprintf(buffer, sizeof(buffer), "Task Staged: %s",
+                    safe_str(description));
+            }
+            hpx::tracy::message(buffer, std::strlen(buffer),
+                static_cast<std::uint32_t>(color::staged));
+        }
+
+        void task_created_impl(char const* description, void const* task_id,
+            void const* parent_task_id) noexcept
+        {
+            char buffer[256];
+            if (parent_task_id)
+            {
+                std::snprintf(buffer, sizeof(buffer),
+                    "Task Created: %p - %s (Parent: %p)",
+                    const_cast<void*>(task_id), safe_str(description),
+                    const_cast<void*>(parent_task_id));
+            }
+            else
+            {
+                std::snprintf(buffer, sizeof(buffer), "Task Created: %p - %s",
+                    const_cast<void*>(task_id), safe_str(description));
+            }
+            hpx::tracy::message(buffer, std::strlen(buffer),
+                static_cast<std::uint32_t>(color::created));
+        }
+
+        void task_executing_impl(void const* task_id, char const* description,
+            std::size_t worker_thread) noexcept
+        {
+            char buffer[256];
             std::snprintf(buffer, sizeof(buffer),
-                "Task Staged: %s (Parent: %p)", detail::safe_str(description),
-                const_cast<void*>(parent_task_id));
+                "Task Executing (W%zu): %p - %s", worker_thread,
+                const_cast<void*>(task_id), safe_str(description));
+            hpx::tracy::message(buffer, std::strlen(buffer),
+                static_cast<std::uint32_t>(color::executing));
         }
-        else
+
+        void task_yielded_impl(
+            void const* task_id, char const* description) noexcept
         {
-            std::snprintf(buffer, sizeof(buffer), "Task Staged: %s",
-                detail::safe_str(description));
+            char buffer[256];
+            std::snprintf(buffer, sizeof(buffer), "Task Yielded: %p - %s",
+                const_cast<void*>(task_id), safe_str(description));
+            hpx::tracy::message(buffer, std::strlen(buffer),
+                static_cast<std::uint32_t>(color::yielded));
         }
-        hpx::tracy::message(buffer, std::strlen(buffer),
-            static_cast<std::uint32_t>(detail::color::staged));
-    }
 
-    void task_created(char const* description, void const* task_id,
-        void const* parent_task_id) noexcept
-    {
-        char buffer[256];
-        if (parent_task_id)
+        void task_suspended_impl(void const* task_id, char const* description,
+            char const* reason) noexcept
         {
-            std::snprintf(buffer, sizeof(buffer),
-                "Task Created: %p - %s (Parent: %p)",
-                const_cast<void*>(task_id), detail::safe_str(description),
-                const_cast<void*>(parent_task_id));
+            char buffer[256];
+            if (reason)
+            {
+                std::snprintf(buffer, sizeof(buffer),
+                    "Task Suspended: %p - %s (Reason: %s)",
+                    const_cast<void*>(task_id), safe_str(description), reason);
+            }
+            else
+            {
+                std::snprintf(buffer, sizeof(buffer), "Task Suspended: %p - %s",
+                    const_cast<void*>(task_id), safe_str(description));
+            }
+            hpx::tracy::message(buffer, std::strlen(buffer),
+                static_cast<std::uint32_t>(color::suspended));
         }
-        else
+
+        void task_resumed_impl(void const* task_id, char const* description,
+            char const* wake_reason) noexcept
         {
-            std::snprintf(buffer, sizeof(buffer), "Task Created: %p - %s",
-                const_cast<void*>(task_id), detail::safe_str(description));
+            char buffer[256];
+            if (wake_reason)
+            {
+                std::snprintf(buffer, sizeof(buffer),
+                    "Task Resumed: %p - %s (Wake: %s)",
+                    const_cast<void*>(task_id), safe_str(description),
+                    wake_reason);
+            }
+            else
+            {
+                std::snprintf(buffer, sizeof(buffer), "Task Resumed: %p - %s",
+                    const_cast<void*>(task_id), safe_str(description));
+            }
+            hpx::tracy::message(buffer, std::strlen(buffer),
+                static_cast<std::uint32_t>(color::resumed));
         }
-        hpx::tracy::message(buffer, std::strlen(buffer),
-            static_cast<std::uint32_t>(detail::color::created));
-    }
 
-    void task_executing(void const* task_id, char const* description,
-        std::size_t worker_thread) noexcept
-    {
-        char buffer[256];
-        std::snprintf(buffer, sizeof(buffer), "Task Executing (W%zu): %p - %s",
-            worker_thread, const_cast<void*>(task_id),
-            detail::safe_str(description));
-        hpx::tracy::message(buffer, std::strlen(buffer),
-            static_cast<std::uint32_t>(detail::color::executing));
-    }
-
-    void task_yielded(void const* task_id, char const* description) noexcept
-    {
-        char buffer[256];
-        std::snprintf(buffer, sizeof(buffer), "Task Yielded: %p - %s",
-            const_cast<void*>(task_id), detail::safe_str(description));
-        hpx::tracy::message(buffer, std::strlen(buffer),
-            static_cast<std::uint32_t>(detail::color::yielded));
-    }
-
-    void task_suspended(void const* task_id, char const* description,
-        char const* reason) noexcept
-    {
-        char buffer[256];
-        if (reason)
+        void task_completed_impl(
+            void const* task_id, char const* description) noexcept
         {
-            std::snprintf(buffer, sizeof(buffer),
-                "Task Suspended: %p - %s (Reason: %s)",
-                const_cast<void*>(task_id), detail::safe_str(description),
-                reason);
+            char buffer[256];
+            std::snprintf(buffer, sizeof(buffer), "Task Completed: %p - %s",
+                const_cast<void*>(task_id), safe_str(description));
+            hpx::tracy::message(buffer, std::strlen(buffer),
+                static_cast<std::uint32_t>(color::completed));
         }
-        else
-        {
-            std::snprintf(buffer, sizeof(buffer), "Task Suspended: %p - %s",
-                const_cast<void*>(task_id), detail::safe_str(description));
-        }
-        hpx::tracy::message(buffer, std::strlen(buffer),
-            static_cast<std::uint32_t>(detail::color::suspended));
-    }
 
-    void task_resumed(void const* task_id, char const* description,
-        char const* wake_reason) noexcept
-    {
-        char buffer[256];
-        if (wake_reason)
+        void task_deleted_impl(void const* task_id) noexcept
         {
-            std::snprintf(buffer, sizeof(buffer),
-                "Task Resumed: %p - %s (Wake: %s)", const_cast<void*>(task_id),
-                detail::safe_str(description), wake_reason);
-        }
-        else
-        {
-            std::snprintf(buffer, sizeof(buffer), "Task Resumed: %p - %s",
-                const_cast<void*>(task_id), detail::safe_str(description));
-        }
-        hpx::tracy::message(buffer, std::strlen(buffer),
-            static_cast<std::uint32_t>(detail::color::resumed));
-    }
-
-    void task_completed(void const* task_id, char const* description) noexcept
-    {
-        char buffer[256];
-        std::snprintf(buffer, sizeof(buffer), "Task Completed: %p - %s",
-            const_cast<void*>(task_id), detail::safe_str(description));
-        hpx::tracy::message(buffer, std::strlen(buffer),
-            static_cast<std::uint32_t>(detail::color::completed));
-    }
-
-    void task_deleted(void const* task_id) noexcept
-    {
-        char buffer[256];
-        std::snprintf(buffer, sizeof(buffer), "Task Deleted: %p",
-            const_cast<void*>(task_id));
-        hpx::tracy::message(buffer, std::strlen(buffer),
-            static_cast<std::uint32_t>(detail::color::deleted));
-    }
-
-    ////////////////////////////////////////////////////////////////////////////
-    // Causal tracing: future fulfillment signals
-
-    void future_fulfilled(void const* future_id, char const* desc) noexcept
-    {
-        char buffer[256];
-        if (desc)
-        {
-            std::snprintf(buffer, sizeof(buffer), "Future Fulfilled: %p (%s)",
-                const_cast<void*>(future_id), desc);
-        }
-        else
-        {
-            std::snprintf(buffer, sizeof(buffer), "Future Fulfilled: %p",
-                const_cast<void*>(future_id));
-        }
-        std::size_t const len = std::strlen(buffer);
-        // Green: producer signal
-        hpx::tracy::message(buffer, len, 0x00FF00u);
-        // Embed directly into active fiber visual zone text
-        hpx::tracy::detail::add_zone_text_to_fiber(buffer, len);
-    }
-
-    void future_exception_set(void const* future_id, char const* desc) noexcept
-    {
-        char buffer[256];
-        if (desc)
-        {
-            std::snprintf(buffer, sizeof(buffer),
-                "Future Exception Set: %p (%s)", const_cast<void*>(future_id),
-                desc);
-        }
-        else
-        {
-            std::snprintf(buffer, sizeof(buffer), "Future Exception Set: %p",
-                const_cast<void*>(future_id));
-        }
-        std::size_t const len = std::strlen(buffer);
-        // Red: producer error signal
-        hpx::tracy::message(buffer, len, 0xFF0000u);
-        // Embed directly into active fiber visual zone text
-        hpx::tracy::detail::add_zone_text_to_fiber(buffer, len);
-    }
-
-    namespace {
-        std::int64_t g_active_continuations{0};
-        std::mutex g_active_continuations_mtx;
-    }    // namespace
-
-    void continuation_run(void const* task_id) noexcept
-    {
-        char buffer[256];
-        if (task_id)
-        {
-            std::snprintf(buffer, sizeof(buffer), "Continuation Run: %p",
+            char buffer[256];
+            std::snprintf(buffer, sizeof(buffer), "Task Deleted: %p",
                 const_cast<void*>(task_id));
+            hpx::tracy::message(buffer, std::strlen(buffer),
+                static_cast<std::uint32_t>(color::deleted));
         }
-        else
-        {
-            std::snprintf(buffer, sizeof(buffer), "Continuation Run");
-        }
-        std::size_t const len = std::strlen(buffer);
-        // White: consumer signal
-        hpx::tracy::message(buffer, len, 0xFFFFFFu);
-        // Embed directly into active fiber visual zone text
-        hpx::tracy::detail::add_zone_text_to_fiber(buffer, len);
 
-        // Update live time-series plot graph for Active Continuations in Tracy
-        std::int64_t current_active = 0;
-        {
-            std::lock_guard<std::mutex> lock(g_active_continuations_mtx);
-            current_active = ++g_active_continuations;
-            hpx::tracy::sample_value(
-                "Active Continuations", static_cast<double>(current_active));
-        }
-    }
+        ////////////////////////////////////////////////////////////////////////////
+        // Causal tracing: future fulfillment signals
 
-    void continuation_finished(void const* /* task_id */) noexcept
-    {
-        std::int64_t current_active = 0;
+        void future_fulfilled_impl(
+            void const* future_id, char const* desc) noexcept
         {
-            std::lock_guard<std::mutex> lock(g_active_continuations_mtx);
-            current_active = --g_active_continuations;
-            hpx::tracy::sample_value(
-                "Active Continuations", static_cast<double>(current_active));
+            char buffer[256];
+            if (desc)
+            {
+                std::snprintf(buffer, sizeof(buffer),
+                    "Future Fulfilled: %p (%s)", const_cast<void*>(future_id),
+                    desc);
+            }
+            else
+            {
+                std::snprintf(buffer, sizeof(buffer), "Future Fulfilled: %p",
+                    const_cast<void*>(future_id));
+            }
+            std::size_t const len = std::strlen(buffer);
+            // Green: producer signal
+            hpx::tracy::message(buffer, len, 0x00FF00u);
+            // Embed directly into active fiber visual zone text
+            hpx::tracy::detail::add_zone_text_to_fiber(buffer, len);
         }
-    }
 
-    void handle_on_completed_fired(void const* task_id) noexcept
-    {
-        char buffer[256];
-        if (task_id)
+        void future_exception_set_impl(
+            void const* future_id, char const* desc) noexcept
         {
+            char buffer[256];
+            if (desc)
+            {
+                std::snprintf(buffer, sizeof(buffer),
+                    "Future Exception Set: %p (%s)",
+                    const_cast<void*>(future_id), desc);
+            }
+            else
+            {
+                std::snprintf(buffer, sizeof(buffer),
+                    "Future Exception Set: %p", const_cast<void*>(future_id));
+            }
+            std::size_t const len = std::strlen(buffer);
+            // Red: producer error signal
+            hpx::tracy::message(buffer, len, 0xFF0000u);
+            // Embed directly into active fiber visual zone text
+            hpx::tracy::detail::add_zone_text_to_fiber(buffer, len);
+        }
+
+        namespace {
+            std::int64_t g_active_continuations{0};
+            std::mutex g_active_continuations_mtx;
+        }    // namespace
+
+        void continuation_run_impl(void const* task_id) noexcept
+        {
+            char buffer[256];
+            if (task_id)
+            {
+                std::snprintf(buffer, sizeof(buffer), "Continuation Run: %p",
+                    const_cast<void*>(task_id));
+            }
+            else
+            {
+                std::snprintf(buffer, sizeof(buffer), "Continuation Run");
+            }
+            std::size_t const len = std::strlen(buffer);
+            // White: consumer signal
+            hpx::tracy::message(buffer, len, 0xFFFFFFu);
+            // Embed directly into active fiber visual zone text
+            hpx::tracy::detail::add_zone_text_to_fiber(buffer, len);
+
+            // Update live time-series plot graph for Active Continuations in Tracy
+            std::int64_t current_active = 0;
+            {
+                std::lock_guard<std::mutex> lock(g_active_continuations_mtx);
+                current_active = ++g_active_continuations;
+                hpx::tracy::sample_value("Active Continuations",
+                    static_cast<double>(current_active));
+            }
+        }
+
+        void continuation_finished_impl(void const* /* task_id */) noexcept
+        {
+            std::int64_t current_active = 0;
+            {
+                std::lock_guard<std::mutex> lock(g_active_continuations_mtx);
+                current_active = --g_active_continuations;
+                hpx::tracy::sample_value("Active Continuations",
+                    static_cast<double>(current_active));
+            }
+        }
+
+        void handle_on_completed_fired_impl(void const* task_id) noexcept
+        {
+            char buffer[256];
+            if (task_id)
+            {
+                std::snprintf(buffer, sizeof(buffer),
+                    "Handle On Completed Fired: %p",
+                    const_cast<void*>(task_id));
+            }
+            else
+            {
+                std::snprintf(
+                    buffer, sizeof(buffer), "Handle On Completed Fired");
+            }
+            std::size_t const len = std::strlen(buffer);
+            // Yellow: dispatch signal
+            hpx::tracy::message(buffer, len, 0xFFFF00u);
+            // Embed directly into active fiber visual zone text
+            hpx::tracy::detail::add_zone_text_to_fiber(buffer, len);
+        }
+
+        void work_stolen_impl(std::size_t thief_id, std::size_t victim_id,
+            void const* task_id, char const* desc) noexcept
+        {
+            char buffer[256];
+            if (desc && desc[0] != '\0')
+            {
+                std::snprintf(buffer, sizeof(buffer),
+                    "Work Stolen: Thief W#%zu <- Victim W#%zu | Task: %p (%s)",
+                    thief_id, victim_id, task_id, desc);
+            }
+            else
+            {
+                std::snprintf(buffer, sizeof(buffer),
+                    "Work Stolen: Thief W#%zu <- Victim W#%zu | Task: %p",
+                    thief_id, victim_id, task_id);
+            }
+            // Amber/Gold color: 0xFFC107
+            hpx::tracy::message(buffer, std::strlen(buffer), 0xFFC107u);
+        }
+
+        void frame_mark_impl(char const* name) noexcept
+        {
+            hpx::tracy::frame_mark(name);
+        }
+
+        void os_thread_sleep_impl(std::size_t num_thread) noexcept
+        {
+            char buffer[64];
             std::snprintf(buffer, sizeof(buffer),
-                "Handle On Completed Fired: %p", const_cast<void*>(task_id));
+                "OS Worker #%zu entering sleep on CV", num_thread);
+            // Blue-grey: cold/inactive state
+            hpx::tracy::message(buffer, std::strlen(buffer), 0x546E7Au);
         }
-        else
-        {
-            std::snprintf(buffer, sizeof(buffer), "Handle On Completed Fired");
-        }
-        std::size_t const len = std::strlen(buffer);
-        // Yellow: dispatch signal
-        hpx::tracy::message(buffer, len, 0xFFFF00u);
-        // Embed directly into active fiber visual zone text
-        hpx::tracy::detail::add_zone_text_to_fiber(buffer, len);
-    }
 
-    void work_stolen(std::size_t thief_id, std::size_t victim_id,
-        void const* task_id, char const* desc) noexcept
-    {
-        char buffer[256];
-        if (desc && desc[0] != '\0')
-        {
-            std::snprintf(buffer, sizeof(buffer),
-                "Work Stolen: Thief W#%zu <- Victim W#%zu | Task: %p (%s)",
-                thief_id, victim_id, task_id, desc);
-        }
-        else
-        {
-            std::snprintf(buffer, sizeof(buffer),
-                "Work Stolen: Thief W#%zu <- Victim W#%zu | Task: %p", thief_id,
-                victim_id, task_id);
-        }
-        // Amber/Gold color: 0xFFC107
-        hpx::tracy::message(buffer, std::strlen(buffer), 0xFFC107u);
-    }
-
-    void frame_mark(char const* name) noexcept
-    {
-        hpx::tracy::frame_mark(name);
-    }
-
-    void os_thread_sleep(std::size_t num_thread) noexcept
-    {
-        char buffer[64];
-        std::snprintf(buffer, sizeof(buffer),
-            "OS Worker #%zu entering sleep on CV", num_thread);
-        // Blue-grey: cold/inactive state
-        hpx::tracy::message(buffer, std::strlen(buffer), 0x546E7Au);
-    }
+    }    // namespace detail
 
     ////////////////////////////////////////////////////////////////////////////
     // counters

--- a/libs/core/tracy/CMakeLists.txt
+++ b/libs/core/tracy/CMakeLists.txt
@@ -28,6 +28,6 @@ add_hpx_module(
   SOURCES ${tracy_sources}
   HEADERS ${tracy_headers}
   MODULE_DEPENDENCIES hpx_config
-  PRIVATE_DEPENDENCIES tracy::tracy
+  DEPENDENCIES tracy::tracy
   CMAKE_SUBDIRS tests
 )

--- a/libs/core/tracy/include/hpx/tracy/tracy_tls.hpp
+++ b/libs/core/tracy/include/hpx/tracy/tracy_tls.hpp
@@ -128,16 +128,37 @@ namespace hpx::tracy {
 
     HPX_CXX_CORE_EXPORT struct background_work_region
     {
-        explicit background_work_region(std::size_t num_thread) noexcept
-          : surrounding_region(
-                detail::start_named_region("hpx::background_work", 0x008080u))
+        // Two-arg ctor: caller supplies an explicit `active` flag captured
+        // at the outer wrapper's construction (see backends/tracy.hpp
+        // background_work_region). Disconnected -> we skip start_named_region
+        // AND the paired stop_region in the dtor, preserving the invariant
+        // that an instance whose ctor didn't emit must not emit on destroy.
+        explicit background_work_region(
+            std::size_t num_thread, bool active) noexcept
+          : active_(active)
         {
-            detail::add_worker_thread_text(surrounding_region, num_thread);
+            if (active_)
+            {
+                surrounding_region = detail::start_named_region(
+                    "hpx::background_work", 0x008080u);
+                detail::add_worker_thread_text(surrounding_region, num_thread);
+            }
+        }
+
+        // Legacy single-arg ctor kept for source-compat with code that
+        // instantiates this type directly (nothing in-tree does today).
+        // Defaults to active — the classic pre-gate behaviour.
+        explicit background_work_region(std::size_t num_thread) noexcept
+          : background_work_region(num_thread, true)
+        {
         }
 
         ~background_work_region() noexcept
         {
-            detail::stop_region(surrounding_region);
+            if (active_)
+            {
+                detail::stop_region(surrounding_region);
+            }
         }
 
         background_work_region(background_work_region const&) = delete;
@@ -145,13 +166,24 @@ namespace hpx::tracy {
             background_work_region const&) = delete;
 
     private:
+        bool active_;
         region_data surrounding_region;
     };
 
     HPX_CXX_CORE_EXPORT struct mark_event
     {
+        // Two-arg ctor: `active` records the profiler-connected decision
+        // taken by the outer wrapper. If not active, we skip push_zone and
+        // the paired pop_zone in the dtor.
+        explicit mark_event(char const* name, bool active) noexcept
+          : active_(active)
+          , ctx_value(active_ ? detail::push_zone(name) : 0)
+        {
+        }
+
+        // Legacy single-arg ctor for direct instantiation; defaults active.
         explicit mark_event(char const* name) noexcept
-          : ctx_value(detail::push_zone(name))
+          : mark_event(name, true)
         {
         }
 
@@ -162,10 +194,14 @@ namespace hpx::tracy {
 
         ~mark_event()
         {
-            detail::pop_zone(ctx_value);
+            if (active_)
+            {
+                detail::pop_zone(ctx_value);
+            }
         }
 
     private:
+        bool active_;
         std::uint64_t ctx_value;
     };
 
@@ -177,16 +213,37 @@ namespace hpx::tracy {
     // start_region() - so there is no zone-stack conflict.
     struct fiber_suspend_region
     {
+        // Two-arg ctor honours the profiler-connected decision captured by
+        // the outer wrapper. Skipping suspend_fiber_zone means the paired
+        // resume_fiber_zone in the dtor is also skipped — critical for
+        // zone-stack balance.
+        explicit fiber_suspend_region(
+            char const* suspend_reason, bool active) noexcept
+          : active_(active)
+        {
+            if (active_)
+            {
+                detail::suspend_fiber_zone(suspend_reason);
+            }
+        }
+
+        // Legacy single-arg ctor for direct instantiation; defaults active.
         explicit fiber_suspend_region(
             char const* suspend_reason = nullptr) noexcept
+          : fiber_suspend_region(suspend_reason, true)
         {
-            detail::suspend_fiber_zone(suspend_reason);
         }
 
         ~fiber_suspend_region() noexcept
         {
-            detail::resume_fiber_zone();
+            if (active_)
+            {
+                detail::resume_fiber_zone();
+            }
         }
+
+    private:
+        bool active_;
     };
 }    // namespace hpx::tracy
 

--- a/libs/core/tracy/include/hpx/tracy/tracy_tls.hpp
+++ b/libs/core/tracy/include/hpx/tracy/tracy_tls.hpp
@@ -128,6 +128,9 @@ namespace hpx::tracy {
 
     HPX_CXX_CORE_EXPORT struct background_work_region
     {
+        /// \brief Opens a background-work zone on the given worker thread.
+        ///
+        /// \param active  If false, the ctor and dtor emit no Tracy events.
         // Two-arg ctor: caller supplies an explicit `active` flag captured
         // at the outer wrapper's construction (see backends/tracy.hpp
         // background_work_region). Disconnected -> we skip start_named_region
@@ -147,7 +150,7 @@ namespace hpx::tracy {
 
         // Legacy single-arg ctor kept for source-compat with code that
         // instantiates this type directly (nothing in-tree does today).
-        // Defaults to active — the classic pre-gate behaviour.
+        // Defaults to active -- the classic pre-gate behaviour.
         explicit background_work_region(std::size_t num_thread) noexcept
           : background_work_region(num_thread, true)
         {
@@ -172,6 +175,9 @@ namespace hpx::tracy {
 
     HPX_CXX_CORE_EXPORT struct mark_event
     {
+        /// \brief Opens a Tracy zone for the given event name.
+        ///
+        /// \param active  If false, the ctor and dtor emit no Tracy events.
         // Two-arg ctor: `active` records the profiler-connected decision
         // taken by the outer wrapper. If not active, we skip push_zone and
         // the paired pop_zone in the dtor.
@@ -213,9 +219,13 @@ namespace hpx::tracy {
     // start_region() - so there is no zone-stack conflict.
     struct fiber_suspend_region
     {
+        /// \brief Suspends the currently active fiber zone with the given
+        ///        reason.
+        ///
+        /// \param active  If false, the ctor and dtor emit no Tracy events.
         // Two-arg ctor honours the profiler-connected decision captured by
         // the outer wrapper. Skipping suspend_fiber_zone means the paired
-        // resume_fiber_zone in the dtor is also skipped — critical for
+        // resume_fiber_zone in the dtor is also skipped -- critical for
         // zone-stack balance.
         explicit fiber_suspend_region(
             char const* suspend_reason, bool active) noexcept


### PR DESCRIPTION
## Proposed Changes

  - Move Tracy's "is a profiler connected" check to the HPX call site, so the tracing hooks skip their work when nothing is listening. Each entry point becomes a small inline wrapper that returns early on a single atomic load, otherwise calling the original body, now named `detail::*_impl`.
  - Applied to the message-style hooks (task lifecycle, causal signals, work stealing), `rename_region`, `frame_mark`, `os_thread_sleep`, `lock_context`, and the five RAII types.
  - The RAII types record whether a profiler was connected at construction and check that same flag in the destructor, so an object created while disconnected never emits on destruction even if a client connects during its lifetime. Otherwise the zone and fiber stacks could end up unbalanced.
  - Forward-declares `___tracy_connected` instead of including `<tracy/TracyC.h>`, keeping Tracy's C API out of the ~60 translation units that include the tracing headers.

## Any background context you want to provide?

Every HPX task fires around a dozen tracing calls, more if it suspends or waits on a future. Each one formats a message with `snprintf` and calls into Tracy, which then checks whether a profiler is connected and drops it if not. With no profiler attached we were building strings and crossing into the Tracy client only to throw the result away.

Measured with `tests/performance/local/future_overhead.cpp`. Overhead below means tracing compiled in with no client attached, minus tracing compiled out.

| Workers | Overhead before | Overhead after |
|---|---|---|
| 1 | +283 ns/task | +76 ns/task |
| 4 | +104 ns/task | +43 ns/task |
| 8 | +25 ns/task | within noise |

25 reps at 1 and 4 workers, 12 at 8. Intel i5-13450HX, GCC 16.1, `-O3 -DNDEBUG`.

Behaviour with a profiler attached is unchanged. I captured 12 traces of `causal_chain_smoke`, six per build against the pinned Tracy v0.13.1, and the 11 task-lifecycle and causal message types match at the median with only capture-boundary jitter between runs.

`lock_context` is gated here for consistency, but nothing in the tree calls it today — `hpx::spinlock` still uses the `HPX_ITT_SYNC_*` macros. That part is groundwork rather than a measured win.

## Checklist

Not all points below apply to all pull requests.
- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.

This is a performance change with no functional difference when a profiler is attached — when connected, each hook runs the same body as before. The natural regression guard is a benchmark rather than a test. `tests/performance/local/future_overhead.cpp` was the measurement vehicle here and could be adapted into a tracing-dedicated benchmark as a follow-up.