### PR TITLE
Make the nvcc CUDA configurations compile and pass again

### DIFF
--- a/cmake/HPX_PatchStdexecNvcc.cmake
+++ b/cmake/HPX_PatchStdexecNvcc.cmake
@@ -18,9 +18,21 @@ if(NOT DEFINED HPX_STDEXEC_NVCC_PATCH_FILE)
   message(FATAL_ERROR "HPX_STDEXEC_NVCC_PATCH_FILE must be defined")
 endif()
 
+# Only an nvcc build is broken by an unpatched stdexec, and
+# HPX_STDEXEC_NVCC_PATCH_REQUIRED says whether this is one. Fail hard there;
+# warn everywhere else rather than failing configuration for users whose
+# compiler parses stdexec unpatched.
+if(HPX_STDEXEC_NVCC_PATCH_REQUIRED)
+  set(_hpx_stdexec_nvcc_patch_severity FATAL_ERROR)
+else()
+  set(_hpx_stdexec_nvcc_patch_severity WARNING)
+endif()
+
 find_package(Git QUIET)
 if(NOT GIT_EXECUTABLE)
-  message(WARNING "git not found, cannot apply the stdexec nvcc workarounds")
+  message(${_hpx_stdexec_nvcc_patch_severity}
+          "git not found, cannot apply the stdexec nvcc workarounds"
+  )
   return()
 endif()
 
@@ -44,7 +56,7 @@ execute_process(
 )
 if(NOT _hpx_stdexec_nvcc_patch_result EQUAL 0)
   message(
-    WARNING
-      "Failed to apply the stdexec nvcc workarounds: ${_hpx_stdexec_nvcc_patch_error}"
+    ${_hpx_stdexec_nvcc_patch_severity}
+    "Failed to apply the stdexec nvcc workarounds: ${_hpx_stdexec_nvcc_patch_error}"
   )
 endif()

--- a/cmake/HPX_PatchStdexecNvcc.cmake
+++ b/cmake/HPX_PatchStdexecNvcc.cmake
@@ -1,0 +1,50 @@
+#  Copyright (c) 2026 Hartmut Kaiser
+#  Copyright (c) 2026 Anshuman Agrawal
+#
+#  SPDX-License-Identifier: BSL-1.0
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# Applies the nvcc compatibility workarounds to the fetched stdexec sources.
+# stdexec's own GPU CI covers clang-CUDA and nvc++ only; without these patches
+# no translation unit compiled by nvcc can include the HPX execution headers.
+# See cmake/HPX_StdexecNvccWorkarounds.patch for the details.
+
+if(NOT DEFINED HPX_STDEXEC_SOURCE_DIR)
+  message(FATAL_ERROR "HPX_STDEXEC_SOURCE_DIR must be defined")
+endif()
+
+if(NOT DEFINED HPX_STDEXEC_NVCC_PATCH_FILE)
+  message(FATAL_ERROR "HPX_STDEXEC_NVCC_PATCH_FILE must be defined")
+endif()
+
+find_package(Git QUIET)
+if(NOT GIT_EXECUTABLE)
+  message(WARNING "git not found, cannot apply the stdexec nvcc workarounds")
+  return()
+endif()
+
+# Already applied (a reconfigure re-runs the patch command)?
+execute_process(
+  COMMAND "${GIT_EXECUTABLE}" apply --reverse --check
+          "${HPX_STDEXEC_NVCC_PATCH_FILE}"
+  WORKING_DIRECTORY "${HPX_STDEXEC_SOURCE_DIR}"
+  RESULT_VARIABLE _hpx_stdexec_nvcc_patch_applied
+  OUTPUT_QUIET ERROR_QUIET
+)
+if(_hpx_stdexec_nvcc_patch_applied EQUAL 0)
+  return()
+endif()
+
+execute_process(
+  COMMAND "${GIT_EXECUTABLE}" apply "${HPX_STDEXEC_NVCC_PATCH_FILE}"
+  WORKING_DIRECTORY "${HPX_STDEXEC_SOURCE_DIR}"
+  RESULT_VARIABLE _hpx_stdexec_nvcc_patch_result
+  ERROR_VARIABLE _hpx_stdexec_nvcc_patch_error
+)
+if(NOT _hpx_stdexec_nvcc_patch_result EQUAL 0)
+  message(
+    WARNING
+      "Failed to apply the stdexec nvcc workarounds: ${_hpx_stdexec_nvcc_patch_error}"
+  )
+endif()

