### PR TITLE
Stop the colocated tests finalizing from inside the hpx_main loop

### DIFF
--- a/libs/full/async_colocated/tests/unit/async_continue_cb_colocated.cpp
+++ b/libs/full/async_colocated/tests/unit/async_continue_cb_colocated.cpp
@@ -79,7 +79,7 @@ void cb()
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
-int test_async_continue_cb_colocated(test_client const& target)
+void test_async_continue_cb_colocated(test_client const& target)
 {
     using hpx::make_continuation;
 
@@ -228,8 +228,6 @@ int test_async_continue_cb_colocated(test_client const& target)
         hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
         HPX_TEST_EQ(callback_called.load(), 1);
     }
-
-    return hpx::finalize();
 }
 
 int hpx_main()

--- a/libs/full/async_colocated/tests/unit/async_continue_colocated.cpp
+++ b/libs/full/async_colocated/tests/unit/async_continue_colocated.cpp
@@ -63,7 +63,7 @@ struct test_client : hpx::components::client_base<test_client, test_server>
 };
 
 ///////////////////////////////////////////////////////////////////////////////
-int test_async_continue_colocated(test_client const& target)
+void test_async_continue_colocated(test_client const& target)
 {
     using hpx::make_continuation;
 
@@ -131,8 +131,6 @@ int test_async_continue_colocated(test_client const& target)
             hpx::colocated(target), 42);
         HPX_TEST_EQ(f.get(), 86);
     }
-
-    return hpx::finalize();
 }
 
 int hpx_main()


### PR DESCRIPTION
`hpx_main` in `async_continue_cb_colocated` and `async_continue_colocated` iterates over every locality and calls a per-locality helper that returned `hpx::finalize()`. With two localities that requests shutdown three times, and the second iteration keeps submitting distributed work after the first request has already gone out.

`async_continue_cb_colocated.distributed.tcp` then times out. Termination detection itself completes normally; `runtime_support::stop` spins on `threadmanager::is_busy()` over the work the second iteration left behind, while the other locality has already exited.

The misuse is old. It became visible after 37abadbe0e (#7495) made the termination probe restart its ring cursor for every probe, which removed the repeated self-addressed probe that had been draining the queue by accident. Before that change the console ran 48 probes, the first to locality 1 and the rest to itself; after it, 2 probes, both to locality 1.

The fix is to match the other colocated tests: the helper returns `void`, only `hpx_main` finalizes. `async_continue_colocated` gets the same change in a second commit; it does not hang today because it runs with a single locality, so termination detection takes the early path that only waits for the thread queues to drain, but the shape is identical.

Verified on `daf61d358e`: the test times out without the change and passes in 1.5s with it. The full `async_colocated` group is 6/6 over five repeats.

This does not address the underlying shutdown behaviour. `hpx.shutdown_timeout` defaults to `-1.0`, `runtime_support::stop` maps that to `0.0`, and `yield_while_count_timeout` treats a zero duration as no timeout, so the `abort_all_suspended_threads` recovery path in `stop` is unreachable at the default setting. That is why this presents as an unbounded hang rather than a slow shutdown. Separate PR.
