### PR TITLE
Fix the two shutdown regressions from #7471 that hang the distributed CIs

### DIFF
--- a/libs/full/parcelset/include/hpx/parcelset/parcelport_impl.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/parcelport_impl.hpp
@@ -1093,10 +1093,10 @@ namespace hpx::parcelset {
                     parcel_locality_id, HPX_MOVE(parcels), HPX_MOVE(handlers));
             }
 
-            // We yield here for a short amount of time to give another HPX
-            // thread the chance to put a subsequent parcel which leads to a
-            // more effective parcel buffering
-            hpx::execution_base::this_thread::yield();
+            // Note: this function must not suspend. It executes within the
+            // operations_in_flight_ window opened by the caller, and a
+            // suspension here can live-lock against a higher-priority thread
+            // spinning in flush_parcels waiting for that count to drop.
         }
 
     public:

--- a/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
+++ b/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
@@ -376,12 +376,12 @@ namespace hpx::components::server {
             locality_id = num_localities;
 
         // accommodate for disconnected localities
-        bool const token_sent = detail::dijkstra_forward_token(locality_id,
-            initiating_locality_id,
-            [&](std::uint32_t const target_locality_id) {
-                return send_dijkstra_termination_token(target_locality_id,
-                    initiating_locality_id, num_localities, dijkstra_color_);
-            });
+        bool const token_sent =
+            detail::dijkstra_forward_token(locality_id, initiating_locality_id,
+                [&](std::uint32_t const target_locality_id) {
+                    return send_dijkstra_termination_token(target_locality_id,
+                        initiating_locality_id, num_localities, dijkstra_token);
+                });
 
         if (!token_sent && initiating_locality_id != agas::get_locality_id())
         {
@@ -396,9 +396,9 @@ namespace hpx::components::server {
             for (int attempt = 0;
                 !fallback_sent && attempt != max_fallback_attempts; ++attempt)
             {
-                fallback_sent = send_dijkstra_termination_token(
-                    initiating_locality_id, initiating_locality_id,
-                    num_localities, dijkstra_color_);
+                fallback_sent =
+                    send_dijkstra_termination_token(initiating_locality_id,
+                        initiating_locality_id, num_localities, dijkstra_token);
             }
 
             if (!fallback_sent)

--- a/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
+++ b/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
@@ -284,14 +284,8 @@ namespace hpx::components::server {
         // Rule 2: When machine nr.i + 1 propagates the probe, it hands over a
         // black token to machine nr.i if it is black itself, whereas while
         // being white it leaves the color of the token unchanged.
-        {
-            if (!passive || dijkstra_color_)
-                dijkstra_token = true;
-
-            // Rule 5: Upon transmission of the token to machine nr.i, machine
-            // nr.i + 1 becomes white.
-            dijkstra_color_ = false;
-        }
+        if (!passive || dijkstra_color_)
+            dijkstra_token = true;
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         // Only the post_cb completion callback ever counts down the latch;
@@ -318,7 +312,18 @@ namespace hpx::components::server {
                 // callback above has been registered and is guaranteed to run
                 // (and count down the latch) eventually.
                 l->wait();
-                return !ec;
+                if (ec)
+                {
+                    return false;
+                }
+
+                // Rule 5: Upon transmission of the token to machine nr.i,
+                // machine nr.i + 1 becomes white. Whitening before the send
+                // would drop the local taint whenever the send fails, because
+                // dijkstra_forward_token and the fallback loop both re-read
+                // dijkstra_color_ for every retry.
+                dijkstra_color_ = false;
+                return true;
             },
             [&](std::exception_ptr const& e) {
                 // post_cb threw synchronously, i.e. the completion callback


### PR DESCRIPTION
Fixes the two remaining #7471 shutdown regressions behind the hierarchical-collectives timeouts on the rostam CIs (#7503). Two independent one-file commits.

## 1. Termination detection loses the token's taint

`runtime_support::dijkstra_termination` forwards `dijkstra_color_` (the forwarder's own color, freshly reset every round) instead of the received `dijkstra_token`. The initiator's busy-taint travels in the token: `send_dijkstra_termination_token` waits up to 10ms for the local thread manager to drain and taints the token when it cannot (`if (!passive || dijkstra_color_) dijkstra_token = true`). Dropping the received token on the forwarding hop lets a probe come back white while the console is still running application threads between sends.

The observable consequence: with two localities the non-console locality finishes `hpx_main` first (its symbol operations are served locally, the console's are remote), posts `shutdown_all`, the probe passes while the console is mid-test, and the console's remaining operations to the other locality strand forever. The console then spins in `runtime_support::stop` on `is_busy()` while the other locality waits in `mpi::parcelport::do_stop`'s `MPI_Barrier`. Instrumented traces show 341 tokens circulating before this change's parent (the pre-#7495 cursor bug acted as an accidental grace period) versus 5 after, with `shutdown_action` sent mid-test.

The fix forwards the received token again at both forwarding sites; the sender already ORs in the local color and passivity.

## 2. Suspension inside the new in-flight window

`send_pending_parcels` ends with an advisory `this_thread::yield()` ("more effective parcel buffering", pre-existing). #7471 wrapped its caller `get_connection_and_send_parcels` in the new `++operations_in_flight_` / scope-exit guard, so that yield now suspends while holding the in-flight count. Every received parcel is scheduled at `thread_priority::boost` (`handle_received_parcels`), so the termination-token handler's `parcelhandler::flush_parcels` spin outranks the default-priority sender parked on the yield. With one worker thread that is a permanent priority-inversion livelock: `operations_in_flight_ == 1`, `pending == 0`, observed unchanged for 40M+ spin iterations, with the sender's trace ending between `async_write` returning and the function exit.

This explains the failure selectivity exactly: `--hpx:threads=2` and up pass (another worker finishes the sender), LCI/LCW pass (send-immediate is on by default so this path is not taken), MPI fails (`hpx.parcel.mpi.sendimm` defaults to 0, the queued path), TCP rarely lines up the window. Before #7471 the counter only tracked hardware-completed writes, which background work drains without needing the starved thread.

The fix removes the yield and documents that the function must not suspend inside the in-flight window. A residual hazard is noted here for completeness: encode-time GID credit splitting could in principle suspend in the same window (not observed).

## Verification

Rostam (medusa, Debug, clang-19, C++23, the full LSU CI option set, `HPXRUN_RUNWRAPPER=srun`), all previously-hanging configurations, 26/26 pass:

- `--hpx:threads=1 -l 2` mpi: `broadcast_hierarchical` x3, `barrier_hierarchical` x3, `all_reduce_hierarchical`
- `--hpx:threads=1 -l 5` mpi: `hierarchical_flat_fallback` x2
- `--hpx:threads=1 -l 2` lci, lcw, tcp
- `--hpx:threads=2 -l 2` mpi: broadcast/all_reduce/barrier/gather/subtree_gather_scatter/cross_collective/concurrent_collectives/inclusive_scan hierarchical, broadcast_sync, hierarchical_flat_fallback (each was a 300s timeout before)
- `--hpx:threads=4 -l 2` and `-l 4` mpi, tcp controls
- `dijkstra_termination_forwarding` unit test

Bisect for both regressions: `aa0fabb3eb` (parent of #7471) passes everything; the first commit of #7471 hangs. Fixes #7503.