--- a/cmake/HPX_SetupStdexec.cmake
+++ b/cmake/HPX_SetupStdexec.cmake
@@ -21,6 +21,15 @@ if(HPX_WITH_FETCH_STDEXEC)
     "HPX_WITH_FETCH_STDEXEC=${HPX_WITH_FETCH_STDEXEC}, Stdexec will be fetched using CMake's FetchContent and installed alongside HPX (HPX_WITH_STDEXEC_TAG=${HPX_WITH_STDEXEC_TAG})"
   )
 
+  # The nvcc workarounds only matter when nvcc itself compiles the HPX execution
+  # headers; clang-CUDA and every non-CUDA build parse stdexec fine without
+  # them. Report that below so a patch that no longer applies fails the builds
+  # it breaks instead of every build that fetches stdexec.
+  set(_hpx_stdexec_nvcc_patch_required OFF)
+  if(HPX_WITH_CUDA AND CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA")
+    set(_hpx_stdexec_nvcc_patch_required ON)
+  endif()
+
   include(FetchContent)
   # We only consume stdexec's headers; HPX wraps them with its own `Stdexec`
   # INTERFACE target below. SOURCE_SUBDIR points at a non-existent path so
@@ -38,6 +47,7 @@ if(HPX_WITH_FETCH_STDEXEC)
       -P ${CMAKE_CURRENT_LIST_DIR}/HPX_PatchStdexecSpinLoopPause.cmake COMMAND
       ${CMAKE_COMMAND} "-DHPX_STDEXEC_SOURCE_DIR=<SOURCE_DIR>"
       "-DHPX_STDEXEC_NVCC_PATCH_FILE=${CMAKE_CURRENT_LIST_DIR}/HPX_StdexecNvccWorkarounds.patch"
+      "-DHPX_STDEXEC_NVCC_PATCH_REQUIRED=${_hpx_stdexec_nvcc_patch_required}"
       -P ${CMAKE_CURRENT_LIST_DIR}/HPX_PatchStdexecNvcc.cmake
   )
 

--- a/cmake/HPX_SetupStdexec.cmake
+++ b/cmake/HPX_SetupStdexec.cmake
@@ -35,7 +35,10 @@ if(HPX_WITH_FETCH_STDEXEC)
     PATCH_COMMAND
       ${CMAKE_COMMAND}
       "-DHPX_STDEXEC_SPIN_LOOP_PAUSE_FILE=<SOURCE_DIR>/include/stdexec/__detail/__spin_loop_pause.hpp"
-      -P ${CMAKE_CURRENT_LIST_DIR}/HPX_PatchStdexecSpinLoopPause.cmake
+      -P ${CMAKE_CURRENT_LIST_DIR}/HPX_PatchStdexecSpinLoopPause.cmake COMMAND
+      ${CMAKE_COMMAND} "-DHPX_STDEXEC_SOURCE_DIR=<SOURCE_DIR>"
+      "-DHPX_STDEXEC_NVCC_PATCH_FILE=${CMAKE_CURRENT_LIST_DIR}/HPX_StdexecNvccWorkarounds.patch"
+      -P ${CMAKE_CURRENT_LIST_DIR}/HPX_PatchStdexecNvcc.cmake
   )
 
   fetchcontent_makeavailable(Stdexec)

