### PR TITLE
async_distributed: add launch policy overloads for reflect sync and async_cb

### DIFF
--- a/libs/full/async_distributed/include/hpx/async_distributed/async_callback.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/async_callback.hpp
@@ -294,5 +294,31 @@ namespace hpx {
             HPX_FORWARD(Target, target), HPX_FORWARD(Callback, cb),
             HPX_FORWARD(Ts, ts)...);
     }
+    /// \brief Reflection-based async_cb overload with launch policy.
+    ///
+    /// Allows calling hpx::async_cb<^^func>(policy, target, callback, ...)
+    /// without defining an explicit action type.
+    ///
+    /// \tparam F        A std::meta::info reflection of a free function.
+    /// \tparam Policy   Launch policy type.
+    /// \tparam Target   id_type, client, or distribution policy.
+    /// \tparam Callback Callback type invoked on completion.
+    /// \tparam Ts       Additional arguments to pass to the function.
+    // clang-format off
+    HPX_CXX_EXPORT template <std::meta::info F, typename Policy,
+        typename Target, typename Callback, typename... Ts>
+        requires(std::meta::is_namespace_member(F) && std::meta::is_function(F) &&
+            traits::is_launch_policy_v<Policy> &&
+            (std::is_same_v<std::decay_t<Target>, hpx::id_type> ||
+                hpx::traits::is_client_v<std::decay_t<Target>> ||
+                hpx::traits::is_distribution_policy_v<std::decay_t<Target>>))
+    HPX_FORCEINLINE auto async_cb(
+        Policy&& policy, Target&& target, Callback&& cb, Ts&&... ts)
+    // clang-format on
+    {
+        return hpx::async_cb(hpx::actions::reflect_action<F>{},
+            HPX_FORWARD(Policy, policy), HPX_FORWARD(Target, target),
+            HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, ts)...);
+    }
 #endif    // HPX_HAVE_CXX26_REFLECTION
 }    // namespace hpx

--- a/libs/full/async_distributed/include/hpx/async_distributed/sync.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/sync.hpp
@@ -207,6 +207,30 @@ namespace hpx {
         return hpx::sync<hpx::actions::reflect_action<F>>(
             HPX_FORWARD(Target, target), HPX_FORWARD(Ts, ts)...);
     }
+    /// \brief Reflection-based sync overload with launch policy.
+    ///
+    /// Allows calling hpx::sync<^^func>(policy, target, ...) directly
+    /// without defining an explicit action type.
+    ///
+    /// \tparam F      A std::meta::info reflection of a free function.
+    /// \tparam Policy Launch policy type.
+    /// \tparam Target id_type, client, or distribution policy.
+    /// \tparam Ts     Additional arguments to pass to the function.
+    // clang-format off
+    HPX_CXX_EXPORT template <std::meta::info F, typename Policy,
+        typename Target, typename... Ts>
+        requires(std::meta::is_namespace_member(F) && std::meta::is_function(F) &&
+            traits::is_launch_policy_v<Policy> &&
+            (std::is_same_v<std::decay_t<Target>, hpx::id_type> ||
+                hpx::traits::is_client_v<std::decay_t<Target>> ||
+                hpx::traits::is_distribution_policy_v<std::decay_t<Target>>))
+    HPX_FORCEINLINE auto sync(Policy&& policy, Target&& target, Ts&&... ts)
+    // clang-format on
+    {
+        return hpx::sync<hpx::actions::reflect_action<F>>(
+            HPX_FORWARD(Policy, policy), HPX_FORWARD(Target, target),
+            HPX_FORWARD(Ts, ts)...);
+    }
 #endif    // HPX_HAVE_CXX26_REFLECTION
 }    // namespace hpx
 


### PR DESCRIPTION
The reflection overloads added in #7462 for `hpx::sync<^^func>` and
`hpx::async_cb<^^func>` were missing the launch policy variants that
the existing action-based overloads support.

Adds:

```cpp
hpx::sync<^^my_function>(hpx::launch::sync, target, args...);
hpx::async_cb<^^my_function>(hpx::launch::async, target, cb, args...);
```

Both follow the same pattern as `hpx::async<^^func>(policy, target, ...)`
from #7376, constrained with `traits::is_launch_policy_v<Policy>`.