### PR TITLE
Waiting for threads in pools to start running before continuing

### DIFF
--- a/libs/core/io_service/include/hpx/io_service/io_service_pool.hpp
+++ b/libs/core/io_service/include/hpx/io_service/io_service_pool.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  Parts of this code were taken from the Boost.Asio library
 //  Copyright (c) 2003-2007 Christopher M. Kohlhoff (chris at kohlhoff dot com)
@@ -13,6 +13,7 @@
 #include <hpx/modules/threading_base.hpp>
 
 #include <cstddef>
+#include <memory>
 #include <thread>
 
 #include <hpx/config/warnings_prefix.hpp>
@@ -26,9 +27,10 @@ namespace hpx::util {
         {
             virtual ~io_service_pool_base() = default;
 
-            virtual bool run(bool join_threads, barrier* startup) = 0;
+            virtual bool run(
+                bool join_threads, std::shared_ptr<barrier> startup) = 0;
             virtual bool run(std::size_t num_threads, bool join_threads,
-                barrier* startup) = 0;
+                std::shared_ptr<barrier> startup) = 0;
             virtual void stop() = 0;
             virtual void join() = 0;
             virtual void clear() = 0;
@@ -39,7 +41,7 @@ namespace hpx::util {
                 std::size_t thread_num) = 0;
             virtual std::size_t size() const noexcept = 0;
             virtual void thread_run(
-                std::size_t index, barrier* startup) const = 0;
+                std::size_t index, std::shared_ptr<barrier> startup) const = 0;
             virtual char const* get_name() const noexcept = 0;
             virtual void init(std::size_t pool_size) = 0;
         };
@@ -77,12 +79,13 @@ namespace hpx::util {
 
         /// Run all io_service objects in the pool. If join_threads is true
         /// this will also wait for all threads to complete
-        bool run(bool join_threads = true, barrier* startup = nullptr) const;
+        bool run(bool join_threads = true,
+            std::shared_ptr<barrier> startup = {}) const;
 
         /// Run all io_service objects in the pool. If join_threads is true
         /// this will also wait for all threads to complete
         bool run(std::size_t num_threads, bool join_threads = true,
-            barrier* startup = nullptr) const;
+            std::shared_ptr<barrier> startup = {}) const;
 
         /// \brief Stop all io_service objects in the pool.
         void stop() const;