--- a/cmake/HPX_StdexecNvccWorkarounds.patch
+++ b/cmake/HPX_StdexecNvccWorkarounds.patch
@@ -1,0 +1,201 @@
+Workarounds for building stdexec with nvcc as the CUDA compiler.
+
+stdexec's own GPU CI covers clang-CUDA and nvc++ only, and current stdexec
+main does not compile under nvcc. These changes make the headers acceptable
+to nvcc 12.9 with a gcc 12 host compiler:
+
+- __connect.hpp: nvcc rejects the constrained redeclarations of the
+  __connect_declfn_v variable template; use the existing MSVC if-constexpr
+  fallback for nvcc as well.
+- __counting_scopes.hpp: the sender constraint on the two join() members
+  fails in the host compiler pass on the cudafe-transformed sexpr; relax the
+  return-type constraint under nvcc (the returned type is unchanged).
+- __env.hpp: nvcc fails to deduce __as_root_env_fn::operator() when the
+  return type goes through the __join_env_t alias (a call through an
+  `auto const&` NTTP) in an unevaluated context; spell the result type out
+  structurally under nvcc.
+- __receiver_adaptor.hpp: nvcc's front end mis-parses the qualified
+  concept-id in the __has_base initializer; parenthesize it.
+- __transform_completion_signatures.hpp: nvcc rejects the pack expansion of
+  the diagnostic function type _WHERE_(_IN_ALGORITHM_, _AlgoTag); form it
+  through an alias template so the function-type syntax stays dependent.
+- __typeinfo.hpp: the pretty-function name extraction is wrong under nvcc
+  (diagnostics-only, skip the assert), and the __type_index NTTP form of
+  __msplice ICEs gcc < 13 as the host compiler behind nvcc, which does not
+  hit the existing STDEXEC_GCC() version check.
+
+SPDX-License-Identifier: BSL-1.0
+
+diff --git a/include/stdexec/__detail/__connect.hpp b/include/stdexec/__detail/__connect.hpp
+index d9b4c5d6..4fede426 100644
+--- a/include/stdexec/__detail/__connect.hpp
++++ b/include/stdexec/__detail/__connect.hpp
+@@ -64,7 +64,7 @@ namespace STDEXEC
+                               || __with_co_await<_Sender, _Receiver>
+                               || __with_legacy_tag_invoke<_Sender, _Receiver>;
+ 
+-#  if !STDEXEC_MSVC()
++#  if !STDEXEC_MSVC() && !STDEXEC_NVCC()
+ 
+ #    define STDEXEC_CONNECT_DECLFN_FOR(_EXPR) __declfn_t<decltype(_EXPR), noexcept(_EXPR)>
+ 
+diff --git a/include/stdexec/__detail/__counting_scopes.hpp b/include/stdexec/__detail/__counting_scopes.hpp
+index dc1651b8..c199c36a 100644
+--- a/include/stdexec/__detail/__counting_scopes.hpp
++++ b/include/stdexec/__detail/__counting_scopes.hpp
+@@ -46,6 +46,15 @@ import stdexec;
+ 
+ #  include "__prologue.hpp"
+ 
++// nvcc's cudafe lambda transformation makes the __scope_join_t sexpr fail the
++// sender constraint in the host compiler pass; relax the return-type
++// constraint there. The returned type is unchanged.
++#if STDEXEC_NVCC()
++#  define STDEXEC_JOIN_SENDER_AUTO auto
++#else
++#  define STDEXEC_JOIN_SENDER_AUTO sender auto
++#endif
++
+ namespace STDEXEC
+ {
+   struct _JOINING_A_COUNTING_SCOPE_NEEDS_A_SCHEDULER_IN_THE_ENVIRONMENT_
+@@ -773,7 +782,7 @@ namespace STDEXEC
+     using __counting_scopes::__base_scope::close;
+ 
+     [[nodiscard]]
+-    sender auto join() noexcept
++    STDEXEC_JOIN_SENDER_AUTO join() noexcept
+     {
+       // [exec.simple.counting.mem] paragraph 4
+       return __make_sexpr<__counting_scopes::__scope_join_t>(this);
+@@ -847,7 +856,7 @@ namespace STDEXEC
+     using __counting_scopes::__base_scope::close;
+ 
+     [[nodiscard]]
+-    sender auto join() noexcept
++    STDEXEC_JOIN_SENDER_AUTO join() noexcept
+     {
+       return __make_sexpr<__counting_scopes::__scope_join_t>(this);
+     }
+diff --git a/include/stdexec/__detail/__env.hpp b/include/stdexec/__detail/__env.hpp
+index a3102eb5..403e202a 100644
+--- a/include/stdexec/__detail/__env.hpp
++++ b/include/stdexec/__detail/__env.hpp
+@@ -159,6 +159,34 @@ namespace STDEXEC
+       }
+     };
+ 
++#if STDEXEC_NVCC()
++    // nvcc fails to deduce operator() when the return type goes through the
++    // __join_env_t alias (a call through an `auto const&` NTTP) in an
++    // unevaluated context. Spell the result type out structurally instead;
++    // it mirrors __join_fn's branches for a by-value environment exactly.
++    template <class _Env>
++    struct __as_root_env_result
++    {
++      using __t = env<__root_env, __if_c<__is_fwd_env<_Env>, _Env, __fwd<_Env>>>;
++    };
++
++    template <>
++    struct __as_root_env_result<env<>>
++    {
++      using __t = __root_env;
++    };
++
++    struct __as_root_env_fn
++    {
++      template <class _Env>
++      STDEXEC_ATTRIBUTE(nodiscard, always_inline, host, device)
++      constexpr auto operator()(_Env __env) const noexcept ->
++        typename __as_root_env_result<std::unwrap_reference_t<_Env>>::__t
++      {
++        return __join(__root_env{}, static_cast<std::unwrap_reference_t<_Env> &&>(__env));
++      }
++    };
++#else
+     struct __as_root_env_fn
+     {
+       template <class _Env>
+@@ -169,6 +197,7 @@ namespace STDEXEC
+         return __join(__root_env{}, static_cast<std::unwrap_reference_t<_Env> &&>(__env));
+       }
+     };
++#endif
+   }  // namespace __env
+ 
+   STDEXEC_MODULE_EXPORT_AUTHORING
+diff --git a/include/stdexec/__detail/__receiver_adaptor.hpp b/include/stdexec/__detail/__receiver_adaptor.hpp
+index b670170f..2a68be62 100644
+--- a/include/stdexec/__detail/__receiver_adaptor.hpp
++++ b/include/stdexec/__detail/__receiver_adaptor.hpp
+@@ -122,7 +122,8 @@ namespace STDEXEC
+     : __adaptors::__adaptor_base<_Base>
+     , receiver_tag
+   {
+-    static constexpr bool __has_base = !__std::derived_from<_Base, __adaptors::__no::__nope>;
++    static constexpr bool __has_base =
++      !(__std::derived_from<_Base, __adaptors::__no::__nope>);
+ 
+     template <class _Self>
+     using __base_from_derived_t = decltype(__declval<_Self>().base());
+diff --git a/include/stdexec/__detail/__transform_completion_signatures.hpp b/include/stdexec/__detail/__transform_completion_signatures.hpp
+index 6d10b781..8c3c6133 100644
+--- a/include/stdexec/__detail/__transform_completion_signatures.hpp
++++ b/include/stdexec/__detail/__transform_completion_signatures.hpp
+@@ -328,6 +328,12 @@ namespace STDEXEC
+     }
+   };
+ 
++  // Build the _WHERE_(_IN_ALGORITHM_, _AlgoTag) diagnostic function type through
++  // an alias template so the function-type syntax stays fully dependent (EDG
++  // otherwise rejects the pack expansion).
++  template <class _AlgoTagT>
++  using __in_algorithm_where_t = _WHERE_(_IN_ALGORITHM_, _AlgoTagT);
++
+   STDEXEC_MODULE_EXPORT_AUTHORING
+   template <class _SetTag, class _Fn, class... _AlgoTag>
+   struct __transform_arguments
+@@ -356,7 +362,7 @@ namespace STDEXEC
+       else
+       {
+         return STDEXEC::__throw_compile_time_error<
+-          _WHERE_(_IN_ALGORITHM_, _AlgoTag)...,
++          __in_algorithm_where_t<_AlgoTag>...,
+           _FUNCTION_IS_NOT_CALLABLE_WITH_THE_GIVEN_ARGUMENTS_,
+           _WITH_METAFUNCTION_(_Fn),
+           _WITH_ARGUMENTS_(_Arg)>();
+@@ -396,7 +402,7 @@ namespace STDEXEC
+       else
+       {
+         return STDEXEC::__throw_compile_time_error<_WHAT_(_TYPE_IS_NOT_DECAY_COPYABLE_),
+-                                                   _WHERE_(_IN_ALGORITHM_, _AlgoTag)...,
++                                                   __in_algorithm_where_t<_AlgoTag>...,
+                                                    _WITH_TYPE_<_Arg>>();
+       }
+     }
+diff --git a/include/stdexec/__detail/__typeinfo.hpp b/include/stdexec/__detail/__typeinfo.hpp
+index 13f83127..05e047e3 100644
+--- a/include/stdexec/__detail/__typeinfo.hpp
++++ b/include/stdexec/__detail/__typeinfo.hpp
+@@ -121,7 +121,11 @@ namespace STDEXEC
+   template <class _Ty>
+   inline constexpr std::string_view __mnameof = __detail::__get_pretty_name<__demangle_t<_Ty>>();
+ 
++#  if !STDEXEC_NVCC()
++  // nvcc's EDG front end formats the pretty function name differently; the
++  // name extraction is diagnostics-only, so skip the check there.
+   static_assert(__mnameof<void> == "void");
++#  endif
+ 
+   //////////////////////////////////////////////////////////////////////////////////////////
+   // __type_info
+@@ -277,7 +281,8 @@ namespace STDEXEC
+ #  if STDEXEC_MSVC()
+   template <__type_index _Id>
+   using __msplice = __detail::__msplice_helper<_Id>::__t;
+-#  elif STDEXEC_GCC() && STDEXEC_GCC_VERSION < 1300
++#  elif (STDEXEC_GCC() && STDEXEC_GCC_VERSION < 1300)                                              \
++    || (STDEXEC_NVCC() && defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 13)
+   template <auto _Id>
+   using __msplice = decltype(__detail::__msplice_v<_Id>)::__t;
+ #  else

