### PR TITLE
Fix the -Werror=comment build break in reflect_action_overhead

### DIFF
--- a/libs/full/actions_base/tests/performance/reflect_action_overhead.cpp
+++ b/libs/full/actions_base/tests/performance/reflect_action_overhead.cpp
@@ -15,8 +15,7 @@
 /// Reports min, median, and stddev over --nruns timed passes.
 ///
 /// Usage:
-///   ./reflect_action_overhead_test \
-///       --nparcels=1000 --nwarmup=100 --nruns=10
+///   ./reflect_action_overhead_test --nparcels=1000 --nwarmup=100 --nruns=10
 
 #include <hpx/config.hpp>
 #if !defined(HPX_COMPUTE_DEVICE_CODE)


### PR DESCRIPTION
`reflect_action_overhead.cpp:18` is a `///` comment ending in a backslash, which splices the following line into it. GCC reports that under `-Wcomment`, and the LSU configs build with `-DHPX_WITH_COMPILER_WARNINGS_AS_ERRORS=ON`, so it is a hard error there:

```
libs/full/actions_base/tests/performance/reflect_action_overhead.cpp:18:1:
error: multi-line comment [-Werror=comment]
```

It breaks the build on every gcc config, `gcc-12`, `gcc-13`, `gcc-14` and `gcc-15`, in both debug and release. `gcc-13/14/15` record no test results at all as a consequence. Clang does not warn, which is why the clang configs and the GitHub Actions builds are unaffected. Every open PR on the LSU dashboard currently reports this same single build error.

Introduced by 84b8978532 (#7459). It is the only trailing-backslash line comment in the repository.

The fix puts the usage line on one line, 77 characters. Verified with g++-15: `-Wcomment -Werror=comment` reports the error on the file before the change and is clean after.
