### PR TITLE
Fill in documentation gaps for the tracing modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1185,6 +1185,21 @@ hpx_option(
   CATEGORY "Profiling"
 )
 
+if(HPX_WITH_TRACY)
+  hpx_option(
+    HPX_WITH_TRACY_TAG STRING "Tracy repository tag or branch when fetched"
+    "v0.13.1" CATEGORY "Profiling"
+  )
+endif()
+
+hpx_option(
+  HPX_WITH_FETCH_TRACY
+  BOOL
+  "Use FetchContent to fetch Tracy. By default an installed Tracy will be used. (default: OFF)"
+  OFF
+  CATEGORY "Build Targets"
+)
+
 # Experimental settings
 hpx_option(
   HPX_WITH_IO_POOL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1187,8 +1187,8 @@ hpx_option(
 
 if(HPX_WITH_TRACY)
   hpx_option(
-    HPX_WITH_TRACY_TAG STRING "Tracy repository tag or branch when fetched"
-    "v0.13.1" CATEGORY "Profiling"
+    HPX_WITH_TRACY_TAG STRING "Tracy repository tag or branch" "v0.13.1"
+    CATEGORY "Profiling"
   )
 endif()
 

--- a/cmake/templates/conf.py.in
+++ b/cmake/templates/conf.py.in
@@ -951,6 +951,10 @@ rst_prolog += '''
 .. _apex_hpx_doc: https://uo-oaciss.github.io/apex/usage/#hpx-louisiana-state-university
 .. |tau| replace:: TAU
 .. _tau: https://www.cs.uoregon.edu/research/tau/home.php
+.. |tracy| replace:: Tracy
+.. _tracy: https://github.com/wolfpld/tracy
+.. |ittnotify| replace:: Intel ITT API
+.. _ittnotify: https://github.com/intel/ittapi
 .. |cmake| replace:: CMake
 .. _cmake: https://www.cmake.org
 .. |cppdependencies| replace:: cpp-dependencies

--- a/docs/sphinx/manual/building_hpx.rst
+++ b/docs/sphinx/manual/building_hpx.rst
@@ -107,7 +107,8 @@ used CMake options.
 
 .. option:: HPX_WITH_ITTNOTIFY
 
-   Enable |ittnotify|_ integration. Requires Intel VTune.
+   Enable |ittnotify|_ integration. Requires Intel VTune; point
+   ``Amplifier_ROOT`` at the install.
 
 .. option:: HPX_WITH_PARCEL_PROFILING
 

--- a/docs/sphinx/manual/building_hpx.rst
+++ b/docs/sphinx/manual/building_hpx.rst
@@ -107,8 +107,9 @@ used CMake options.
 
 .. option:: HPX_WITH_ITTNOTIFY
 
-   Enable |ittnotify|_ integration. Requires VTune or any other ITTNotify
-   provider; point ``Amplifier_ROOT`` at the install.
+   Enable |ittnotify|_ integration. Requires VTune or any other |ittnotify|
+   provider; point ``Amplifier_ROOT`` at the install (the name is legacy;
+   it accepts any ITTNotify installation).
 
 .. option:: HPX_WITH_PARCEL_PROFILING
 

--- a/docs/sphinx/manual/building_hpx.rst
+++ b/docs/sphinx/manual/building_hpx.rst
@@ -99,6 +99,22 @@ used CMake options.
    Enable APEX integration. `APEX <https://uo-oaciss.github.io/apex/quickstarthpx/>`_ can be used to profile |hpx|
    applications. In particular, it provides information about individual tasks in the |hpx| runtime.
 
+.. option:: HPX_WITH_TRACY
+
+   Enable |tracy|_ integration. Tracy shows task lifecycle, work stealing, suspension, and (with
+   :option:`HPX_WITH_PARCEL_PROFILING`) distributed parcel events. See :ref:`optimizing_with_tracy` for
+   build and attach instructions.
+
+.. option:: HPX_WITH_ITTNOTIFY
+
+   Enable |ittnotify|_ integration. Requires Intel VTune.
+
+.. option:: HPX_WITH_PARCEL_PROFILING
+
+   Enable per-parcel profiling data. Adds per-parcel identifier and timestamp fields (creation time,
+   start time, parcel id) that are carried on the wire and surfaced to whichever tracing backend is
+   enabled. Defaults to ``ON`` when :option:`HPX_WITH_APEX` is on, ``OFF`` otherwise.
+
 .. option:: HPX_WITH_GENERIC_CONTEXT_COROUTINES
 
    Enable Boost. Context for task context switching. It must be enabled for non-x86 architectures such as ARM and Power.

--- a/docs/sphinx/manual/building_hpx.rst
+++ b/docs/sphinx/manual/building_hpx.rst
@@ -107,8 +107,8 @@ used CMake options.
 
 .. option:: HPX_WITH_ITTNOTIFY
 
-   Enable |ittnotify|_ integration. Requires Intel VTune; point
-   ``Amplifier_ROOT`` at the install.
+   Enable |ittnotify|_ integration. Requires VTune or any other ITTNotify
+   provider; point ``Amplifier_ROOT`` at the install.
 
 .. option:: HPX_WITH_PARCEL_PROFILING
 

--- a/docs/sphinx/manual/optimizing_hpx_applications.rst
+++ b/docs/sphinx/manual/optimizing_hpx_applications.rst
@@ -3623,8 +3623,8 @@ Tracy can be supplied via a system install (point ``Tracy_ROOT`` at the install
 tree) or fetched by CMake at configure time by adding
 ``HPX_WITH_FETCH_TRACY=ON``. The version fetched is pinned by
 ``HPX_WITH_TRACY_TAG``, which defaults to ``v0.13.1``. When Tracy is
-fetched, |hpx| enables ``TRACY_ON_DEMAND`` and ``TRACY_FIBERS`` on the built
-client.
+fetched, |hpx| forces ``TRACY_ON_DEMAND`` and ``TRACY_FIBERS`` on the built
+client. A system-supplied Tracy must have been built with both.
 
 To profile a distributed run, additionally enable
 :option:`HPX_WITH_PARCEL_PROFILING`\ ``=ON`` so per-parcel identifiers are

--- a/docs/sphinx/manual/optimizing_hpx_applications.rst
+++ b/docs/sphinx/manual/optimizing_hpx_applications.rst
@@ -3610,6 +3610,31 @@ addition, you can override the tag used for |apex|_ with the
 :option:`HPX_WITH_APEX_TAG` option. Please see the |apex_hpx_doc|_ for detailed
 instructions on using |apex|_ with |hpx|.
 
+.. _optimizing_with_tracy:
+
+Tracy integration
+=================
+
+|hpx| provides integration with the |tracy|_ profiler, which offers
+per-thread zone tracking, message logs, and fiber support. Enable it with
+:option:`HPX_WITH_TRACY`\ ``=ON`` during |cmake|_ configuration.
+
+Tracy can be supplied via a system install (point ``Tracy_ROOT`` at the install
+tree) or fetched by CMake at configure time by adding
+``HPX_WITH_FETCH_TRACY=ON``. The version fetched is pinned by
+``HPX_WITH_TRACY_TAG``, which defaults to ``v0.13.1``. When Tracy is
+fetched, |hpx| enables ``TRACY_ON_DEMAND`` and ``TRACY_FIBERS`` on the built
+client.
+
+To profile a distributed run, additionally enable
+:option:`HPX_WITH_PARCEL_PROFILING`\ ``=ON`` so per-parcel identifiers are
+carried on the wire and the ``send_parcel`` / ``recv_parcel`` /
+``parcel_scheduled`` events can be correlated across localities by parcel id.
+
+Start ``tracy-profiler`` (or ``tracy-capture`` for headless capture) before
+or during the run. Tracy discovers instrumented processes via UDP broadcast
+on the local network; no port configuration is required for the common case.
+
 References
 ==========
 

--- a/libs/core/modules.rst
+++ b/libs/core/modules.rst
@@ -90,6 +90,7 @@ Core modules
    /libs/core/timed_execution/docs/index.rst
    /libs/core/timing/docs/index.rst
    /libs/core/topology/docs/index.rst
+   /libs/core/tracing/docs/index.rst
    /libs/core/tracy/docs/index.rst
    /libs/core/type_support/docs/index.rst
    /libs/core/util/docs/index.rst

--- a/libs/core/tracing/docs/index.rst
+++ b/libs/core/tracing/docs/index.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright (c) 2026 The STE||AR-Group
+    Copyright (c) 2026 Vansh Dobhal
 
     SPDX-License-Identifier: BSL-1.0
     Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/tracing/docs/index.rst
+++ b/libs/core/tracing/docs/index.rst
@@ -28,10 +28,12 @@ configure time if more than one of :option:`HPX_WITH_APEX`,
   ``constexpr`` no-ops and the tracing macros expand to nothing, so every
   entry compiles out at zero runtime cost.
 
-The public entry points live in ``hpx/tracing/backends/{empty,ittnotify,apex,tracy}.hpp``
-and are all under the ``hpx::tracing`` namespace. The dispatch macros
-(``HPX_TRACING_MARK_EVENT``, ``HPX_TRACING_ZONE``, ``HPX_TRACING_PAUSE``,
-``HPX_TRACING_RESUME``) live in ``hpx/tracing/macros.hpp``.
+Include ``hpx/modules/tracing.hpp`` to get the public API; it dispatches
+at compile time to one of the four per-backend headers under
+``hpx/tracing/backends/``. Entries are declared in the ``hpx::tracing``
+namespace and the dispatch macros (``HPX_TRACING_MARK_EVENT``,
+``HPX_TRACING_ZONE``, ``HPX_TRACING_PAUSE``, ``HPX_TRACING_RESUME``) live
+in ``hpx/tracing/macros.hpp``.
 
 See :ref:`optimizing_with_tracy` for how to build |hpx| against Tracy and
 attach the profiler.

--- a/libs/core/tracing/docs/index.rst
+++ b/libs/core/tracing/docs/index.rst
@@ -1,0 +1,35 @@
+..
+    Copyright (c) 2026 The STE||AR-Group
+
+    SPDX-License-Identifier: BSL-1.0
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+.. _modules_tracing:
+
+=======
+tracing
+=======
+
+This module provides the |hpx| tracing abstraction: a compile-time-dispatched
+API that annotates |hpx| runtime events (task lifecycle, futures, parcels, work
+stealing, worker sleep, and more) and routes those annotations to a single
+profiler backend selected at build time.
+
+Four backends are supported, one at a time:
+
+* :ref:`modules_tracy` — the |tracy|_ profiler, enabled with
+  :option:`HPX_WITH_TRACY`.
+* |ittnotify|_, enabled with :option:`HPX_WITH_ITTNOTIFY`.
+* |apex|_, enabled with :option:`HPX_WITH_APEX`.
+* an empty backend when none of the above is enabled — the C++ hooks are
+  ``constexpr`` no-ops and the tracing macros expand to nothing, so every
+  entry compiles out at zero runtime cost.
+
+The public entry points live in ``hpx/tracing/backends/{empty,ittnotify,apex,tracy}.hpp``
+and are all under the ``hpx::tracing`` namespace. The dispatch macros
+(``HPX_TRACING_MARK_EVENT``, ``HPX_TRACING_ZONE``, ``HPX_TRACING_PAUSE``,
+``HPX_TRACING_RESUME``) live in ``hpx/tracing/macros.hpp``.
+
+See :ref:`optimizing_with_tracy` for how to build |hpx| against Tracy and
+attach the profiler.

--- a/libs/core/tracing/docs/index.rst
+++ b/libs/core/tracing/docs/index.rst
@@ -16,20 +16,21 @@ API that annotates |hpx| runtime events (task lifecycle, futures, parcels, work
 stealing, worker sleep, and more) and routes those annotations to a single
 profiler backend selected at build time.
 
-Four backends are supported; ``HPX_SetupTracing.cmake`` errors out at
-configure time if more than one of :option:`HPX_WITH_APEX`,
-:option:`HPX_WITH_ITTNOTIFY` or :option:`HPX_WITH_TRACY` is enabled.
+Three profiler backends are supported, with a no-op fallback when none is
+enabled. ``HPX_SetupTracing.cmake`` errors out at configure time if more
+than one of :option:`HPX_WITH_APEX`, :option:`HPX_WITH_ITTNOTIFY` or
+:option:`HPX_WITH_TRACY` is enabled.
 
 * :ref:`modules_tracy` — the |tracy|_ profiler, enabled with
   :option:`HPX_WITH_TRACY`.
 * |ittnotify|_, enabled with :option:`HPX_WITH_ITTNOTIFY`.
 * |apex|_, enabled with :option:`HPX_WITH_APEX`.
 * an empty backend when none of the above is enabled — the C++ hooks are
-  ``constexpr`` no-ops and the tracing macros expand to nothing, so every
-  entry compiles out at zero runtime cost.
+  ``constexpr`` no-ops and the tracing macros expand to nothing, so the
+  hooks compile away when tracing is disabled.
 
 Include ``hpx/modules/tracing.hpp`` to get the public API; it dispatches
-at compile time to one of the four per-backend headers under
+at compile time to one of the per-backend headers under
 ``hpx/tracing/backends/``. Entries are declared in the ``hpx::tracing``
 namespace and the dispatch macros (``HPX_TRACING_MARK_EVENT``,
 ``HPX_TRACING_ZONE``, ``HPX_TRACING_PAUSE``, ``HPX_TRACING_RESUME``) live

--- a/libs/core/tracing/docs/index.rst
+++ b/libs/core/tracing/docs/index.rst
@@ -16,7 +16,9 @@ API that annotates |hpx| runtime events (task lifecycle, futures, parcels, work
 stealing, worker sleep, and more) and routes those annotations to a single
 profiler backend selected at build time.
 
-Four backends are supported, one at a time:
+Four backends are supported; ``HPX_SetupTracing.cmake`` errors out at
+configure time if more than one of :option:`HPX_WITH_APEX`,
+:option:`HPX_WITH_ITTNOTIFY` or :option:`HPX_WITH_TRACY` is enabled.
 
 * :ref:`modules_tracy` — the |tracy|_ profiler, enabled with
   :option:`HPX_WITH_TRACY`.

--- a/libs/core/tracy/docs/index.rst
+++ b/libs/core/tracy/docs/index.rst
@@ -13,5 +13,5 @@ tracy
 
 This module enables the integration of |hpx| applications with the |tracy|_
 profiler. See :ref:`modules_tracing` for the backend abstraction that dispatches
-to Tracy at compile time, and :ref:`optimizing_with_tracy` for how to build
-|hpx| against Tracy and attach the profiler.
+to |tracy| at compile time, and :ref:`optimizing_with_tracy` for how to build
+|hpx| against |tracy| and attach the profiler.

--- a/libs/core/tracy/docs/index.rst
+++ b/libs/core/tracy/docs/index.rst
@@ -11,6 +11,7 @@
 tracy
 =====
 
-This modules enables the integration of |hpx| applications with the |tracy|_ profiler.
-
-.. tracy: https://github.com/wolfpld/tracy
+This module enables the integration of |hpx| applications with the |tracy|_
+profiler. See :ref:`modules_tracing` for the backend abstraction that dispatches
+to Tracy at compile time, and :ref:`optimizing_with_tracy` for how to build
+|hpx| against Tracy and attach the profiler.


### PR DESCRIPTION
## Proposed Changes

  - Fixed a dead link in the `tracy` module page. The `.. tracy:` line was missing an underscore, so it parsed as a comment and `|tracy|_` resolved to nothing. Added global `|tracy|` and `|ittnotify|` substitutions to `conf.py.in` instead, matching the existing `|apex|` and `|tau|` entries.
  - Added `libs/core/tracing/docs/index.rst` and registered the module in `libs/core/modules.rst`. `hpx_tracing` was missing from the index entirely.
  - Registered `HPX_WITH_FETCH_TRACY` and `HPX_WITH_TRACY_TAG` as proper `hpx_option`s. They were only read inside `HPX_SetupTracy.cmake`, so there was no way to discover them or to see that Tracy is pinned at `v0.13.1`.
  - Documented `HPX_WITH_TRACY`, `HPX_WITH_ITTNOTIFY` and `HPX_WITH_PARCEL_PROFILING` in the manual, next to the existing `HPX_WITH_APEX` entry, and added a Tracy section to the profiling chapter.

## Any background context you want to provide?

The tracing work merged over the last few months added a module, several CMake options and a set of backends, but no documentation. `hpx_tracing` never appeared in the module index, the two Tracy CMake options were undiscoverable, and the one page that did exist had a broken link.

Nothing here changes behaviour. `HPX_WITH_TRACY_TAG` keeps its existing default of `v0.13.1` and is registered inside `if(HPX_WITH_TRACY)`, matching how `HPX_WITH_APEX_TAG` is handled.

I checked the prose against the code rather than writing from memory, so the option descriptions, the backend list and the defaults all reflect what is actually there. Following the existing convention, `HPX_WITH_FETCH_TRACY` and `HPX_WITH_TRACY_TAG` are referenced as literals rather than with the `:option:` role, since `HPX_WITH_FETCH_APEX` and `HPX_WITH_APEX_TAG` have no `.. option::` blocks either.

## Checklist

Not all points below apply to all pull requests.
- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.

Documentation and CMake option registration only, no functional change.