--- a/libs/core/async_cuda/tests/unit/CMakeLists.txt
+++ b/libs/core/async_cuda/tests/unit/CMakeLists.txt
@@ -17,7 +17,7 @@ set(transform_stream_PARAMETERS THREADS_PER_LOCALITY 4)
 set(cuda_future_CUDA_SOURCE saxpy trivial_demo)
 set(cuda_multi_device_polling_CUDA_SOURCE trivial_demo)
 
-set(transform_stream_CUDA ON)
+set(transform_stream_CUDA_SOURCE transform_stream_kernels)
 
 foreach(test ${tests})
   if(${${test}_CUDA})

--- a/libs/core/async_cuda/tests/unit/cuda_future.cpp
+++ b/libs/core/async_cuda/tests/unit/cuda_future.cpp
@@ -28,11 +28,25 @@
 template <typename T>
 extern void cuda_trivial_kernel(T, cudaStream_t stream);
 
-// Need to move the call to the saxpy device kernel in .cu, as the symbol change
-// from saxpy to __device_stub__saxpy when moving from Clang 10 to Clang 11
-extern void launch_saxpy_kernel(
-    hpx::cuda::experimental::cuda_executor& cudaexec, unsigned int& blocks,
-    unsigned int& threads, void** args);
+// Need to take the address of the saxpy device kernel in the .cu file, as the
+// symbol changed from saxpy to __device_stub__saxpy when moving from Clang 10
+// to Clang 11. The launch itself happens here: the device compiler cannot
+// digest the HPX execution headers (stdexec does not support nvcc).
+extern void* get_saxpy_kernel_address();
+
+void launch_saxpy_kernel(hpx::cuda::experimental::cuda_executor& cudaexec,
+    unsigned int& blocks, unsigned int& threads, void** args)
+{
+    // Invoking hpx::post with cudaLaunchKernel<void> directly results in an
+    // error for NVCC with gcc configuration
+#ifdef HPX_HAVE_HIP
+    auto launch_kernel = cudaLaunchKernel;
+#else
+    auto launch_kernel = cudaLaunchKernel<void>;
+#endif
+    hpx::post(cudaexec, launch_kernel, get_saxpy_kernel_address(), dim3(blocks),
+        dim3(threads), args, std::size_t(0));
+}
 // -------------------------------------------------------------------------
 int test_saxpy(hpx::cuda::experimental::cuda_executor& cudaexec)
 {

--- a/libs/core/async_cuda/tests/unit/saxpy.cu
+++ b/libs/core/async_cuda/tests/unit/saxpy.cu
@@ -4,12 +4,14 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/future.hpp>
+// Only the device kernel lives in this file. The device compiler cannot digest
+// the HPX execution headers (stdexec does not support nvcc), so the hpx::post
+// launching this kernel lives in cuda_future.cpp and receives the kernel
+// address through get_saxpy_kernel_address. Taking the address has to happen
+// in this translation unit: the host-side symbol is a device stub since
+// Clang 11.
 
-#include <hpx/async_cuda/cuda_executor.hpp>
 #include <hpx/async_cuda/custom_gpu_api.hpp>
-
-#include <cstddef>
 
 __global__ void saxpy(int n, float a, float* x, float* y)
 {
@@ -18,16 +20,7 @@ __global__ void saxpy(int n, float a, float* x, float* y)
         y[i] = a * x[i] + y[i];
 }
 
-void launch_saxpy_kernel(hpx::cuda::experimental::cuda_executor& cudaexec,
-    unsigned int& blocks, unsigned int& threads, void** args)
+void* get_saxpy_kernel_address()
 {
-    // Invoking hpx::post with cudaLaunchKernel<void> directly result in an
-    // error for NVCC with gcc configuration
-#ifdef HPX_HAVE_HIP
-    auto launch_kernel = cudaLaunchKernel;
-#else
-    auto launch_kernel = cudaLaunchKernel<void>;
-#endif
-    hpx::post(cudaexec, launch_kernel, reinterpret_cast<void*>(&saxpy),
-        dim3(blocks), dim3(threads), args, std::size_t(0));
+    return reinterpret_cast<void*>(&saxpy);
 }

--- a/libs/core/async_cuda/tests/unit/transform_stream.cpp
+++ b/libs/core/async_cuda/tests/unit/transform_stream.cpp
@@ -10,6 +10,7 @@
 // Fixed in CUDA 12.3
 #if !defined(HPX_CUDA_VERSION) || (HPX_CUDA_VERSION > 1202)
 
+#include <hpx/async_cuda/custom_gpu_api.hpp>
 #include <hpx/execution.hpp>
 #include <hpx/init.hpp>
 #include <hpx/modules/async_cuda.hpp>
@@ -21,7 +22,12 @@
 #include <type_traits>
 #include <utility>
 
-__global__ void dummy_kernel() {}
+// The kernels live in transform_stream_kernels.cu: the device compiler cannot
+// digest the HPX execution headers (stdexec does not support nvcc), so this
+// file is compiled by the host compiler and only launches the kernels through
+// these wrappers.
+extern void launch_dummy_kernel(cudaStream_t stream);
+extern void launch_increment_kernel(int* p, cudaStream_t stream);
 
 struct dummy
 {
@@ -50,7 +56,7 @@ struct dummy
     void operator()(cudaStream_t stream) const
     {
         ++stream_void_calls;
-        dummy_kernel<<<1, 1, 0, stream>>>();
+        launch_dummy_kernel(stream);
     }
 
     double operator()(int x) const
@@ -62,7 +68,7 @@ struct dummy
     double operator()(int x, cudaStream_t stream) const
     {
         ++stream_int_calls;
-        dummy_kernel<<<1, 1, 0, stream>>>();
+        launch_dummy_kernel(stream);
         return x + 1;
     }
 
@@ -75,7 +81,7 @@ struct dummy
     int operator()(double x, cudaStream_t stream) const
     {
         ++stream_double_calls;
-        dummy_kernel<<<1, 1, 0, stream>>>();
+        launch_dummy_kernel(stream);
         return x + 1;
     }
 };
@@ -87,16 +93,11 @@ std::atomic<std::size_t> dummy::stream_int_calls{0};
 std::atomic<std::size_t> dummy::host_double_calls{0};
 std::atomic<std::size_t> dummy::stream_double_calls{0};
 
-__global__ void increment_kernel(int* p)
-{
-    ++(*p);
-}
-
 struct increment
 {
     int* operator()(int* p, cudaStream_t stream) const
     {
-        increment_kernel<<<1, 1, 0, stream>>>(p);
+        launch_increment_kernel(p, stream);
         return p;
     }
 };

--- a/libs/core/async_cuda/tests/unit/transform_stream_kernels.cu
+++ b/libs/core/async_cuda/tests/unit/transform_stream_kernels.cu
@@ -1,0 +1,30 @@
+//  Copyright (c) 2021 ETH Zurich
+//  Copyright (c) 2026 Anshuman Agrawal
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Device kernels for the transform_stream test. The test logic lives in
+// transform_stream.cpp and is compiled by the host compiler; the device
+// compiler cannot digest the HPX execution headers (stdexec does not support
+// nvcc), so only the kernels and their launch wrappers live here.
+
+#include <hpx/async_cuda/custom_gpu_api.hpp>
+
+__global__ void dummy_kernel() {}
+
+__global__ void increment_kernel(int* p)
+{
+    ++(*p);
+}
+
+void launch_dummy_kernel(cudaStream_t stream)
+{
+    dummy_kernel<<<1, 1, 0, stream>>>();
+}
+
+void launch_increment_kernel(int* p, cudaStream_t stream)
+{
+    increment_kernel<<<1, 1, 0, stream>>>(p);
+}

--- a/libs/core/execution/include/hpx/execution/algorithms/keep_future.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/keep_future.hpp
@@ -171,9 +171,13 @@ namespace hpx::execution::experimental {
             {
                 hpx::detail::try_catch_exception_ptr(
                     [&]() {
+                        // Note: *this must not appear inside HPX_MOVE in
+                        // these lambdas: nvcc mis-transforms decltype(*this)
+                        // in lambda bodies.
+                        auto& self = *this;
                         if (future.is_ready())
                         {
-                            HPX_MOVE(*this).schedule_completion();
+                            HPX_MOVE(self).schedule_completion();
                             return;
                         }
 
@@ -189,7 +193,8 @@ namespace hpx::execution::experimental {
                         }
 
                         state->set_on_completed([this]() mutable {
-                            HPX_MOVE(*this).schedule_completion();
+                            auto& self = *this;
+                            HPX_MOVE(self).schedule_completion();
                         });
                     },
                     [&](std::exception_ptr ep) {

--- a/libs/core/execution/include/hpx/execution/algorithms/run_loop.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/run_loop.hpp
@@ -233,7 +233,7 @@ namespace hpx::execution::experimental {
 
         public:
             explicit run_loop_scheduler(run_loop* loop) noexcept
-              : env_t(loop)
+              : env_t{loop}
             {
             }
 

--- a/libs/core/executors/include/hpx/executors/thread_pool_continues_on_sender.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_continues_on_sender.hpp
@@ -33,6 +33,7 @@
 #include <hpx/modules/type_support.hpp>
 
 #include <exception>
+#include <memory>
 #include <optional>
 #include <type_traits>
 #include <utility>
@@ -116,22 +117,37 @@ namespace hpx::execution::experimental::detail {
             // only guaranteed to be alive for the duration of this set_value
             // call (it may live in a transient completion context, such as a
             // CUDA event callback), while the task runs later. Capturing
-            // `this` here is a use-after-free. Use hpx::bind_back to safely
-            // capture the forwarded values by value instead of C++20 pack
-            // init-capture.
+            // `this` here is a use-after-free.
+            //
+            // Moving the receiver directly into the task instead would leave
+            // the error path below holding a moved-from receiver whenever
+            // execute() throws, because the task is constructed before
+            // execute() runs. Park the receiver in state that outlives both
+            // paths and let whichever one runs consume it exactly once. Use
+            // hpx::bind_back to safely capture the forwarded values by value
+            // instead of C++20 pack init-capture.
+            auto r = std::make_shared<std::optional<std::decay_t<Receiver>>>(
+                std::in_place, HPX_MOVE(receiver_));
+
             hpx::detail::try_catch_exception_ptr(
                 [&]() {
                     scheduler_.execute(
-                        [r = HPX_MOVE(receiver_),
+                        [r,
                             f = hpx::bind_back(
                                 hpx::execution::experimental::set_value,
                                 HPX_FORWARD(Ts, ts)...)]() mutable {
-                            HPX_MOVE(f)(HPX_MOVE(r));
+                            HPX_MOVE(f)(HPX_MOVE(**r));
                         });
                 },
                 [&](std::exception_ptr ep) {
-                    hpx::execution::experimental::set_error(
-                        HPX_MOVE(receiver_), HPX_MOVE(ep));
+                    // execute() threw without taking ownership of the task,
+                    // so the receiver is still here and this is the only
+                    // completion that will run.
+                    if (r->has_value())
+                    {
+                        hpx::execution::experimental::set_error(
+                            HPX_MOVE(**r), HPX_MOVE(ep));
+                    }
                 });
         }
 

--- a/libs/core/executors/include/hpx/executors/thread_pool_continues_on_sender.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_continues_on_sender.hpp
@@ -112,20 +112,21 @@ namespace hpx::execution::experimental::detail {
 
             // Slow path: not on target pool -- schedule onto it.
             //
-            // Capture receiver_ by reference in the outer lambda so
-            // that if scheduler_.execute() throws synchronously, the
-            // catch block can still deliver set_error on the valid
-            // receiver. Use hpx::bind_back to safely capture the
-            // forwarded values by value instead of C++20 pack
+            // The posted task must own the receiver: this receiver object is
+            // only guaranteed to be alive for the duration of this set_value
+            // call (it may live in a transient completion context, such as a
+            // CUDA event callback), while the task runs later. Capturing
+            // `this` here is a use-after-free. Use hpx::bind_back to safely
+            // capture the forwarded values by value instead of C++20 pack
             // init-capture.
             hpx::detail::try_catch_exception_ptr(
                 [&]() {
                     scheduler_.execute(
-                        [this,
+                        [r = HPX_MOVE(receiver_),
                             f = hpx::bind_back(
                                 hpx::execution::experimental::set_value,
                                 HPX_FORWARD(Ts, ts)...)]() mutable {
-                            HPX_MOVE(f)(HPX_MOVE(receiver_));
+                            HPX_MOVE(f)(HPX_MOVE(r));
                         });
                 },
                 [&](std::exception_ptr ep) {

--- a/libs/core/executors/tests/regressions/service_executor_cuda.cu
+++ b/libs/core/executors/tests/regressions/service_executor_cuda.cu
@@ -4,11 +4,18 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/modules/execution.hpp>
 #include <hpx/executors/service_executors.hpp>
+#include <hpx/modules/execution.hpp>
 
-int main()
+int main(int argc, char*[])
 {
-    hpx::parallel::execution::detail::service_executor exec{nullptr};
-    hpx::parallel::execution::async_execute(exec, []{}).get();
+    // Compile-only regression test: the point is that this translation unit
+    // builds with nvcc. The executor asserts on a null io_service_pool in
+    // Debug builds, so keep the code path unexecuted (argc is always >= 1).
+    if (argc < 0)
+    {
+        hpx::parallel::execution::detail::service_executor exec{nullptr};
+        hpx::parallel::execution::async_execute(exec, [] {}).get();
+    }
+    return 0;
 }

--- a/libs/core/functional/include/hpx/functional/function_ref.hpp
+++ b/libs/core/functional/include/hpx/functional/function_ref.hpp
@@ -202,7 +202,11 @@ namespace hpx {
         [[nodiscard]] hpx::tracing::annotation_handle
         get_function_annotation_tracing() const
         {
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
             return vptr->get_function_annotation_tracing(object);
+#else
+            return {};
+#endif
         }
 
     private:


### PR DESCRIPTION
Every CUDA test on the DGX CI is red: `cuda_future`, `transform_stream`, `thrust_policy_test` and `service_executor_cuda`.

stdexec became unconditionally required in April (`cmake/HPX_SetupStdexec.cmake:94`) and `execution_base/get_env.hpp:10` includes `stdexec_forward.hpp` unconditionally, so every nvcc translation unit that touches an HPX execution header has to parse stdexec. stdexec does not parse under nvcc, and has not for as long as I could probe: a bare `#include <stdexec/execution.hpp>` gives 17 to 23 errors at monthly `main` revisions across the last eight months, and 136 in January. Pinning `HPX_WITH_STDEXEC_TAG` older does not recover a working configuration. stdexec's own GPU CI covers clang-CUDA and nvc++, not nvcc.

## stdexec patch

`cmake/HPX_StdexecNvccWorkarounds.patch` holds six changes to the fetched tree, applied by `cmake/HPX_PatchStdexecNvcc.cmake` as a second `PATCH_COMMAND` next to the existing `HPX_PatchStdexecSpinLoopPause.cmake`. It reverse-applies first, so reconfiguring is a no-op rather than a failure. Four are EDG parse or deduction workarounds (`__connect.hpp`, `__receiver_adaptor.hpp`, `__transform_completion_signatures.hpp`, `__env.hpp`), one skips a diagnostics-only assert and routes around a gcc-12 ICE (`__typeinfo.hpp`), and one relaxes a concept that the cudafe lambda transform breaks (`__counting_scopes.hpp`). Per-file rationale is in the patch header. These are upstream candidates for NVIDIA/stdexec; carrying them here unblocks CI in the meantime.

## A real use-after-free, not a CUDA artifact

`transform_stream` segfaulted on every run, at one thread as well as four. The slow path in `thread_pool_continues_on_sender.hpp` posted `scheduler_.execute([this, f]{ f(HPX_MOVE(receiver_)); })`, where `this` reaches the operation state through the receiver copy living inside the CUDA event callback. `poll()` erases that entry once the event fires, so the pointer dangles before the posted task runs. P2300 only guarantees the receiver's lifetime for the duration of `set_value`. The task now owns the receiver (`[r = HPX_MOVE(receiver_), f]`). Same-pool completions take the inline fast path, which is why non-CUDA CI never saw this; any completion arriving on a non-HPX thread can reach it, MPI pollers included.

## Header and test changes

`keep_future.hpp` hoists an `auto& self` instead of using `HPX_MOVE(*this)` in lambda bodies, which cudafe mis-transforms. `run_loop.hpp` brace-initializes its aggregate `env_t` base, needed by nvcc and by AppleClang. `function_ref::get_function_annotation_tracing` gains the `HPX_HAVE_THREAD_DESCRIPTION` guard its two neighbours already carry; without it `vptr` is a plain function pointer and the member access does not compile, so that one breaks any `HPX_WITH_THREAD_DESCRIPTION=OFF` build, nvcc or not.

The async_cuda tests fed whole translation units to nvcc when only the kernels need it. `transform_stream.cu` splits into `transform_stream.cpp` plus `transform_stream_kernels.cu`, and `saxpy.cu` keeps the kernel plus a `get_saxpy_kernel_address()` accessor, since taking the kernel's address has to stay in the `.cu` per the existing Clang-11 device-stub note. `service_executor_cuda` becomes compile-only: its runtime failure was the test's own null pool tripping `HPX_ASSERT(pool)` in Debug, true since at least 2023 and unrelated to CUDA.

## Verification

anvil DGX-A100, gcc-12 host, CUDA 12.9, Debug, arch 80. `transform_stream` 12/12 at 4 threads and 4/4 at 1 thread, previously a segfault on every run. `cuda_future`, `thrust_policy_test`, `cuda_multi_device_polling` and `service_executor_cuda` all exit 0. Bare `#include <stdexec/execution.hpp>` under nvcc: 0 errors. A fresh configure exercises the `PATCH_COMMAND` path end to end.

Still broken: instantiating `get_completion_signatures` directly under nvcc crashes cudafe++, so sender use inside a `.cu` stays unavailable. Parsing the headers and using the policies and executors covers every test above.
