### PR TITLE
Update Sphinx/Breathe version requirements in documentation contributing guide

### DIFF
--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   build-documentation:
     runs-on: ubuntu-latest
-    container: stellargroup/build_env:17
+    container: stellargroup/build_env:23
     permissions:
       actions: read
 

--- a/.github/workflows/documentation-push.yml
+++ b/.github/workflows/documentation-push.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   deploy-documentation:
     runs-on: ubuntu-latest
-    container: stellargroup/build_env:17
+    container: stellargroup/build_env:23
     if: >
       (github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.head_repository.full_name == github.repository) ||

--- a/docs/sphinx/contributing/documentation.rst
+++ b/docs/sphinx/contributing/documentation.rst
@@ -27,7 +27,7 @@ packages:
 - ``sphinx`` (Python package, version 7.2 or later)
 - ``sphinx-book-theme`` (Python package)
 - ``breathe`` (Python package, version 4.36.0 or later)
-- ``doxygen`` (version 1.9.2 or later)
+- ``doxygen``
 - ``sphinxcontrib-bibtex``
 - ``sphinx-copybutton``
 

--- a/docs/sphinx/contributing/documentation.rst
+++ b/docs/sphinx/contributing/documentation.rst
@@ -36,9 +36,10 @@ manager, you can install them using the Python package manager ``pip``:
 
 .. code-block:: bash
 
-   pip install --user \
-      sphinx breathe sphinx-book-theme \
-      sphinxcontrib-bibtex sphinx-copybutton
+   pip install \
+      "sphinx>=7.2" "breathe>=4.36.0" \
+      sphinx-book-theme sphinxcontrib-bibtex \
+      sphinx-copybutton
 
 You may need to set the following CMake variables to make sure CMake can
 find the required dependencies.

--- a/docs/sphinx/contributing/documentation.rst
+++ b/docs/sphinx/contributing/documentation.rst
@@ -36,7 +36,9 @@ manager, you can install them using the Python package manager ``pip``:
 
 .. code-block:: bash
 
-   pip install --user sphinx breathe sphinx-book-theme sphinxcontrib-bibtex sphinx-copybutton
+   pip install --user \
+      sphinx breathe sphinx-book-theme \
+      sphinxcontrib-bibtex sphinx-copybutton
 
 You may need to set the following CMake variables to make sure CMake can
 find the required dependencies.

--- a/docs/sphinx/contributing/documentation.rst
+++ b/docs/sphinx/contributing/documentation.rst
@@ -27,7 +27,7 @@ packages:
 - ``sphinx`` (Python package, version 7.2 or later)
 - ``sphinx-book-theme`` (Python package)
 - ``breathe`` (Python package, version 4.36.0 or later)
-- ``doxygen``
+- ``doxygen`` (version 1.9.2 or later)
 - ``sphinxcontrib-bibtex``
 - ``sphinx-copybutton``
 

--- a/docs/sphinx/contributing/documentation.rst
+++ b/docs/sphinx/contributing/documentation.rst
@@ -24,20 +24,21 @@ To build the |hpx| documentation, you need recent versions of the following
 packages:
 
 - ``python3`` (3.9 or later)
-- ``sphinx`` (Python package, version 7.2 or later)
+- ``sphinx`` 7.2 or later (Python package)
 - ``sphinx-book-theme`` (Python package)
-- ``breathe`` (Python package, version 4.36.0 or later)
+- ``breathe`` 4.36.0 or later (Python package)
 - ``doxygen``
 - ``sphinxcontrib-bibtex``
 - ``sphinx-copybutton``
 
 If the |python|_ dependencies are not available through your system package
-manager, you can install them using the Python package manager ``pip``. We
-recommend doing this inside a virtual environment (for example, one created
-with ``python3 -m venv .venv``) to avoid polluting the global package state:
+manager, you can install them using the Python package manager ``pip``.
+We recommend using a virtual environment:
 
 .. code-block:: bash
 
+   python3 -m venv .venv
+   source .venv/bin/activate
    pip install \
       "sphinx>=7.2" "breathe>=4.36.0" \
       sphinx-book-theme sphinxcontrib-bibtex \

--- a/docs/sphinx/contributing/documentation.rst
+++ b/docs/sphinx/contributing/documentation.rst
@@ -37,8 +37,9 @@ We recommend using a virtual environment:
 
 .. code-block:: bash
 
