### PR TITLE
parcelset,tracing: Emit Tracy events for parcel send and receive

### DIFF
--- a/libs/core/threading_base/src/external_timer.cpp
+++ b/libs/core/threading_base/src/external_timer.cpp
@@ -229,18 +229,22 @@ namespace hpx::tracing {
         }
     }
 
-    void send_parcel(std::uint64_t const tag, std::uint64_t const size,
+    // util::external_timer::send/recv take a single uint64_t tag, so we
+    // forward tag_lsb and drop tag_msb. Extending APEX's own API to carry
+    // both halves is out of scope for this change. Receive-side size is
+    // fixed at 0 because parcel::size_ is never populated on that path.
+    void send_parcel(std::uint64_t const /*tag_msb*/,
+        std::uint64_t const tag_lsb, std::uint64_t const size,
         std::uint64_t const target_locality_id) noexcept
     {
-        util::external_timer::send(tag, size, target_locality_id);
+        util::external_timer::send(tag_lsb, size, target_locality_id);
     }
 
-    void recv_parcel(std::uint64_t const tag, std::uint64_t const size,
-        std::uint64_t const source_locality_id,
-        std::uint64_t const source_thread_id) noexcept
+    void recv_parcel(std::uint64_t const /*tag_msb*/,
+        std::uint64_t const tag_lsb,
+        std::uint64_t const source_locality_id) noexcept
     {
-        util::external_timer::recv(
-            tag, size, source_locality_id, source_thread_id);
+        util::external_timer::recv(tag_lsb, 0, source_locality_id, 0);
     }
 
     void set_enable_parent_task_handler(enable_parent_task_handler_type f)

--- a/libs/core/threading_base/src/external_timer.cpp
+++ b/libs/core/threading_base/src/external_timer.cpp
@@ -247,6 +247,13 @@ namespace hpx::tracing {
         util::external_timer::recv(tag_lsb, 0, source_locality_id, 0);
     }
 
+    void parcel_scheduled(std::uint64_t const /*tag_msb*/,
+        std::uint64_t const /*tag_lsb*/,
+        std::uint64_t const /*source_locality_id*/,
+        std::uint64_t const /*source_thread_id*/) noexcept
+    {
+    }
+
     void set_enable_parent_task_handler(enable_parent_task_handler_type f)
     {
         util::set_enable_parent_task_handler(f);

--- a/libs/core/threading_base/src/external_timer.cpp
+++ b/libs/core/threading_base/src/external_timer.cpp
@@ -230,9 +230,10 @@ namespace hpx::tracing {
     }
 
     // util::external_timer::send/recv take a single uint64_t tag, so we
-    // forward tag_lsb and drop tag_msb. Extending APEX's own API to carry
-    // both halves is out of scope for this change. Receive-side size is
-    // fixed at 0 because parcel::size_ is never populated on that path.
+    // forward tag_lsb and drop tag_msb. The two zeros below match what
+    // APEX consumes: parcel::size_ is never populated on the receive
+    // path, and APEX marks its source_thread parameter APEX_UNUSED and
+    // substitutes 0 internally.
     void send_parcel(std::uint64_t const /*tag_msb*/,
         std::uint64_t const tag_lsb, std::uint64_t const size,
         std::uint64_t const target_locality_id) noexcept

--- a/libs/core/tracing/include/hpx/tracing/backends/apex.hpp
+++ b/libs/core/tracing/include/hpx/tracing/backends/apex.hpp
@@ -312,6 +312,11 @@ namespace hpx::tracing {
     HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void recv_parcel(std::uint64_t tag_msb,
         std::uint64_t tag_lsb, std::uint64_t source_locality_id) noexcept;
 
+    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void parcel_scheduled(
+        std::uint64_t tag_msb, std::uint64_t tag_lsb,
+        std::uint64_t source_locality_id,
+        std::uint64_t source_thread_id) noexcept;
+
     HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void set_enable_parent_task_handler(
         enable_parent_task_handler_type f);
 

--- a/libs/core/tracing/include/hpx/tracing/backends/apex.hpp
+++ b/libs/core/tracing/include/hpx/tracing/backends/apex.hpp
@@ -305,13 +305,17 @@ namespace hpx::tracing {
         std::string const& name, std::string const& short_name,
         double value) noexcept;
 
+    /// \brief Parcel-send signal: parcel handed to parcelport (APEX shim).
     HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void send_parcel(std::uint64_t tag_msb,
         std::uint64_t tag_lsb, std::uint64_t size,
         std::uint64_t target_locality_id) noexcept;
 
+    /// \brief Parcel-receive signal: parcel arrived (APEX shim).
     HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void recv_parcel(std::uint64_t tag_msb,
         std::uint64_t tag_lsb, std::uint64_t source_locality_id) noexcept;
 
+    /// \brief Parcel-scheduled signal: action entered local scheduler
+    ///        (no-op stub for APEX).
     HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void parcel_scheduled(
         std::uint64_t tag_msb, std::uint64_t tag_lsb,
         std::uint64_t source_locality_id,

--- a/libs/core/tracing/include/hpx/tracing/backends/apex.hpp
+++ b/libs/core/tracing/include/hpx/tracing/backends/apex.hpp
@@ -305,12 +305,12 @@ namespace hpx::tracing {
         std::string const& name, std::string const& short_name,
         double value) noexcept;
 
-    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void send_parcel(std::uint64_t tag,
-        std::uint64_t size, std::uint64_t target_locality_id) noexcept;
+    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void send_parcel(std::uint64_t tag_msb,
+        std::uint64_t tag_lsb, std::uint64_t size,
+        std::uint64_t target_locality_id) noexcept;
 
-    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void recv_parcel(std::uint64_t tag,
-        std::uint64_t size, std::uint64_t source_locality_id,
-        std::uint64_t source_thread_id) noexcept;
+    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void recv_parcel(std::uint64_t tag_msb,
+        std::uint64_t tag_lsb, std::uint64_t source_locality_id) noexcept;
 
     HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void set_enable_parent_task_handler(
         enable_parent_task_handler_type f);

--- a/libs/core/tracing/include/hpx/tracing/backends/empty.hpp
+++ b/libs/core/tracing/include/hpx/tracing/backends/empty.hpp
@@ -274,13 +274,15 @@ namespace hpx::tracing {
     {
     }
 
-    HPX_CXX_CORE_EXPORT constexpr void send_parcel(
-        std::uint64_t, std::uint64_t, std::uint64_t) noexcept
+    HPX_CXX_CORE_EXPORT constexpr void send_parcel(std::uint64_t /*tag_msb*/,
+        std::uint64_t /*tag_lsb*/, std::uint64_t /*size*/,
+        std::uint64_t /*target_locality_id*/) noexcept
     {
     }
 
-    HPX_CXX_CORE_EXPORT constexpr void recv_parcel(
-        std::uint64_t, std::uint64_t, std::uint64_t, std::uint64_t) noexcept
+    HPX_CXX_CORE_EXPORT constexpr void recv_parcel(std::uint64_t /*tag_msb*/,
+        std::uint64_t /*tag_lsb*/,
+        std::uint64_t /*source_locality_id*/) noexcept
     {
     }
 

--- a/libs/core/tracing/include/hpx/tracing/backends/empty.hpp
+++ b/libs/core/tracing/include/hpx/tracing/backends/empty.hpp
@@ -286,6 +286,13 @@ namespace hpx::tracing {
     {
     }
 
+    HPX_CXX_CORE_EXPORT constexpr void parcel_scheduled(
+        std::uint64_t /*tag_msb*/, std::uint64_t /*tag_lsb*/,
+        std::uint64_t /*source_locality_id*/,
+        std::uint64_t /*source_thread_id*/) noexcept
+    {
+    }
+
     HPX_CXX_CORE_EXPORT constexpr void set_enable_parent_task_handler(
         enable_parent_task_handler_type) noexcept
     {

--- a/libs/core/tracing/include/hpx/tracing/backends/empty.hpp
+++ b/libs/core/tracing/include/hpx/tracing/backends/empty.hpp
@@ -274,18 +274,22 @@ namespace hpx::tracing {
     {
     }
 
+    /// \brief Parcel-send signal: parcel handed to parcelport (no-op stub).
     HPX_CXX_CORE_EXPORT constexpr void send_parcel(std::uint64_t /*tag_msb*/,
         std::uint64_t /*tag_lsb*/, std::uint64_t /*size*/,
         std::uint64_t /*target_locality_id*/) noexcept
     {
     }
 
+    /// \brief Parcel-receive signal: parcel arrived (no-op stub).
     HPX_CXX_CORE_EXPORT constexpr void recv_parcel(std::uint64_t /*tag_msb*/,
         std::uint64_t /*tag_lsb*/,
         std::uint64_t /*source_locality_id*/) noexcept
     {
     }
 
+    /// \brief Parcel-scheduled signal: action entered local scheduler
+    ///        (no-op stub).
     HPX_CXX_CORE_EXPORT constexpr void parcel_scheduled(
         std::uint64_t /*tag_msb*/, std::uint64_t /*tag_lsb*/,
         std::uint64_t /*source_locality_id*/,

--- a/libs/core/tracing/include/hpx/tracing/backends/ittnotify.hpp
+++ b/libs/core/tracing/include/hpx/tracing/backends/ittnotify.hpp
@@ -362,6 +362,13 @@ namespace hpx::tracing {
     {
     }
 
+    HPX_CXX_CORE_EXPORT constexpr void parcel_scheduled(
+        std::uint64_t /*tag_msb*/, std::uint64_t /*tag_lsb*/,
+        std::uint64_t /*source_locality_id*/,
+        std::uint64_t /*source_thread_id*/) noexcept
+    {
+    }
+
     HPX_CXX_CORE_EXPORT constexpr void set_enable_parent_task_handler(
         enable_parent_task_handler_type) noexcept
     {

--- a/libs/core/tracing/include/hpx/tracing/backends/ittnotify.hpp
+++ b/libs/core/tracing/include/hpx/tracing/backends/ittnotify.hpp
@@ -350,18 +350,23 @@ namespace hpx::tracing {
         std::string const& name, std::string const& short_name,
         double value) noexcept;
 
+    /// \brief Parcel-send signal: parcel handed to parcelport
+    ///        (no-op stub for ITTNotify).
     HPX_CXX_CORE_EXPORT constexpr void send_parcel(std::uint64_t /*tag_msb*/,
         std::uint64_t /*tag_lsb*/, std::uint64_t /*size*/,
         std::uint64_t /*target_locality_id*/) noexcept
     {
     }
 
+    /// \brief Parcel-receive signal: parcel arrived (no-op stub for ITTNotify).
     HPX_CXX_CORE_EXPORT constexpr void recv_parcel(std::uint64_t /*tag_msb*/,
         std::uint64_t /*tag_lsb*/,
         std::uint64_t /*source_locality_id*/) noexcept
     {
     }
 
+    /// \brief Parcel-scheduled signal: action entered local scheduler
+    ///        (no-op stub for ITTNotify).
     HPX_CXX_CORE_EXPORT constexpr void parcel_scheduled(
         std::uint64_t /*tag_msb*/, std::uint64_t /*tag_lsb*/,
         std::uint64_t /*source_locality_id*/,

--- a/libs/core/tracing/include/hpx/tracing/backends/ittnotify.hpp
+++ b/libs/core/tracing/include/hpx/tracing/backends/ittnotify.hpp
@@ -350,13 +350,15 @@ namespace hpx::tracing {
         std::string const& name, std::string const& short_name,
         double value) noexcept;
 
-    HPX_CXX_CORE_EXPORT constexpr void send_parcel(
-        std::uint64_t, std::uint64_t, std::uint64_t) noexcept
+    HPX_CXX_CORE_EXPORT constexpr void send_parcel(std::uint64_t /*tag_msb*/,
+        std::uint64_t /*tag_lsb*/, std::uint64_t /*size*/,
+        std::uint64_t /*target_locality_id*/) noexcept
     {
     }
 
-    HPX_CXX_CORE_EXPORT constexpr void recv_parcel(
-        std::uint64_t, std::uint64_t, std::uint64_t, std::uint64_t) noexcept
+    HPX_CXX_CORE_EXPORT constexpr void recv_parcel(std::uint64_t /*tag_msb*/,
+        std::uint64_t /*tag_lsb*/,
+        std::uint64_t /*source_locality_id*/) noexcept
     {
     }
 

--- a/libs/core/tracing/include/hpx/tracing/backends/tracy.hpp
+++ b/libs/core/tracing/include/hpx/tracing/backends/tracy.hpp
@@ -38,7 +38,7 @@ namespace hpx::tracing {
     // hot-path entries below short-circuit at the call site to a single
     // atomic load.
     namespace detail {
-        inline bool is_profiler_connected() noexcept
+        HPX_CXX_CORE_EXPORT inline bool is_profiler_connected() noexcept
         {
             return ___tracy_connected() != 0;
         }
@@ -206,7 +206,8 @@ namespace hpx::tracing {
     // Disconnected path returns the caller's input, mirroring the underlying
     // `hpx::tracy::detail::rename_region`'s in-fiber no-op. Returning nullptr
     // would risk a strlen(nullptr) if a caller later restored a saved name.
-    inline char const* rename_region(char const* name) noexcept
+    HPX_CXX_CORE_EXPORT inline char const* rename_region(
+        char const* name) noexcept
     {
         if (!detail::is_profiler_connected())
             return name;
@@ -291,7 +292,7 @@ namespace hpx::tracing {
     ///
     /// \param parent_task_id  Optional pointer to the spawning task, for
     ///                        parent-child correlation.
-    inline void task_staged(
+    HPX_CXX_CORE_EXPORT inline void task_staged(
         char const* description, void const* parent_task_id = nullptr) noexcept
     {
         if (!detail::is_profiler_connected())
@@ -303,8 +304,8 @@ namespace hpx::tracing {
     ///
     /// \param parent_task_id  Optional pointer to the spawning task, for
     ///                        parent-child correlation.
-    inline void task_created(char const* description, void const* task_id,
-        void const* parent_task_id = nullptr) noexcept
+    HPX_CXX_CORE_EXPORT inline void task_created(char const* description,
+        void const* task_id, void const* parent_task_id = nullptr) noexcept
     {
         if (!detail::is_profiler_connected())
             return;
@@ -314,8 +315,8 @@ namespace hpx::tracing {
     /// \brief Task-lifecycle signal: task begins executing on a worker thread.
     ///
     /// \param worker_thread  Index of the worker executing this task.
-    inline void task_executing(void const* task_id, char const* description,
-        std::size_t worker_thread) noexcept
+    HPX_CXX_CORE_EXPORT inline void task_executing(void const* task_id,
+        char const* description, std::size_t worker_thread) noexcept
     {
         if (!detail::is_profiler_connected())
             return;
@@ -323,7 +324,7 @@ namespace hpx::tracing {
     }
 
     /// \brief Task-lifecycle signal: task voluntarily yielded to the scheduler.
-    inline void task_yielded(
+    HPX_CXX_CORE_EXPORT inline void task_yielded(
         void const* task_id, char const* description) noexcept
     {
         if (!detail::is_profiler_connected())
@@ -334,8 +335,8 @@ namespace hpx::tracing {
     /// \brief Task-lifecycle signal: task blocked on an external resource.
     ///
     /// \param reason  Optional description of what the task is waiting on.
-    inline void task_suspended(void const* task_id, char const* description,
-        char const* reason = nullptr) noexcept
+    HPX_CXX_CORE_EXPORT inline void task_suspended(void const* task_id,
+        char const* description, char const* reason = nullptr) noexcept
     {
         if (!detail::is_profiler_connected())
             return;
@@ -346,8 +347,8 @@ namespace hpx::tracing {
     ///        pending state.
     ///
     /// \param wake_reason  Optional description of what unblocked the task.
-    inline void task_resumed(void const* task_id, char const* description,
-        char const* wake_reason = nullptr) noexcept
+    HPX_CXX_CORE_EXPORT inline void task_resumed(void const* task_id,
+        char const* description, char const* wake_reason = nullptr) noexcept
     {
         if (!detail::is_profiler_connected())
             return;
@@ -355,7 +356,7 @@ namespace hpx::tracing {
     }
 
     /// \brief Task-lifecycle signal: task finished its execution loop.
-    inline void task_completed(
+    HPX_CXX_CORE_EXPORT inline void task_completed(
         void const* task_id, char const* description) noexcept
     {
         if (!detail::is_profiler_connected())
@@ -364,7 +365,7 @@ namespace hpx::tracing {
     }
 
     /// \brief Task-lifecycle signal: task identity removed from scheduler maps.
-    inline void task_deleted(void const* task_id) noexcept
+    HPX_CXX_CORE_EXPORT inline void task_deleted(void const* task_id) noexcept
     {
         if (!detail::is_profiler_connected())
             return;
@@ -449,7 +450,7 @@ namespace hpx::tracing {
     ///                   consumer events in the Tracy message log.
     /// \param desc       Optional description of the producing context
     ///                   (e.g. the name of the promise or task).
-    inline void future_fulfilled(
+    HPX_CXX_CORE_EXPORT inline void future_fulfilled(
         void const* future_id, char const* desc = nullptr) noexcept
     {
         if (!detail::is_profiler_connected())
@@ -462,7 +463,7 @@ namespace hpx::tracing {
     ///
     /// \param future_id  Pointer to the `future_data` shared state.
     /// \param desc       Optional description of the producing context.
-    inline void future_exception_set(
+    HPX_CXX_CORE_EXPORT inline void future_exception_set(
         void const* future_id, char const* desc = nullptr) noexcept
     {
         if (!detail::is_profiler_connected())
@@ -472,7 +473,8 @@ namespace hpx::tracing {
 
     /// \brief Consumer-side signal: a continuation has started
     ///        executing, correlated with the source future state.
-    inline void continuation_run(void const* task_id = nullptr) noexcept
+    HPX_CXX_CORE_EXPORT inline void continuation_run(
+        void const* task_id = nullptr) noexcept
     {
         // Counter update runs unconditionally so the tally stays consistent
         // across connect/disconnect transitions -- see g_active_continuations.
@@ -484,7 +486,7 @@ namespace hpx::tracing {
 
     /// \brief Consumer-side signal: a continuation has finished
     ///        executing.
-    inline void continuation_finished(
+    HPX_CXX_CORE_EXPORT inline void continuation_finished(
         void const* /* task_id */ = nullptr) noexcept
     {
         detail::g_active_continuations.fetch_sub(1, std::memory_order_relaxed);
@@ -495,7 +497,7 @@ namespace hpx::tracing {
 
     /// \brief Consumer-side signal: handle_on_completed fired,
     ///        dispatching registered continuations.
-    inline void handle_on_completed_fired(
+    HPX_CXX_CORE_EXPORT inline void handle_on_completed_fired(
         void const* task_id = nullptr) noexcept
     {
         if (!detail::is_profiler_connected())
@@ -505,8 +507,9 @@ namespace hpx::tracing {
 
     /// \brief Signal emitted when a worker thread steals a task from
     ///        another worker.
-    inline void work_stolen(std::size_t thief_id, std::size_t victim_id,
-        void const* task_id, char const* desc = nullptr) noexcept
+    HPX_CXX_CORE_EXPORT inline void work_stolen(std::size_t thief_id,
+        std::size_t victim_id, void const* task_id,
+        char const* desc = nullptr) noexcept
     {
         if (!detail::is_profiler_connected())
             return;
@@ -516,7 +519,8 @@ namespace hpx::tracing {
     /// \brief Emit a frame/stage boundary marker in Tracy timeline.
     ///
     /// \param name  Optional name for the frame/stage.
-    inline void frame_mark(char const* name = nullptr) noexcept
+    HPX_CXX_CORE_EXPORT inline void frame_mark(
+        char const* name = nullptr) noexcept
     {
         if (!detail::is_profiler_connected())
             return;
@@ -527,7 +531,8 @@ namespace hpx::tracing {
     ///        on its condition variable.
     ///
     /// \param num_thread  Index of the worker thread entering sleep.
-    inline void os_thread_sleep(std::size_t num_thread) noexcept
+    HPX_CXX_CORE_EXPORT inline void os_thread_sleep(
+        std::size_t num_thread) noexcept
     {
         if (!detail::is_profiler_connected())
             return;
@@ -562,8 +567,9 @@ namespace hpx::tracing {
     /// \param size                 Wire size of the parcel in bytes.
     /// \param target_locality_id   Destination locality id, or
     ///                             `naming::invalid_locality_id` if unknown.
-    inline void send_parcel(std::uint64_t tag_msb, std::uint64_t tag_lsb,
-        std::uint64_t size, std::uint64_t target_locality_id) noexcept
+    HPX_CXX_CORE_EXPORT inline void send_parcel(std::uint64_t tag_msb,
+        std::uint64_t tag_lsb, std::uint64_t size,
+        std::uint64_t target_locality_id) noexcept
     {
         if (!detail::is_profiler_connected())
             return;
@@ -579,8 +585,8 @@ namespace hpx::tracing {
     ///                             `naming::invalid_locality_id` when the
     ///                             parcel has no source id yet (pre-AGAS
     ///                             handshake parcels).
-    inline void recv_parcel(std::uint64_t tag_msb, std::uint64_t tag_lsb,
-        std::uint64_t source_locality_id) noexcept
+    HPX_CXX_CORE_EXPORT inline void recv_parcel(std::uint64_t tag_msb,
+        std::uint64_t tag_lsb, std::uint64_t source_locality_id) noexcept
     {
         if (!detail::is_profiler_connected())
             return;
@@ -600,8 +606,8 @@ namespace hpx::tracing {
     /// \param source_locality_id   Sending locality id (see recv_parcel).
     /// \param source_thread_id     Parent HPX thread id captured on the
     ///                             sender; may be 0 when unavailable.
-    inline void parcel_scheduled(std::uint64_t tag_msb, std::uint64_t tag_lsb,
-        std::uint64_t source_locality_id,
+    HPX_CXX_CORE_EXPORT inline void parcel_scheduled(std::uint64_t tag_msb,
+        std::uint64_t tag_lsb, std::uint64_t source_locality_id,
         std::uint64_t source_thread_id) noexcept
     {
         if (!detail::is_profiler_connected())

--- a/libs/core/tracing/include/hpx/tracing/backends/tracy.hpp
+++ b/libs/core/tracing/include/hpx/tracing/backends/tracy.hpp
@@ -537,13 +537,15 @@ namespace hpx::tracing {
         std::string const& name, std::string const& short_name,
         double value) noexcept;
 
-    HPX_CXX_CORE_EXPORT constexpr void send_parcel(
-        std::uint64_t, std::uint64_t, std::uint64_t) noexcept
+    HPX_CXX_CORE_EXPORT constexpr void send_parcel(std::uint64_t /*tag_msb*/,
+        std::uint64_t /*tag_lsb*/, std::uint64_t /*size*/,
+        std::uint64_t /*target_locality_id*/) noexcept
     {
     }
 
-    HPX_CXX_CORE_EXPORT constexpr void recv_parcel(
-        std::uint64_t, std::uint64_t, std::uint64_t, std::uint64_t) noexcept
+    HPX_CXX_CORE_EXPORT constexpr void recv_parcel(std::uint64_t /*tag_msb*/,
+        std::uint64_t /*tag_lsb*/,
+        std::uint64_t /*source_locality_id*/) noexcept
     {
     }
 

--- a/libs/core/tracing/include/hpx/tracing/backends/tracy.hpp
+++ b/libs/core/tracing/include/hpx/tracing/backends/tracy.hpp
@@ -549,6 +549,13 @@ namespace hpx::tracing {
     {
     }
 
+    HPX_CXX_CORE_EXPORT constexpr void parcel_scheduled(
+        std::uint64_t /*tag_msb*/, std::uint64_t /*tag_lsb*/,
+        std::uint64_t /*source_locality_id*/,
+        std::uint64_t /*source_thread_id*/) noexcept
+    {
+    }
+
     HPX_CXX_CORE_EXPORT constexpr void set_enable_parent_task_handler(
         enable_parent_task_handler_type) noexcept
     {

--- a/libs/core/tracing/include/hpx/tracing/backends/tracy.hpp
+++ b/libs/core/tracing/include/hpx/tracing/backends/tracy.hpp
@@ -427,6 +427,19 @@ namespace hpx::tracing {
 
         HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void os_thread_sleep_impl(
             std::size_t num_thread) noexcept;
+
+        HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void send_parcel_impl(
+            std::uint64_t tag_msb, std::uint64_t tag_lsb, std::uint64_t size,
+            std::uint64_t target_locality_id) noexcept;
+
+        HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void recv_parcel_impl(
+            std::uint64_t tag_msb, std::uint64_t tag_lsb,
+            std::uint64_t source_locality_id) noexcept;
+
+        HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void parcel_scheduled_impl(
+            std::uint64_t tag_msb, std::uint64_t tag_lsb,
+            std::uint64_t source_locality_id,
+            std::uint64_t source_thread_id) noexcept;
     }    // namespace detail
 
     /// \brief Producer-side signal: a future shared state was set to a value.
@@ -537,23 +550,64 @@ namespace hpx::tracing {
         std::string const& name, std::string const& short_name,
         double value) noexcept;
 
-    HPX_CXX_CORE_EXPORT constexpr void send_parcel(std::uint64_t /*tag_msb*/,
-        std::uint64_t /*tag_lsb*/, std::uint64_t /*size*/,
-        std::uint64_t /*target_locality_id*/) noexcept
+    /// \brief Parcel-send signal: a parcel has been handed to the
+    ///        parcelport for transmission.
+    ///
+    /// \param tag_msb              High 64 bits of the parcel id.
+    /// \param tag_lsb              Low 64 bits of the parcel id. Together
+    ///                             with tag_msb they form the full 128-bit
+    ///                             id used to pair events across localities;
+    ///                             lsb alone restarts per locality and
+    ///                             would produce false matches.
+    /// \param size                 Wire size of the parcel in bytes.
+    /// \param target_locality_id   Destination locality id, or
+    ///                             `naming::invalid_locality_id` if unknown.
+    inline void send_parcel(std::uint64_t tag_msb, std::uint64_t tag_lsb,
+        std::uint64_t size, std::uint64_t target_locality_id) noexcept
     {
+        if (!detail::is_profiler_connected())
+            return;
+        detail::send_parcel_impl(tag_msb, tag_lsb, size, target_locality_id);
     }
 
-    HPX_CXX_CORE_EXPORT constexpr void recv_parcel(std::uint64_t /*tag_msb*/,
-        std::uint64_t /*tag_lsb*/,
-        std::uint64_t /*source_locality_id*/) noexcept
+    /// \brief Parcel-receive signal: a parcel has arrived and its header
+    ///        has been deserialized.
+    ///
+    /// \param tag_msb              High 64 bits of the parcel id.
+    /// \param tag_lsb              Low 64 bits of the parcel id.
+    /// \param source_locality_id   Sending locality id, or
+    ///                             `naming::invalid_locality_id` when the
+    ///                             parcel has no source id yet (pre-AGAS
+    ///                             handshake parcels).
+    inline void recv_parcel(std::uint64_t tag_msb, std::uint64_t tag_lsb,
+        std::uint64_t source_locality_id) noexcept
     {
+        if (!detail::is_profiler_connected())
+            return;
+        detail::recv_parcel_impl(tag_msb, tag_lsb, source_locality_id);
     }
 
-    HPX_CXX_CORE_EXPORT constexpr void parcel_scheduled(
-        std::uint64_t /*tag_msb*/, std::uint64_t /*tag_lsb*/,
-        std::uint64_t /*source_locality_id*/,
-        std::uint64_t /*source_thread_id*/) noexcept
+    /// \brief Parcel-scheduled signal: an action carried by a parcel has
+    ///        been placed onto the local scheduler. Fires for deferred
+    ///        receives (zero-copy or multi-parcel message), for
+    ///        AGAS-routed parcels, and for parcels the AGAS re-route
+    ///        chain delivered after a migration detection. Does not fire
+    ///        for the non-deferred path where load_schedule schedules
+    ///        inline.
+    ///
+    /// \param tag_msb              High 64 bits of the parcel id.
+    /// \param tag_lsb              Low 64 bits of the parcel id.
+    /// \param source_locality_id   Sending locality id (see recv_parcel).
+    /// \param source_thread_id     Parent HPX thread id captured on the
+    ///                             sender; may be 0 when unavailable.
+    inline void parcel_scheduled(std::uint64_t tag_msb, std::uint64_t tag_lsb,
+        std::uint64_t source_locality_id,
+        std::uint64_t source_thread_id) noexcept
     {
+        if (!detail::is_profiler_connected())
+            return;
+        detail::parcel_scheduled_impl(
+            tag_msb, tag_lsb, source_locality_id, source_thread_id);
     }
 
     HPX_CXX_CORE_EXPORT constexpr void set_enable_parent_task_handler(

--- a/libs/core/tracing/src/backends/tracy.cpp
+++ b/libs/core/tracing/src/backends/tracy.cpp
@@ -462,7 +462,7 @@ namespace hpx::tracing {
         }
 
         // Mirror of naming::invalid_locality_id (~std::uint32_t(0)) from
-        // libs/full/naming_base/include/hpx/naming_base/gid_type.hpp.
+        // libs/full/naming_base/include/hpx/naming_base/naming_base.hpp.
         // Duplicated because core cannot depend on full; if the real
         // constant ever changes, update this or the invalid-locality
         // branches will silently start printing L#4294967295 again.

--- a/libs/core/tracing/src/backends/tracy.cpp
+++ b/libs/core/tracing/src/backends/tracy.cpp
@@ -518,23 +518,27 @@ namespace hpx::tracing {
 
         void parcel_scheduled_impl(std::uint64_t tag_msb, std::uint64_t tag_lsb,
             std::uint64_t source_locality_id,
-            std::uint64_t /*source_thread_id*/) noexcept
+            std::uint64_t source_thread_id) noexcept
         {
             char buffer[160];
             if (source_locality_id == invalid_locality)
             {
                 std::snprintf(buffer, sizeof(buffer),
-                    "Parcel Scheduled: id=%016llx:%016llx from=L#unknown",
+                    "Parcel Scheduled: id=%016llx:%016llx from=L#unknown "
+                    "thread=0x%016llx",
                     static_cast<unsigned long long>(tag_msb),
-                    static_cast<unsigned long long>(tag_lsb));
+                    static_cast<unsigned long long>(tag_lsb),
+                    static_cast<unsigned long long>(source_thread_id));
             }
             else
             {
                 std::snprintf(buffer, sizeof(buffer),
-                    "Parcel Scheduled: id=%016llx:%016llx from=L#%llu",
+                    "Parcel Scheduled: id=%016llx:%016llx from=L#%llu "
+                    "thread=0x%016llx",
                     static_cast<unsigned long long>(tag_msb),
                     static_cast<unsigned long long>(tag_lsb),
-                    static_cast<unsigned long long>(source_locality_id));
+                    static_cast<unsigned long long>(source_locality_id),
+                    static_cast<unsigned long long>(source_thread_id));
             }
             hpx::tracy::message(buffer, std::strlen(buffer), 0x9C27B0u);
         }

--- a/libs/core/tracing/src/backends/tracy.cpp
+++ b/libs/core/tracing/src/backends/tracy.cpp
@@ -516,8 +516,8 @@ namespace hpx::tracing {
             hpx::tracy::message(buffer, std::strlen(buffer), 0x4CAF50u);
         }
 
-        void parcel_scheduled_impl(std::uint64_t tag_msb,
-            std::uint64_t tag_lsb, std::uint64_t source_locality_id,
+        void parcel_scheduled_impl(std::uint64_t tag_msb, std::uint64_t tag_lsb,
+            std::uint64_t source_locality_id,
             std::uint64_t /*source_thread_id*/) noexcept
         {
             char buffer[160];

--- a/libs/core/tracing/src/backends/tracy.cpp
+++ b/libs/core/tracing/src/backends/tracy.cpp
@@ -472,6 +472,9 @@ namespace hpx::tracing {
             std::uint64_t size, std::uint64_t target_locality_id) noexcept
         {
             char buffer[160];
+            // "Parcel Send: id=<msb>:<lsb> size=<N> to=L#<N>" + NUL
+            static_assert(
+                sizeof(buffer) >= 16 + 16 + 1 + 16 + 6 + 20 + 6 + 20 + 1);
             if (target_locality_id == invalid_locality)
             {
                 std::snprintf(buffer, sizeof(buffer),
@@ -498,6 +501,8 @@ namespace hpx::tracing {
             std::uint64_t source_locality_id) noexcept
         {
             char buffer[160];
+            // "Parcel Recv: id=<msb>:<lsb> from=L#<N>" + NUL
+            static_assert(sizeof(buffer) >= 16 + 16 + 1 + 16 + 8 + 20 + 1);
             if (source_locality_id == invalid_locality)
             {
                 std::snprintf(buffer, sizeof(buffer),
@@ -521,6 +526,9 @@ namespace hpx::tracing {
             std::uint64_t source_thread_id) noexcept
         {
             char buffer[160];
+            // "Parcel Scheduled: id=<msb>:<lsb> from=L#<N> thread=0x<hex>" + NUL
+            static_assert(
+                sizeof(buffer) >= 21 + 16 + 1 + 16 + 8 + 20 + 10 + 16 + 1);
             if (source_locality_id == invalid_locality)
             {
                 std::snprintf(buffer, sizeof(buffer),

--- a/libs/core/tracing/src/backends/tracy.cpp
+++ b/libs/core/tracing/src/backends/tracy.cpp
@@ -461,6 +461,84 @@ namespace hpx::tracing {
             hpx::tracy::message(buffer, std::strlen(buffer), 0x546E7Au);
         }
 
+        // Mirror of naming::invalid_locality_id (~std::uint32_t(0)) from
+        // libs/full/naming_base/include/hpx/naming_base/gid_type.hpp.
+        // Duplicated because core cannot depend on full; if the real
+        // constant ever changes, update this or the invalid-locality
+        // branches will silently start printing L#4294967295 again.
+        static constexpr std::uint64_t invalid_locality = 0xFFFFFFFFULL;
+
+        void send_parcel_impl(std::uint64_t tag_msb, std::uint64_t tag_lsb,
+            std::uint64_t size, std::uint64_t target_locality_id) noexcept
+        {
+            char buffer[160];
+            if (target_locality_id == invalid_locality)
+            {
+                std::snprintf(buffer, sizeof(buffer),
+                    "Parcel Send: id=%016llx:%016llx size=%llu to=L#unknown",
+                    static_cast<unsigned long long>(tag_msb),
+                    static_cast<unsigned long long>(tag_lsb),
+                    static_cast<unsigned long long>(size));
+            }
+            else
+            {
+                std::snprintf(buffer, sizeof(buffer),
+                    "Parcel Send: id=%016llx:%016llx size=%llu to=L#%llu",
+                    static_cast<unsigned long long>(tag_msb),
+                    static_cast<unsigned long long>(tag_lsb),
+                    static_cast<unsigned long long>(size),
+                    static_cast<unsigned long long>(target_locality_id));
+            }
+            hpx::tracy::message(buffer, std::strlen(buffer), 0x2196F3u);
+        }
+
+        // Size is omitted here: parcel::size_ is not populated on the
+        // receive side, so any value would be a fixed zero.
+        void recv_parcel_impl(std::uint64_t tag_msb, std::uint64_t tag_lsb,
+            std::uint64_t source_locality_id) noexcept
+        {
+            char buffer[160];
+            if (source_locality_id == invalid_locality)
+            {
+                std::snprintf(buffer, sizeof(buffer),
+                    "Parcel Recv: id=%016llx:%016llx from=L#unknown",
+                    static_cast<unsigned long long>(tag_msb),
+                    static_cast<unsigned long long>(tag_lsb));
+            }
+            else
+            {
+                std::snprintf(buffer, sizeof(buffer),
+                    "Parcel Recv: id=%016llx:%016llx from=L#%llu",
+                    static_cast<unsigned long long>(tag_msb),
+                    static_cast<unsigned long long>(tag_lsb),
+                    static_cast<unsigned long long>(source_locality_id));
+            }
+            hpx::tracy::message(buffer, std::strlen(buffer), 0x4CAF50u);
+        }
+
+        void parcel_scheduled_impl(std::uint64_t tag_msb,
+            std::uint64_t tag_lsb, std::uint64_t source_locality_id,
+            std::uint64_t /*source_thread_id*/) noexcept
+        {
+            char buffer[160];
+            if (source_locality_id == invalid_locality)
+            {
+                std::snprintf(buffer, sizeof(buffer),
+                    "Parcel Scheduled: id=%016llx:%016llx from=L#unknown",
+                    static_cast<unsigned long long>(tag_msb),
+                    static_cast<unsigned long long>(tag_lsb));
+            }
+            else
+            {
+                std::snprintf(buffer, sizeof(buffer),
+                    "Parcel Scheduled: id=%016llx:%016llx from=L#%llu",
+                    static_cast<unsigned long long>(tag_msb),
+                    static_cast<unsigned long long>(tag_lsb),
+                    static_cast<unsigned long long>(source_locality_id));
+            }
+            hpx::tracy::message(buffer, std::strlen(buffer), 0x9C27B0u);
+        }
+
     }    // namespace detail
 
     ////////////////////////////////////////////////////////////////////////////

--- a/libs/full/parcelset/src/parcel.cpp
+++ b/libs/full/parcelset/src/parcel.cpp
@@ -444,9 +444,9 @@ namespace hpx::parcelset::detail {
     {
         load_data(ar);
 
-        // Emit immediately after load_data, before any early return can
-        // skip it (migrated targets, zero-copy, and multi-parcel messages
-        // would otherwise never appear on the receive side).
+        // Emit immediately after load_data, before either early return
+        // can skip it (migrated targets and zero-copy receives would
+        // otherwise never appear on the receive side).
         HPX_TRACING_MARK_EVENT("recv_parcel");
 
 #if defined(HPX_HAVE_PARCEL_PROFILING)

--- a/libs/full/parcelset/src/parcel.cpp
+++ b/libs/full/parcelset/src/parcel.cpp
@@ -444,6 +444,17 @@ namespace hpx::parcelset::detail {
     {
         load_data(ar);
 
+        // Emit immediately after load_data, before any early return can
+        // skip it (migrated targets, zero-copy, and multi-parcel messages
+        // would otherwise never appear on the receive side).
+        HPX_TRACING_MARK_EVENT("recv_parcel");
+
+#if defined(HPX_HAVE_PARCEL_PROFILING)
+        hpx::tracing::recv_parcel(data_.parcel_id_.get_msb(),
+            data_.parcel_id_.get_lsb(),
+            naming::get_locality_id_from_gid(data_.source_id_));
+#endif
+
         // make sure this parcel destination matches the proper locality
         HPX_ASSERT(destination_locality() == data_.addr_.locality_);
 
@@ -471,14 +482,6 @@ namespace hpx::parcelset::detail {
         action_->load_schedule(ar, HPX_MOVE(data_.dest_), p.first, p.second,
             num_thread, deferred_schedule);
 
-        HPX_TRACING_MARK_EVENT("recv_parcel");
-
-#if defined(HPX_HAVE_PARCEL_PROFILING)
-        hpx::tracing::recv_parcel(data_.parcel_id_.get_msb(),
-            data_.parcel_id_.get_lsb(),
-            naming::get_locality_id_from_gid(data_.source_id_));
-#endif
-
         return false;
     }
 
@@ -494,9 +497,24 @@ namespace hpx::parcelset::detail {
         auto const r = action_->was_object_migrated(data_.dest_, p.first);
         if (r.first)
         {
-            // If the object was migrated, just route.
+            // If the object was migrated, just route. No parcel_scheduled
+            // emit here: the AGAS re-route may deliver the same parcel to
+            // another schedule_action call, and emitting on both would
+            // double-count. Only the terminating call, below, emits.
             return true;
         }
+
+        // Emit only when we actually schedule -- migration returns above
+        // do not fire parcel_scheduled.
+        HPX_TRACING_MARK_EVENT("parcel_scheduled");
+
+#if defined(HPX_HAVE_PARCEL_PROFILING)
+        hpx::tracing::parcel_scheduled(data_.parcel_id_.get_msb(),
+            data_.parcel_id_.get_lsb(),
+            naming::get_locality_id_from_gid(data_.source_id_),
+            reinterpret_cast<std::uint64_t>(
+                action_->get_parent_thread_id().get()));
+#endif
 
         // dispatch action, register work item either with or without
         // continuation support, this is handled in the transfer action

--- a/libs/full/parcelset/src/parcel.cpp
+++ b/libs/full/parcelset/src/parcel.cpp
@@ -474,10 +474,9 @@ namespace hpx::parcelset::detail {
         HPX_TRACING_MARK_EVENT("recv_parcel");
 
 #if defined(HPX_HAVE_PARCEL_PROFILING)
-        hpx::tracing::recv_parcel(data_.parcel_id_.get_lsb(), size_,
-            naming::get_locality_id_from_gid(data_.source_id_),
-            reinterpret_cast<std::uint64_t>(
-                action_->get_parent_thread_id().get()));
+        hpx::tracing::recv_parcel(data_.parcel_id_.get_msb(),
+            data_.parcel_id_.get_lsb(),
+            naming::get_locality_id_from_gid(data_.source_id_));
 #endif
 
         return false;

--- a/libs/full/parcelset/src/parcelhandler.cpp
+++ b/libs/full/parcelset/src/parcelhandler.cpp
@@ -668,8 +668,9 @@ namespace hpx::parcelset {
             HPX_TRACING_MARK_EVENT("send_parcel");
 
 #if defined(HPX_HAVE_PARCEL_PROFILING)
-            hpx::tracing::send_parcel(
-                p.parcel_id().get_lsb(), p.size(), p.destination_locality_id());
+            hpx::tracing::send_parcel(p.parcel_id().get_msb(),
+                p.parcel_id().get_lsb(), p.size(),
+                p.destination_locality_id());
 #endif
         }
     }    // namespace detail

--- a/libs/full/parcelset/src/parcelhandler.cpp
+++ b/libs/full/parcelset/src/parcelhandler.cpp
@@ -669,8 +669,7 @@ namespace hpx::parcelset {
 
 #if defined(HPX_HAVE_PARCEL_PROFILING)
             hpx::tracing::send_parcel(p.parcel_id().get_msb(),
-                p.parcel_id().get_lsb(), p.size(),
-                p.destination_locality_id());
+                p.parcel_id().get_lsb(), p.size(), p.destination_locality_id());
 #endif
         }
     }    // namespace detail

--- a/libs/full/parcelset_base/src/parcelport.cpp
+++ b/libs/full/parcelset_base/src/parcelport.cpp
@@ -403,7 +403,7 @@ namespace hpx::parcelset {
         }
 
 #if defined(HPX_HAVE_PARCEL_PROFILING)
-        hpx::tracing::send_parcel(
+        hpx::tracing::send_parcel(p.parcel_id().get_msb(),
             p.parcel_id().get_lsb(), p.size(), p.destination_locality_id());
 #endif
     }


### PR DESCRIPTION
## Proposed Changes

  - `send_parcel` and `recv_parcel` now pass the full 128-bit parcel id as `(msb, lsb)` instead of just the low half. The low half restarts on each locality, so matching on it alone gives false pairs.
  - Added a `parcel_scheduled` event to all four backends. Deferred receives (zero-copy, multi-parcel messages, AGAS-routed parcels) reach the scheduler through `parcel::schedule_action`, which had no hook.
  - Fixed the receive side. The `recv_parcel` emit was sitting after two early returns in `parcel::load_schedule`, so migrated targets and zero-copy receives never got an event. It now fires right after `load_data`, where `parcel_id_` is set and nothing can skip it.
  - Wrote the Tracy bodies for all three, behind the connection gate from #7497.

## Any background context you want to provide?

All four backends declared `send_parcel` and `recv_parcel` but only APEX implemented them, so a Tracy trace of a distributed run had nothing about parcels in it. Without a send and a matching receive you cannot follow a dependency from one locality to another in a merged trace.

I tested this on a two-locality run under Tracy capture, using `zero_copy_parcels_1001_test` to hit the deferred path:

| | Locality 0 | Locality 1 |
|---|---|---|
| Parcel Send | 637 | 620 |
| Parcel Recv | 637 | 620 |
| Parcel Scheduled | 626 | 609 |

Every id sent by one locality shows up exactly once as a receive on the other, both directions, no duplicates. Every `parcel_scheduled` has a matching receive on the same locality and lines up with a send over the zero-copy threshold. A run below that threshold (`1d_stencil_5`) gives 80 sends and 80 receives per locality and zero scheduled events, which is what should happen on the non-deferred path.

Three things worth mentioning.

`parcel_scheduled` does not fire on the migration branch of `schedule_action`. The AGAS re-route can hand the same parcel to a second `schedule_action` call, so emitting in both places would count it twice. Only the call that actually schedules emits.

I left `size` out of the receive event. `parcel::size_` starts at zero and `load_data` never sets it, so that value has always been zero, including on the APEX path today. Printing a number I know is wrong seemed worse than not printing it. I will open a separate issue for that.

The APEX shim takes the `msb` now and drops it, since `util::external_timer::send` and `recv` only take one `uint64_t` tag. Nothing changes for APEX: the call sites passed `get_lsb()` before and pass `msb, lsb` now, with the shim forwarding the same `lsb`. I also dropped `source_thread_id` from `recv_parcel` — APEX marks that parameter `APEX_UNUSED` and puts zero in its place, so it was never used.

One gap: the AGAS routing path, where an inner parcel reaches the scheduler without going through `load_schedule`, is handled in the code but neither test workload hit it. I checked it by reading the call graph, not by running it.

Builds pass with Tracy on and off, parcel profiling on and off, with ITTNotify, with APEX, and with networking off.

## Checklist

Not all points below apply to all pull requests.
- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.

`parcel_scheduled` is a no-op in every backend but Tracy; `send_parcel` and `recv_parcel` still feed the APEX shim as before. All three only compile under `HPX_HAVE_PARCEL_PROFILING`. I verified with a two-locality capture rather than a unit test, since the thing to check is whether ids pair up across two processes.