### PR TITLE
Disable force_disconnect tests if not configured

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,23 +242,34 @@ if(HPX_WITH_LOGGING)
   hpx_add_config_define(HPX_HAVE_LOGGING)
 endif()
 
+# Explicitly enable the supervision functionalities
+hpx_option(
+  HPX_WITH_SUPERVISION BOOL "Enable supervision functionalities. (default: OFF)"
+  OFF
+  CATEGORY "Modules"
+  ADVANCED
+)
+if(HPX_WITH_SUPERVISION)
+  hpx_add_config_define(HPX_HAVE_SUPERVISION)
+endif()
+
 hpx_option(
   HPX_WITH_FAULT_TOLERANCE
   BOOL
   "Build HPX to tolerate failures of nodes, i.e. ignore errors in active communication channels (default: OFF)"
-  OFF
+  ${HPX_WITH_SUPERVISION}
   ADVANCED
 )
-if(HPX_WITH_FAULT_TOLERANCE)
+if(HPX_WITH_FAULT_TOLERANCE OR HPX_WITH_SUPERVISION)
   hpx_add_config_define(HPX_HAVE_FAULT_TOLERANCE)
 endif()
 
 hpx_option(
   HPX_WITH_FORCE_DISCONNECT BOOL
-  "Build HPX to support forceful disconnect of localities (default: OFF)" OFF
-  ADVANCED
+  "Build HPX to support forceful disconnect of localities (default: OFF)"
+  ${HPX_WITH_SUPERVISION} ADVANCED
 )
-if(HPX_WITH_FORCE_DISCONNECT)
+if(HPX_WITH_FORCE_DISCONNECT OR HPX_WITH_SUPERVISION)
   hpx_add_config_define(HPX_HAVE_FORCE_DISCONNECT)
 endif()
 
@@ -1032,20 +1043,6 @@ hpx_option(
 
 if(HPX_WITH_SPINLOCK_DEADLOCK_DETECTION)
   hpx_add_config_define(HPX_HAVE_SPINLOCK_DEADLOCK_DETECTION)
-endif()
-
-# Explicitly enable the supervision functionalities
-hpx_option(
-  HPX_WITH_SUPERVISION BOOL "Enable supervision functionalities. (default: OFF)"
-  OFF
-  CATEGORY "Modules"
-  ADVANCED
-)
-
-if(HPX_WITH_SUPERVISION)
-  hpx_add_config_define(HPX_HAVE_SUPERVISION)
-  hpx_add_config_define(HPX_HAVE_FAULT_TOLERANCE)
-  hpx_add_config_define(HPX_HAVE_FORCE_DISCONNECT)
 endif()
 
 # Profiling related build options

--- a/libs/full/runtime_distributed/tests/regressions/CMakeLists.txt
+++ b/libs/full/runtime_distributed/tests/regressions/CMakeLists.txt
@@ -4,34 +4,39 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests
-    multiple_init multiple_init_2918 shutdown_hang_6699 unhandled_exception_582
-    dijkstra_termination_disconnected_locality_7474
-    dijkstra_termination_disconnected_localities_7474
+set(tests multiple_init multiple_init_2918 shutdown_hang_6699
+          unhandled_exception_582
 )
 
 set(unhandled_exception_582_PARAMETERS THREADS_PER_LOCALITY 1)
-set(dijkstra_termination_disconnected_locality_7474_FLAGS DEPENDENCIES
-                                                          process_component
-)
-add_hpx_executable(
-  dijkstra_termination_disconnected_locality_7474_worker INTERNAL_FLAGS
-  SOURCES dijkstra_termination_disconnected_locality_7474_worker.cpp
-  EXCLUDE_FROM_ALL
-  HPX_PREFIX ${HPX_BUILD_PREFIX}
-  FOLDER "Tests/Regressions/Modules/Full/RuntimeDistributed"
-)
-set(dijkstra_termination_disconnected_locality_7474_PARAMETERS
-    RUN_SERIAL
-    --launch=$<TARGET_FILE:dijkstra_termination_disconnected_locality_7474_worker>
-)
-set(dijkstra_termination_disconnected_localities_7474_FLAGS DEPENDENCIES
+
+if(HPX_WITH_FORCE_DISCONNECT)
+  set(tests ${tests} dijkstra_termination_disconnected_locality_7474
+            dijkstra_termination_disconnected_localities_7474
+  )
+
+  set(dijkstra_termination_disconnected_locality_7474_FLAGS DEPENDENCIES
                                                             process_component
-)
-set(dijkstra_termination_disconnected_localities_7474_PARAMETERS
-    RUN_SERIAL
-    --launch=$<TARGET_FILE:dijkstra_termination_disconnected_locality_7474_worker>
-)
+  )
+  add_hpx_executable(
+    dijkstra_termination_disconnected_locality_7474_worker INTERNAL_FLAGS
+    SOURCES dijkstra_termination_disconnected_locality_7474_worker.cpp
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Regressions/Modules/Full/RuntimeDistributed"
+  )
+  set(dijkstra_termination_disconnected_locality_7474_PARAMETERS
+      RUN_SERIAL
+      --launch=$<TARGET_FILE:dijkstra_termination_disconnected_locality_7474_worker>
+  )
+  set(dijkstra_termination_disconnected_localities_7474_FLAGS DEPENDENCIES
+                                                              process_component
+  )
+  set(dijkstra_termination_disconnected_localities_7474_PARAMETERS
+      RUN_SERIAL
+      --launch=$<TARGET_FILE:dijkstra_termination_disconnected_locality_7474_worker>
+  )
+endif()
 
 foreach(test ${tests})
   set(sources ${test}.cpp)
@@ -62,23 +67,25 @@ foreach(test ${tests})
   endif()
 endforeach()
 
-add_dependencies(
-  dijkstra_termination_disconnected_locality_7474_test
-  dijkstra_termination_disconnected_locality_7474_worker
-)
-
-add_dependencies(
-  dijkstra_termination_disconnected_localities_7474_test
-  dijkstra_termination_disconnected_locality_7474_worker
-)
-
-# MSVC V1951 and V1952 expose ICE compiling this in C++20 module mode
-if(HPX_WITH_CXX_MODULES
-   AND (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-   AND (MSVC_VERSION LESS_EQUAL 1952)
-)
-  target_compile_definitions(
+if(HPX_WITH_FORCE_DISCONNECT)
+  add_dependencies(
+    dijkstra_termination_disconnected_locality_7474_test
     dijkstra_termination_disconnected_locality_7474_worker
-    PRIVATE HPX_HAVE_FORCE_NO_CXX_MODULES
   )
+
+  add_dependencies(
+    dijkstra_termination_disconnected_localities_7474_test
+    dijkstra_termination_disconnected_locality_7474_worker
+  )
+
+  # MSVC V1951 and V1952 expose ICE compiling this in C++20 module mode
+  if(HPX_WITH_CXX_MODULES
+     AND (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+     AND (MSVC_VERSION LESS_EQUAL 1952)
+  )
+    target_compile_definitions(
+      dijkstra_termination_disconnected_locality_7474_worker
+      PRIVATE HPX_HAVE_FORCE_NO_CXX_MODULES
+    )
+  endif()
 endif()


### PR DESCRIPTION
This fixes test failures on CIs that do not enable force_disconnect.