-   python3 -m venv .venv
-   source .venv/bin/activate
+   mkdir -p build
+   python3 -m venv build/.venv
+   source build/.venv/bin/activate
    pip install \
       "sphinx>=7.2" "breathe>=4.36.0" \
       sphinx-book-theme sphinxcontrib-bibtex \

--- a/docs/sphinx/contributing/documentation.rst
+++ b/docs/sphinx/contributing/documentation.rst
@@ -32,7 +32,9 @@ packages:
 - ``sphinx-copybutton``
 
 If the |python|_ dependencies are not available through your system package
-manager, you can install them using the Python package manager ``pip``:
+manager, you can install them using the Python package manager ``pip``. We
+recommend doing this inside a virtual environment (for example, one created
+with ``python3 -m venv .venv``) to avoid polluting the global package state:
 
 .. code-block:: bash
 

--- a/docs/sphinx/contributing/documentation.rst
+++ b/docs/sphinx/contributing/documentation.rst
@@ -23,10 +23,10 @@ Prerequisites
 To build the |hpx| documentation, you need recent versions of the following
 packages:
 
-- ``python3``
-- ``sphinx 4.5.0`` (Python package)
+- ``python3`` (3.9 or later)
+- ``sphinx`` (Python package, version 7.2 or later)
 - ``sphinx-book-theme`` (Python package)
-- ``breathe 4.33.1`` (Python package)
+- ``breathe`` (Python package, version 4.36.0 or later)
 - ``doxygen``
 - ``sphinxcontrib-bibtex``
 - ``sphinx-copybutton``
@@ -36,7 +36,7 @@ manager, you can install them using the Python package manager ``pip``:
 
 .. code-block:: bash
 
-   pip install --user "sphinx<5" sphinx-book-theme breathe sphinxcontrib-bibtex sphinx-copybutton
+   pip install --user sphinx breathe sphinx-book-theme sphinxcontrib-bibtex sphinx-copybutton
 
 You may need to set the following CMake variables to make sure CMake can
 find the required dependencies.


### PR DESCRIPTION
## Summary

Updates the documentation prerequisites and pip install command in `docs/sphinx/contributing/documentation.rst` to recommend currently compatible package versions.

The previous recommendations (Sphinx 4.5.0, Breathe 4.33.1, `"sphinx<5"`) are outdated and conflict with the current Breathe release (4.36.0), which requires Sphinx >= 7.2.

## Issue

Fixes #6528

## What was wrong

The documentation prerequisite list recommended Sphinx 4.5.0 and Breathe 4.33.1. The pip install command constrained Sphinx to `< 5`. However, the current Breathe release (4.36.0) requires Sphinx >= 7.2, making the recommended versions incompatible and causing installation failures when contributors try to build the documentation.

## What changed

- Updated Python version requirement to 3.9+ (required by Breathe 4.36.0)
- Updated Sphinx version recommendation from pinned 4.5.0 to "version 7.2 or later"
- Updated Breathe version recommendation from pinned 4.33.1 to "version 4.36.0 or later"
- Removed the --user flag from the pip install command (incompatible with virtual environments; contributors should use a venv)
- Removed the "sphinx<5" version constraint from the pip install command
- Added explicit lower bounds (sphinx>=7.2, breathe>=4.36.0) to the pip install command
- Updated `documentation-build.yml` and `documentation-push.yml` to use `stellargroup/build_env:23` (required for Sphinx 7.2+ / Breathe 4.36.0 support)


## Testing

Verified in a fresh Python 3.9 virtual environment that the updated pip install command resolves to compatible versions without conflicts:

- Sphinx 7.4.7
- Breathe 4.36.0
- sphinx-book-theme 1.1.4
- sphinxcontrib-bibtex 2.6.5
- sphinx-copybutton 0.5.2

All packages import successfully with no compatibility errors.

## Notes

This PR updates documentation prerequisites, the contributing guide, and the CI workflows that build/deploy documentation. No code behavior or tests are affected. Requires [STEllAR-GROUP/docker_build_env#68](https://github.com/STEllAR-GROUP/docker_build_env/pull/68) to be merged first so the Docker image with updated Sphinx/Breathe is available.