@@ -108,7 +111,8 @@ namespace hpx::util {
         [[nodiscard]] std::size_t size() const noexcept;
 
         /// \brief Activate the thread \a index for this thread pool
-        void thread_run(std::size_t index, barrier* startup = nullptr) const;
+        void thread_run(
+            std::size_t index, std::shared_ptr<barrier> startup = {}) const;
 
         /// \brief Return name of this pool
         [[nodiscard]] char const* get_name() const noexcept;

--- a/libs/core/io_service/include/hpx/io_service/io_service_pool.hpp
+++ b/libs/core/io_service/include/hpx/io_service/io_service_pool.hpp
@@ -77,13 +77,31 @@ namespace hpx::util {
 
         ~io_service_pool();
 
-        /// Run all io_service objects in the pool. If join_threads is true
-        /// this will also wait for all threads to complete
+        /// \brief Run all io_service objects in the pool. If join_threads is
+        ///        true this will also wait for all threads to complete.
+        ///
+        /// \param join_threads [in] If true, wait for all pool threads to join
+        ///                      before returning.
+        /// \param startup [in] Optional startup barrier used to synchronize
+        ///                pool worker thread startup with the caller. Its
+        ///                participant count must equal the number of pool
+        ///                worker threads plus one for the caller. The caller
+        ///                must call startup->wait() after invoking run().
         bool run(bool join_threads = true,
             std::shared_ptr<barrier> startup = {}) const;
 
-        /// Run all io_service objects in the pool. If join_threads is true
-        /// this will also wait for all threads to complete
+        /// \brief Run num_threads io_service objects in the pool. If
+        ///        join_threads is true this will also wait for all threads to
+        ///        complete.
+        ///
+        /// \param num_threads [in] The number of worker threads to start.
+        /// \param join_threads [in] If true, wait for all pool threads to join
+        ///                      before returning.
+        /// \param startup [in] Optional startup barrier used to synchronize
+        ///                pool worker thread startup with the caller. Its
+        ///                participant count must equal num_threads plus one for
+        ///                the caller. The caller must call startup->wait()
+        ///                after invoking run().
         bool run(std::size_t num_threads, bool join_threads = true,
             std::shared_ptr<barrier> startup = {}) const;
 

--- a/libs/core/io_service/src/io_service_pool.cpp
+++ b/libs/core/io_service/src/io_service_pool.cpp
@@ -40,6 +40,39 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx::util::detail { namespace {
 
+    struct startup_gate
+    {
+        bool wait()
+        {
+            std::unique_lock<std::mutex> l(mtx);
+            cond.wait(l, [this] { return ready || cancelled; });
+            return !cancelled;
+        }
+
+        void release()
+        {
+            {
+                std::scoped_lock l(mtx);
+                ready = true;
+            }
+            cond.notify_all();
+        }
+
+        void cancel()
+        {
+            {
+                std::scoped_lock l(mtx);
+                cancelled = true;
+            }
+            cond.notify_all();
+        }
+
+        std::mutex mtx;
+        std::condition_variable cond;
+        bool ready = false;
+        bool cancelled = false;
+    };
+
     /// A pool of io_service objects.
     class io_service_pool final : public io_service_pool_base
     {
@@ -312,21 +345,46 @@ namespace hpx::util::detail { namespace {
     {
         if (io_services_.empty())
         {
-            pool_size_ = num_threads;
+            std::vector<io_service_ptr> io_services;
+            std::vector<work_type> work;
+            io_services.reserve(num_threads);
+            work.reserve(num_threads);
 
-            for (std::size_t i = 0; i < num_threads; ++i)
+            for (std::size_t i = 0; i != num_threads; ++i)
             {
                 auto p = std::make_unique<::asio::io_context>();
-                io_services_.emplace_back(HPX_MOVE(p));
-                work_.emplace_back(initialize_work(*io_services_[i]));
+                io_services.emplace_back(HPX_MOVE(p));
+                work.emplace_back(initialize_work(*io_services[i]));
             }
+
+            io_services_ = HPX_MOVE(io_services);
+            work_ = HPX_MOVE(work);
+            pool_size_ = num_threads;
         }
 
-        for (std::size_t i = 0; i < num_threads; ++i)
+        auto const gate = std::make_shared<startup_gate>();
+        threads_.reserve(num_threads);
+
+        try
         {
-            std::thread t(&io_service_pool::thread_run, this, i, startup);
-            threads_.emplace_back(HPX_MOVE(t));
+            for (std::size_t i = 0; i < num_threads; ++i)
+            {
+                threads_.emplace_back([this, i, startup, gate] {
+                    if (gate->wait())
+                    {
+                        thread_run(i, startup);
+                    }
+                });
+            }
         }
+        catch (...)
+        {
+            gate->cancel();
+            join_locked();
+            throw;
+        }
+
+        gate->release();
 
         next_io_service_ = 0;
         stopped_ = false;

--- a/libs/core/io_service/src/io_service_pool.cpp
+++ b/libs/core/io_service/src/io_service_pool.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Adelstein-Lelbach
 //
 //  Parts of this code were taken from the Boost.Asio library
@@ -60,12 +60,13 @@ namespace hpx::util::detail { namespace {
 
         /// Run all io_service objects in the pool. If join_threads is true
         /// this will also wait for all threads to complete
-        bool run(bool join_threads = true, barrier* startup = nullptr) override;
+        bool run(bool join_threads = true,
+            std::shared_ptr<barrier> startup = {}) override;
 
         /// Run all io_service objects in the pool. If join_threads is true
         /// this will also wait for all threads to complete
         bool run(std::size_t num_threads, bool join_threads = true,
-            barrier* startup = nullptr) override;
+            std::shared_ptr<barrier> startup = {}) override;
 
         /// \brief Stop all io_service objects in the pool.
         void stop() override;
@@ -94,8 +95,8 @@ namespace hpx::util::detail { namespace {
         }
 
         /// \brief Activate the thread \a index for this thread pool
-        void thread_run(
-            std::size_t index, barrier* startup = nullptr) const override;
+        void thread_run(std::size_t index,
+            std::shared_ptr<barrier> startup = {}) const override;
 
         /// \brief Return name of this pool
         [[nodiscard]] char const* get_name() const noexcept override
@@ -106,8 +107,8 @@ namespace hpx::util::detail { namespace {
         void init(std::size_t pool_size) override;
 
     protected:
-        bool run_locked(
-            std::size_t num_threads, bool join_threads, barrier* startup);
+        bool run_locked(std::size_t num_threads, bool join_threads,
+            std::shared_ptr<barrier> startup);
         void stop_locked();
         void join_locked();
         void clear_locked();
@@ -186,8 +187,7 @@ namespace hpx::util::detail { namespace {
         // will not exit until they are explicitly stopped.
         for (std::size_t i = 0; i < pool_size_; ++i)
         {
-            std::unique_ptr<::asio::io_context> p =
-                std::make_unique<::asio::io_context>();
+            auto p = std::make_unique<::asio::io_context>();
             io_services_.emplace_back(HPX_MOVE(p));
             work_.emplace_back(initialize_work(*io_services_[i]));
         }
@@ -218,13 +218,15 @@ namespace hpx::util::detail { namespace {
     }
 
     void io_service_pool::thread_run(
-        std::size_t const index, util::barrier* startup) const
+        std::size_t const index, std::shared_ptr<barrier> const startup) const
     {
-        // wait for all threads to start up before starting HPX work
-        if (startup != nullptr)
-            startup->wait();
-
         notifier_.on_start_thread(index, index, pool_name_, pool_name_postfix_);
+
+        // wait for all threads to start up before starting HPX work
+        if (startup)
+        {
+            startup->wait();
+        }
 
         // use this thread for the given io service
         while (true)
@@ -246,7 +248,7 @@ namespace hpx::util::detail { namespace {
     }
 
     bool io_service_pool::run(std::size_t const num_threads,
-        bool const join_threads, util::barrier* startup)
+        bool const join_threads, std::shared_ptr<barrier> startup)
     {
         std::scoped_lock<std::mutex> l(mtx_);
 
@@ -258,7 +260,9 @@ namespace hpx::util::detail { namespace {
             HPX_ASSERT(work_.size() == io_services_.size());
 
             if (join_threads)
+            {
                 join_locked();
+            }
 
             return false;
         }
@@ -266,12 +270,15 @@ namespace hpx::util::detail { namespace {
         // Give all the io_services work to do so that their run() functions
         // will not exit until they are explicitly stopped.
         if (!io_services_.empty())
+        {
             clear_locked();
+        }
 
-        return run_locked(num_threads, join_threads, startup);
+        return run_locked(num_threads, join_threads, HPX_MOVE(startup));
     }
 
-    bool io_service_pool::run(bool const join_threads, util::barrier* startup)
+    bool io_service_pool::run(
+        bool const join_threads, std::shared_ptr<barrier> startup)
     {
         std::scoped_lock<std::mutex> l(mtx_);
 
@@ -283,7 +290,9 @@ namespace hpx::util::detail { namespace {
             HPX_ASSERT(work_.size() == io_services_.size());
 
             if (join_threads)
+            {
                 join_locked();
+            }
 
             return false;
         }
@@ -291,13 +300,15 @@ namespace hpx::util::detail { namespace {
         // Give all the io_services work to do so that their run() functions
         // will not exit until they are explicitly stopped.
         if (!io_services_.empty())
+        {
             clear_locked();
+        }
 
-        return run_locked(pool_size_, join_threads, startup);
+        return run_locked(pool_size_, join_threads, HPX_MOVE(startup));
     }
 
     bool io_service_pool::run_locked(std::size_t const num_threads,
-        bool const join_threads, util::barrier* startup)
+        bool const join_threads, std::shared_ptr<barrier> startup)
     {
         if (io_services_.empty())
         {
@@ -305,8 +316,7 @@ namespace hpx::util::detail { namespace {
 
             for (std::size_t i = 0; i < num_threads; ++i)
             {
-                std::unique_ptr<::asio::io_context> p =
-                    std::make_unique<::asio::io_context>();
+                auto p = std::make_unique<::asio::io_context>();
                 io_services_.emplace_back(HPX_MOVE(p));
                 work_.emplace_back(initialize_work(*io_services_[i]));
             }
@@ -326,7 +336,9 @@ namespace hpx::util::detail { namespace {
         HPX_ASSERT(work_.size() == io_services_.size());
 
         if (join_threads)
+        {
             join_locked();
+        }
 
         return true;
     }
@@ -341,7 +353,9 @@ namespace hpx::util::detail { namespace {
     {
         // Wait for all threads in the pool to exit.
         for (auto& thread : threads_)
+        {
             thread.join();
+        }
         threads_.clear();
     }
 
@@ -457,7 +471,7 @@ namespace hpx::util::detail { namespace {
 
 namespace hpx::util {
 
-    io_service_pool::io_service_pool(std::size_t pool_size,
+    io_service_pool::io_service_pool(std::size_t const pool_size,
         threads::policies::callback_notifier const& notifier,
         char const* pool_name, char const* name_postfix)
       : pool_(new detail::io_service_pool(
@@ -477,15 +491,16 @@ namespace hpx::util {
         delete pool_;
     }
 
-    bool io_service_pool::run(bool const join_threads, barrier* startup) const
+    bool io_service_pool::run(
+        bool const join_threads, std::shared_ptr<barrier> startup) const
     {
-        return pool_->run(join_threads, startup);
+        return pool_->run(join_threads, HPX_MOVE(startup));
     }
 
     bool io_service_pool::run(std::size_t const num_threads,
-        bool const join_threads, barrier* startup) const
+        bool const join_threads, std::shared_ptr<barrier> startup) const
     {
-        return pool_->run(num_threads, join_threads, startup);
+        return pool_->run(num_threads, join_threads, HPX_MOVE(startup));
     }
 
     void io_service_pool::stop() const
@@ -535,9 +550,9 @@ namespace hpx::util {
     }
 
     void io_service_pool::thread_run(
-        std::size_t const index, barrier* startup) const
+        std::size_t const index, std::shared_ptr<barrier> startup) const
     {
-        pool_->thread_run(index, startup);
+        pool_->thread_run(index, HPX_MOVE(startup));
     }
 
     void io_service_pool::init(std::size_t const pool_size) const

--- a/libs/core/io_service/src/io_service_thread_pool.cpp
+++ b/libs/core/io_service/src/io_service_thread_pool.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017-2023 Hartmut Kaiser
+//  Copyright (c) 2017-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -14,6 +14,7 @@
 
 #include <cstddef>
 #include <exception>
+#include <memory>
 
 namespace hpx::threads::detail {
 
@@ -80,11 +81,14 @@ namespace hpx::threads::detail {
     ///////////////////////////////////////////////////////////////////////////
     bool io_service_thread_pool::run(
         [[maybe_unused]] std::unique_lock<std::mutex>& l,
-        std::size_t num_threads)
+        std::size_t const num_threads)
     {
         HPX_ASSERT(l.owns_lock());
-        util::barrier startup(1);
-        return threads_->run(num_threads, false, &startup);
+
+        auto const startup = std::make_shared<util::barrier>(num_threads + 1);
+        bool const result = threads_->run(num_threads, false, startup);
+        startup->wait();
+        return result;
     }
 
     void io_service_thread_pool::stop(
@@ -121,7 +125,7 @@ namespace hpx::threads::detail {
     }
 
     std::thread& io_service_thread_pool::get_os_thread_handle(
-        std::size_t global_thread_num)
+        std::size_t const global_thread_num)
     {
         return threads_->get_os_thread_handle(
             global_thread_num - this->thread_offset_);

--- a/libs/core/io_service/src/io_service_thread_pool.cpp
+++ b/libs/core/io_service/src/io_service_thread_pool.cpp
@@ -87,7 +87,10 @@ namespace hpx::threads::detail {
 
         auto const startup = std::make_shared<util::barrier>(num_threads + 1);
         bool const result = threads_->run(num_threads, false, startup);
-        startup->wait();
+        if (result)
+        {
+            startup->wait();
+        }
         return result;
     }
 

--- a/libs/core/runtime_local/CMakeLists.txt
+++ b/libs/core/runtime_local/CMakeLists.txt
@@ -107,6 +107,7 @@ add_hpx_module(
   MODULE_DEPENDENCIES
     hpx_async_base
     hpx_command_line_handling_local
+    hpx_concurrency
     hpx_coroutines
     hpx_debugging
     hpx_errors

--- a/libs/core/runtime_local/include/hpx/runtime_local/thread_mapper.hpp
+++ b/libs/core/runtime_local/include/hpx/runtime_local/thread_mapper.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2012 Maciej Brodowicz
-//  Copyright (c) 2020-2024 Hartmut Kaiser
+//  Copyright (c) 2020-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -44,8 +44,12 @@ namespace hpx::util {
         {
         public:
             os_thread_data() = default;
+
+            /// Construct metadata for the current OS thread.
+            /// \param label The thread label.
+            /// \param type The runtime thread type.
             os_thread_data(
-                std::string const& label, runtime_local::os_thread_type type);
+                std::string label, runtime_local::os_thread_type type);
 
         protected:
             friend class util::thread_mapper;

--- a/libs/core/runtime_local/src/runtime_local.cpp
+++ b/libs/core/runtime_local/src/runtime_local.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -10,6 +10,7 @@
 #include <hpx/assert.hpp>
 
 #include <hpx/modules/command_line_handling_local.hpp>
+#include <hpx/modules/concurrency.hpp>
 #include <hpx/modules/coroutines.hpp>
 #include <hpx/modules/debugging.hpp>
 #include <hpx/modules/errors.hpp>
@@ -28,6 +29,7 @@
 #include <hpx/modules/tracing.hpp>
 #include <hpx/modules/type_support.hpp>
 #include <hpx/modules/util.hpp>
+
 #include <hpx/runtime_local/config_entry.hpp>
 #include <hpx/runtime_local/custom_exception_info.hpp>
 #include <hpx/runtime_local/debugging.hpp>
@@ -1515,11 +1517,19 @@ namespace hpx {
             runtime_local::os_thread_type::main_thread, 0, 0, "", "", false);
 
 #ifdef HPX_HAVE_IO_POOL
-        // start the io pool
-        io_pool_->run(false);
-        HPX_UNUSED(
-            lbt_ << "(1st stage) runtime::start: started the application "
-                    "I/O service pool");
+        {
+            // start the io pool
+            auto const p =
+                std::make_shared<util::barrier>(io_pool_->size() + 1);
+            if (io_pool_->run(false, p))
+            {
+                p->wait();
+            }
+
+            HPX_UNUSED(lbt_
+                << "(1st stage) runtime::start: started the application "
+                   "I/O service pool");
+        }
 #endif
         // start the thread manager
         if (!thread_manager_->run())

--- a/libs/core/runtime_local/src/thread_mapper.cpp
+++ b/libs/core/runtime_local/src/thread_mapper.cpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2012 Maciej Brodowicz
+//  Copyright (c) 2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -43,8 +44,8 @@ namespace hpx::util {
 
         // thread-specific data
         os_thread_data::os_thread_data(
-            std::string const& label, runtime_local::os_thread_type type)
-          : label_(label)
+            std::string label, runtime_local::os_thread_type const type)
+          : label_(HPX_MOVE(label))
           , id_(std::this_thread::get_id())
           , tid_(get_system_thread_id())
 #if defined(HPX_HAVE_PAPI) && defined(__linux__) && !defined(__ANDROID) &&     \
@@ -72,14 +73,14 @@ namespace hpx::util {
 
     thread_mapper::~thread_mapper()
     {
-        std::lock_guard<mutex_type> m(mtx_);
+        std::scoped_lock m(mtx_);
 
         std::uint32_t i = 0;
         for (auto&& tinfo : thread_map_)
         {
             if (tinfo.cleanup_)
             {
-                tinfo.cleanup_(i++);
+                [[maybe_unused]] auto _ = tinfo.cleanup_(i++);
             }
         }
     }
@@ -87,13 +88,15 @@ namespace hpx::util {
     std::uint32_t thread_mapper::register_thread(
         char const* name, runtime_local::os_thread_type type)
     {
-        std::lock_guard<mutex_type> m(mtx_);
+        std::unique_lock m(mtx_);
 
         auto const tid = detail::get_system_thread_id();
         for (auto&& tinfo : thread_map_)
         {
             if (tinfo.tid_ == tid)
             {
+                m.unlock();
+
                 HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                     "thread_mapper::register_thread",
                     "thread already registered");
@@ -111,7 +114,7 @@ namespace hpx::util {
 
     bool thread_mapper::unregister_thread()
     {
-        std::lock_guard<mutex_type> m(mtx_);
+        std::scoped_lock m(mtx_);
 
         std::uint32_t i = 0;
         auto const tid = detail::get_system_thread_id();
@@ -142,9 +145,9 @@ namespace hpx::util {
     }
 
     bool thread_mapper::register_callback(
-        std::uint32_t tix, callback_type const& cb)
+        std::uint32_t const tix, callback_type const& cb)
     {
-        std::lock_guard<mutex_type> m(mtx_);
+        std::scoped_lock m(mtx_);
 
         auto const idx = static_cast<std::size_t>(tix);
         if (idx >= thread_map_.size() ||
@@ -157,9 +160,9 @@ namespace hpx::util {
         return true;
     }
 
-    bool thread_mapper::revoke_callback(std::uint32_t tix)
+    bool thread_mapper::revoke_callback(std::uint32_t const tix)
     {
-        std::lock_guard<mutex_type> m(mtx_);
+        std::scoped_lock m(mtx_);
 
         auto const idx = static_cast<std::size_t>(tix);
         if (idx >= thread_map_.size() ||
@@ -172,9 +175,9 @@ namespace hpx::util {
         return true;
     }
 
-    std::thread::id thread_mapper::get_thread_id(std::uint32_t tix) const
+    std::thread::id thread_mapper::get_thread_id(std::uint32_t const tix) const
     {
-        std::lock_guard<mutex_type> m(mtx_);
+        std::scoped_lock m(mtx_);
 
         auto const idx = static_cast<std::size_t>(tix);
         if (idx >= thread_map_.size())
@@ -185,9 +188,9 @@ namespace hpx::util {
     }
 
     std::uint64_t thread_mapper::get_thread_native_handle(
-        std::uint32_t tix) const
+        std::uint32_t const tix) const
     {
-        std::lock_guard<mutex_type> m(mtx_);
+        std::scoped_lock m(mtx_);
 
         auto const idx = static_cast<std::size_t>(tix);
         if (idx >= thread_map_.size())
@@ -212,9 +215,10 @@ namespace hpx::util {
     }
 #endif
 
-    std::string const& thread_mapper::get_thread_label(std::uint32_t tix) const
+    std::string const& thread_mapper::get_thread_label(
+        std::uint32_t const tix) const
     {
-        std::lock_guard<mutex_type> m(mtx_);
+        std::scoped_lock m(mtx_);
 
         auto const idx = static_cast<std::size_t>(tix);
         if (idx >= thread_map_.size())
@@ -226,9 +230,9 @@ namespace hpx::util {
     }
 
     runtime_local::os_thread_type thread_mapper::get_thread_type(
-        std::uint32_t tix) const
+        std::uint32_t const tix) const
     {
-        std::lock_guard<mutex_type> m(mtx_);
+        std::scoped_lock m(mtx_);
 
         auto const idx = static_cast<std::size_t>(tix);
         if (idx >= thread_map_.size())
@@ -241,7 +245,7 @@ namespace hpx::util {
     std::uint32_t thread_mapper::get_thread_index(
         std::string const& label) const
     {
-        std::lock_guard<mutex_type> m(mtx_);
+        std::scoped_lock m(mtx_);
 
         auto const it = label_map_.find(label);
         if (it == label_map_.end())
@@ -253,7 +257,7 @@ namespace hpx::util {
 
     std::uint32_t thread_mapper::get_thread_count() const
     {
-        std::lock_guard<mutex_type> m(mtx_);
+        std::scoped_lock m(mtx_);
 
         return static_cast<std::uint32_t>(label_map_.size());
     }
@@ -262,37 +266,44 @@ namespace hpx::util {
     os_thread_data thread_mapper::get_os_thread_data(
         std::string const& label) const
     {
-        std::lock_guard<mutex_type> m(mtx_);
+        std::scoped_lock m(mtx_);
 
         auto const it = label_map_.find(label);
         if (it == label_map_.end())
         {
-            return runtime_local::os_thread_data{"", std::thread::id{},
-                thread_mapper::invalid_tid,
-                runtime_local::os_thread_type::unknown};
+            return runtime_local::os_thread_data{.label_ = "",
+                .id_ = std::thread::id{},
+                .native_handle_ = thread_mapper::invalid_tid,
+                .type_ = runtime_local::os_thread_type::unknown};
         }
 
         auto const idx = static_cast<std::size_t>(it->second);
         if (idx >= thread_map_.size())
         {
-            return runtime_local::os_thread_data{"", std::thread::id{},
-                thread_mapper::invalid_tid,
-                runtime_local::os_thread_type::unknown};
+            return runtime_local::os_thread_data{.label_ = "",
+                .id_ = std::thread::id{},
+                .native_handle_ = thread_mapper::invalid_tid,
+                .type_ = runtime_local::os_thread_type::unknown};
         }
 
         auto const& tinfo = thread_map_[idx];
-        return runtime_local::os_thread_data{
-            tinfo.label_, tinfo.id_, tinfo.tid_, tinfo.type_};
+        return runtime_local::os_thread_data{.label_ = tinfo.label_,
+            .id_ = tinfo.id_,
+            .native_handle_ = tinfo.tid_,
+            .type_ = tinfo.type_};
     }
 
     bool thread_mapper::enumerate_os_threads(
         hpx::function<bool(os_thread_data const&)> const& f) const
     {
-        std::lock_guard<mutex_type> m(mtx_);
+        std::scoped_lock m(mtx_);
         for (auto const& tinfo : thread_map_)
         {
-            os_thread_data data{
-                tinfo.label_, tinfo.id_, tinfo.tid_, tinfo.type_};
+            os_thread_data data{.label_ = tinfo.label_,
+                .id_ = tinfo.id_,
+                .native_handle_ = tinfo.tid_,
+                .type_ = tinfo.type_};
+
             if (!f(data))
             {
                 return false;

--- a/libs/core/runtime_local/tests/unit/thread_mapper.cpp
+++ b/libs/core/runtime_local/tests/unit/thread_mapper.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2020-2025 Hartmut Kaiser
+//  Copyright (c) 2020-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -14,50 +14,61 @@
 #include <thread>
 #include <vector>
 
-void enumerate_threads(std::size_t num_custom_threads)
-{
-    std::size_t counts[std::size_t(hpx::os_thread_type::custom_thread) + 1] = {
-        0};
+namespace {
 
-    bool result =
-        hpx::enumerate_os_threads([&counts](hpx::os_thread_data const& data) {
-            if (data.type_ != hpx::os_thread_type::unknown)
-            {
-                HPX_TEST(std::size_t(data.type_) <=
-                    std::size_t(hpx::os_thread_type::custom_thread));
+    void enumerate_threads(std::size_t const num_custom_threads)
+    {
+        std::size_t counts[static_cast<std::size_t>(
+                               hpx::os_thread_type::custom_thread) +
+            1] = {0};
 
-                ++counts[std::size_t(data.type_)];
-                HPX_TEST(data.label_.find(hpx::get_os_thread_type_name(
-                             data.type_)) != std::string::npos);
-            }
-            return true;
-        });
-    HPX_TEST(result);
+        bool const result = hpx::enumerate_os_threads(
+            [&counts](hpx::os_thread_data const& data) {
+                if (data.type_ != hpx::os_thread_type::unknown)
+                {
+                    HPX_TEST(static_cast<std::size_t>(data.type_) <=
+                        static_cast<std::size_t>(
+                            hpx::os_thread_type::custom_thread));
 
-    HPX_TEST_EQ(
-        counts[std::size_t(hpx::os_thread_type::main_thread)], std::size_t(1));
+                    ++counts[static_cast<std::size_t>(data.type_)];
+                    HPX_TEST(data.label_.find(hpx::get_os_thread_type_name(
+                                 data.type_)) != std::string::npos);
+                }
+                return true;
+            });
+        HPX_TEST(result);
 
-    std::size_t num_workers = hpx::get_num_worker_threads();
-    HPX_TEST_EQ(
-        counts[std::size_t(hpx::os_thread_type::worker_thread)], num_workers);
+        HPX_TEST_EQ(
+            counts[static_cast<std::size_t>(hpx::os_thread_type::main_thread)],
+            static_cast<std::size_t>(1));
+
+        std::size_t const num_workers = hpx::get_num_worker_threads();
+        HPX_TEST_EQ(counts[static_cast<std::size_t>(
+                        hpx::os_thread_type::worker_thread)],
+            num_workers);
 
 #ifdef HPX_HAVE_IO_POOL
-    std::size_t num_io_threads = hpx::util::from_string<std::size_t>(
-        hpx::get_config_entry("hpx.threadpools.io_pool_size", "0"));
-    HPX_TEST_EQ(
-        counts[std::size_t(hpx::os_thread_type::io_thread)], num_io_threads);
+        std::size_t const num_io_threads = hpx::util::from_string<std::size_t>(
+            hpx::get_config_entry("hpx.threadpools.io_pool_size", "0"));
+        HPX_TEST_EQ(
+            counts[static_cast<std::size_t>(hpx::os_thread_type::io_thread)],
+            num_io_threads);
 #endif
 
 #ifdef HPX_HAVE_TIMER_POOL
-    std::size_t num_timer_threads = hpx::util::from_string<std::size_t>(
-        hpx::get_config_entry("hpx.threadpools.timer_pool_size", "0"));
-    HPX_TEST_EQ(counts[std::size_t(hpx::os_thread_type::timer_thread)],
-        num_timer_threads);
+        std::size_t const num_timer_threads =
+            hpx::util::from_string<std::size_t>(
+                hpx::get_config_entry("hpx.threadpools.timer_pool_size", "0"));
+        HPX_TEST_EQ(
+            counts[static_cast<std::size_t>(hpx::os_thread_type::timer_thread)],
+            num_timer_threads);
 #endif
 
-    HPX_TEST_EQ(counts[std::size_t(hpx::os_thread_type::custom_thread)],
-        num_custom_threads);
-}
+        HPX_TEST_EQ(counts[static_cast<std::size_t>(
+                        hpx::os_thread_type::custom_thread)],
+            num_custom_threads);
+    }
+}    // namespace
 
 int hpx_main()
 {
@@ -77,7 +88,7 @@ int hpx_main()
 
 int main(int argc, char* argv[])
 {
-    hpx::local::init_params init_args;
+    hpx::local::init_params const init_args;
 
     HPX_TEST_EQ(hpx::local::init(hpx_main, argc, argv, init_args), 0);
 

--- a/libs/core/threadmanager/CMakeLists.txt
+++ b/libs/core/threadmanager/CMakeLists.txt
@@ -29,6 +29,7 @@ add_hpx_module(
   COMPAT_HEADERS ${threadmanager_compat_headers}
   MODULE_DEPENDENCIES
     hpx_async_combinators
+    hpx_concurrency
     hpx_errors
     hpx_execution
     hpx_execution_base

--- a/libs/core/threadmanager/src/threadmanager.cpp
+++ b/libs/core/threadmanager/src/threadmanager.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2024 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach, Katelyn Kufahl
 //  Copyright (c) 2008-2009 Chirag Dekate, Anshul Tandon
 //  Copyright (c) 2015 Patricia Grubel
@@ -11,6 +11,7 @@
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/modules/async_combinators.hpp>
+#include <hpx/modules/concurrency.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/execution_base.hpp>
@@ -1579,8 +1580,15 @@ namespace hpx::threads {
         init_tss(rp.get_num_threads());
 
 #ifdef HPX_HAVE_TIMER_POOL
-        LTM_(info).format("run: running timer pool");
-        timer_pool_.run(false);
+        {
+            LTM_(info).format("run: running timer pool");
+            auto const p =
+                std::make_shared<util::barrier>(timer_pool_.size() + 1);
+            if (timer_pool_.run(false, p))
+            {
+                p->wait();
+            }
+        }
 #endif
 
         for (auto const& pool_iter : pools_)


### PR DESCRIPTION
## Thread startup synchronization and mapper cleanup

### Summary
Synchronizes I/O and timer pool startup in the runtime and thread manager, and cleans up thread mapper ownership, locking, and initialization.

### Changes

**Pool startup barriers**
- `runtime_local.cpp` / `threadmanager.cpp`: Runtime and thread manager startup now wait on I/O and timer pool startup barriers before proceeding, ensuring pool worker threads have reached their startup point.
- `io_service_pool.cpp`: Adds/updates the startup barrier mechanism used by the I/O service pool.
- `CMakeLists.txt` (runtime_local, threadmanager): Minor build config updates related to the above.

**Thread mapper state and locking**
- `thread_mapper.hpp` / `thread_mapper.cpp`: Moves labels into thread data, switches to scoped locking, unlocks before throwing on duplicate registration, and uses designated initialization for OS thread data.

**Thread mapper test updates**
- `thread_mapper.cpp` (unit test): Const-correctness and formatting cleanup; existing thread enumeration checks preserved.


