### PR TITLE
async_distributed: add reflection overloads for async_continue, post_cb policy, and dataflow

### DIFF
--- a/libs/full/async_distributed/include/hpx/async_distributed/async_continue.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/async_continue.hpp
@@ -98,3 +98,54 @@ namespace hpx {
             HPX_FORWARD(Cont, cont), policy, HPX_FORWARD(Ts, vs)...);
     }
 }    // namespace hpx
+
+#if defined(HPX_HAVE_CXX26_REFLECTION)
+
+namespace hpx {
+
+    /// \brief Reflection-based async_continue overload targeting a gid.
+    ///
+    /// \tparam F        A std::meta::info reflection of a free function.
+    /// \tparam Cont     Continuation type.
+    /// \tparam Ts       Additional arguments forwarded to the action.
+    /// \param cont      The continuation to invoke on completion.
+    /// \param gid       The target locality id.
+    /// \param ts        Additional arguments forwarded to the action.
+    // clang-format off
+    HPX_CXX_EXPORT template <std::meta::info F, typename Cont,
+        typename... Ts>
+        requires(std::meta::is_namespace_member(F) &&
+            std::meta::is_function(F))
+    auto async_continue(Cont&& cont,
+        hpx::id_type const& gid, Ts&&... ts)
+    // clang-format on
+    {
+        return hpx::async_continue<hpx::actions::reflect_action<F>>(
+            HPX_FORWARD(Cont, cont), gid, HPX_FORWARD(Ts, ts)...);
+    }
+
+    /// \brief Reflection-based async_continue overload targeting a distribution policy.
+    ///
+    /// \tparam F          A std::meta::info reflection of a free function.
+    /// \tparam Cont       Continuation type.
+    /// \tparam DistPolicy Distribution policy type.
+    /// \tparam Ts         Additional arguments forwarded to the action.
+    /// \param cont        The continuation to invoke on completion.
+    /// \param policy      The distribution policy.
+    /// \param ts          Additional arguments forwarded to the action.
+    // clang-format off
+    HPX_CXX_EXPORT template <std::meta::info F, typename Cont,
+        typename DistPolicy, typename... Ts>
+        requires(std::meta::is_namespace_member(F) &&
+            std::meta::is_function(F) &&
+            traits::is_distribution_policy_v<DistPolicy>)
+    auto async_continue(
+        Cont&& cont, DistPolicy const& policy, Ts&&... ts)
+    // clang-format on
+    {
+        return hpx::async_continue<hpx::actions::reflect_action<F>>(
+            HPX_FORWARD(Cont, cont), policy, HPX_FORWARD(Ts, ts)...);
+    }
+
+}    // namespace hpx
+#endif    // HPX_HAVE_CXX26_REFLECTION

--- a/libs/full/async_distributed/include/hpx/async_distributed/async_continue_callback.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/async_continue_callback.hpp
@@ -106,3 +106,60 @@ namespace hpx {
             HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, vs)...);
     }
 }    // namespace hpx
+
+#if defined(HPX_HAVE_CXX26_REFLECTION)
+
+namespace hpx {
+
+    /// \brief Reflection-based async_continue_cb overload targeting a gid.
+    ///
+    /// \tparam F        A std::meta::info reflection of a free function.
+    /// \tparam Cont     Continuation type.
+    /// \tparam Callback Callback type invoked on completion.
+    /// \tparam Ts       Additional arguments forwarded to the action.
+    /// \param cont      The continuation to invoke on completion.
+    /// \param gid       The target locality id.
+    /// \param cb        The callback invoked on completion.
+    /// \param vs        Additional arguments forwarded to the action.
+    // clang-format off
+    HPX_CXX_EXPORT template <std::meta::info F, typename Cont,
+        typename Callback, typename... Ts>
+        requires(std::meta::is_namespace_member(F) &&
+            std::meta::is_function(F))
+    auto async_continue_cb(
+        Cont&& cont, hpx::id_type const& gid, Callback&& cb, Ts&&... vs)
+    // clang-format on
+    {
+        return hpx::async_continue_cb<hpx::actions::reflect_action<F>>(
+            HPX_FORWARD(Cont, cont), gid, HPX_FORWARD(Callback, cb),
+            HPX_FORWARD(Ts, vs)...);
+    }
+
+    /// \brief Reflection-based async_continue_cb overload targeting a distribution policy.
+    ///
+    /// \tparam F          A std::meta::info reflection of a free function.
+    /// \tparam Cont       Continuation type.
+    /// \tparam DistPolicy Distribution policy type.
+    /// \tparam Callback   Callback type invoked on completion.
+    /// \tparam Ts         Additional arguments forwarded to the action.
+    /// \param cont        The continuation to invoke on completion.
+    /// \param policy      The distribution policy.
+    /// \param cb          The callback invoked on completion.
+    /// \param vs          Additional arguments forwarded to the action.
+    // clang-format off
+    HPX_CXX_EXPORT template <std::meta::info F, typename Cont,
+        typename DistPolicy, typename Callback, typename... Ts>
+        requires(std::meta::is_namespace_member(F) &&
+            std::meta::is_function(F) &&
+            traits::is_distribution_policy_v<DistPolicy>)
+    auto async_continue_cb(
+        Cont&& cont, DistPolicy const& policy, Callback&& cb, Ts&&... vs)
+    // clang-format on
+    {
+        return hpx::async_continue_cb<hpx::actions::reflect_action<F>>(
+            HPX_FORWARD(Cont, cont), policy, HPX_FORWARD(Callback, cb),
+            HPX_FORWARD(Ts, vs)...);
+    }
+
+}    // namespace hpx
+#endif    // HPX_HAVE_CXX26_REFLECTION

--- a/libs/full/async_distributed/include/hpx/async_distributed/bind_action.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/bind_action.hpp
@@ -190,3 +190,30 @@ namespace hpx::serialization {
         bound.serialize(ar, version);
     }
 }    // namespace hpx::serialization
+
+#if defined(HPX_HAVE_CXX26_REFLECTION)
+#include <hpx/modules/actions_base.hpp>
+
+namespace hpx {
+
+    /// \brief Reflection-based bind overload.
+    ///
+    /// Allows calling hpx::bind<^^func>(ts...) directly without defining
+    /// an explicit action type. Forwards to hpx::bind<reflect_action<F>>.
+    ///
+    /// \tparam F   A std::meta::info reflection of a free function.
+    /// \tparam Ts  Types of the arguments to bind.
+    /// \param vs   Arguments forwarded to the bound action.
+    // clang-format off
+    HPX_CXX_EXPORT template <std::meta::info F, typename... Ts>
+        requires(std::meta::is_namespace_member(F) &&
+            std::meta::is_function(F))
+    // clang-format on
+    auto bind(Ts&&... vs)
+    {
+        return hpx::bind<hpx::actions::reflect_action<F>>(
+            HPX_FORWARD(Ts, vs)...);
+    }
+
+}    // namespace hpx
+#endif    // HPX_HAVE_CXX26_REFLECTION

--- a/libs/full/async_distributed/include/hpx/async_distributed/dataflow.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/dataflow.hpp
@@ -142,4 +142,59 @@ namespace hpx {
     }
 }    // namespace hpx
 
+#if defined(HPX_HAVE_CXX26_REFLECTION)
+
+namespace hpx {
+
+    /// \brief Reflection-based dataflow overload.
+    ///
+    /// Allows calling hpx::dataflow<^^func>(target, ts...) directly
+    /// without defining an explicit action type.
+    ///
+    /// \tparam F      A std::meta::info reflection of a free function.
+    /// \tparam Ts     Additional arguments forwarded to the action.
+    /// \param ts      Target and additional arguments forwarded to the action.
+    // clang-format off
+    HPX_CXX_EXPORT template <std::meta::info F, typename Target,
+        typename... Ts>
+        requires(std::meta::is_namespace_member(F) &&
+            std::meta::is_function(F) &&
+            (std::is_same_v<std::decay_t<Target>, hpx::id_type> ||
+                hpx::traits::is_client_v<std::decay_t<Target>> ||
+                hpx::traits::is_distribution_policy_v<std::decay_t<Target>>))
+    // clang-format on
+    decltype(auto) dataflow(Target&& target, Ts&&... ts)
+    {
+        return hpx::dataflow(hpx::actions::reflect_action<F>{},
+            HPX_FORWARD(Target, target), HPX_FORWARD(Ts, ts)...);
+    }
+    /// \brief Reflection-based dataflow overload with launch policy.
+    ///
+    /// \tparam F       A std::meta::info reflection of a free function.
+    /// \tparam Policy  Launch policy type.
+    /// \tparam Target  id_type, client, or distribution policy.
+    /// \tparam Ts      Additional arguments forwarded to the action.
+    /// \param policy   The launch policy.
+    /// \param target   The target where the action should be executed.
+    /// \param ts       Additional arguments forwarded to the action.
+    // clang-format off
+    HPX_CXX_EXPORT template <std::meta::info F, typename Policy,
+        typename Target, typename... Ts>
+        requires(std::meta::is_namespace_member(F) &&
+            std::meta::is_function(F) &&
+            traits::is_launch_policy_v<Policy> &&
+            (std::is_same_v<std::decay_t<Target>, hpx::id_type> ||
+                hpx::traits::is_client_v<std::decay_t<Target>> ||
+                hpx::traits::is_distribution_policy_v<std::decay_t<Target>>))
+    // clang-format on
+    decltype(auto) dataflow(Policy&& policy, Target&& target, Ts&&... ts)
+    {
+        return hpx::dataflow(HPX_FORWARD(Policy, policy),
+            hpx::actions::reflect_action<F>{}, HPX_FORWARD(Target, target),
+            HPX_FORWARD(Ts, ts)...);
+    }
+
+}    // namespace hpx
+#endif    // HPX_HAVE_CXX26_REFLECTION
+
 #endif

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/post_callback.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/post_callback.hpp
@@ -522,9 +522,55 @@ namespace hpx {
         Target&& target, Callback&& cb, Ts&&... ts)
     // clang-format on
     {
-        return hpx::post_cb(hpx::actions::reflect_action<F>{},
+        return hpx::post_cb<hpx::actions::reflect_action<F>>(
             HPX_FORWARD(Target, target), HPX_FORWARD(Callback, cb),
             HPX_FORWARD(Ts, ts)...);
+    }
+    /// \brief Reflection-based post_cb overload with explicit launch policy.
+    ///
+    /// \tparam F        A std::meta::info reflection of a free function.
+    /// \tparam Callback Callback type invoked on completion.
+    /// \tparam Ts       Additional arguments to pass to the function.
+    /// \param target    The target locality id.
+    /// \param policy    The launch policy.
+    /// \param cb        The callback invoked on completion.
+    /// \param ts        Additional arguments forwarded to the function.
+    // clang-format off
+    HPX_CXX_EXPORT template <std::meta::info F, typename Callback,
+        typename... Ts>
+        requires(std::meta::is_namespace_member(F) &&
+            std::meta::is_function(F))
+    HPX_FORCEINLINE bool post_cb(
+        hpx::id_type const& target, hpx::launch policy,
+        Callback&& cb, Ts&&... ts)
+    // clang-format on
+    {
+        return hpx::post_p_cb<hpx::actions::reflect_action<F>>(
+            target, policy, HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, ts)...);
+    }
+    /// \brief Reflection-based post_cb overload with distribution policy and launch policy.
+    ///
+    /// \tparam F          A std::meta::info reflection of a free function.
+    /// \tparam DistPolicy Distribution policy type.
+    /// \tparam Callback   Callback type invoked on completion.
+    /// \tparam Ts         Additional arguments to pass to the function.
+    /// \param dist_policy The distribution policy.
+    /// \param launch      The launch policy.
+    /// \param cb          The callback invoked on completion.
+    /// \param ts          Additional arguments forwarded to the function.
+    // clang-format off
+    HPX_CXX_EXPORT template <std::meta::info F, typename DistPolicy,
+        typename Callback, typename... Ts>
+        requires(std::meta::is_namespace_member(F) &&
+            std::meta::is_function(F) &&
+            hpx::traits::is_distribution_policy_v<std::decay_t<DistPolicy>>)
+    HPX_FORCEINLINE bool post_cb(
+        DistPolicy const& dist_policy, hpx::launch launch,
+        Callback&& cb, Ts&&... ts)
+    // clang-format on
+    {
+        return hpx::post_p_cb<hpx::actions::reflect_action<F>>(dist_policy,
+            launch, HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, ts)...);
     }
 #endif    // HPX_HAVE_CXX26_REFLECTION
 }    // namespace hpx

--- a/libs/full/async_distributed/include/hpx/async_distributed/packaged_action.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/packaged_action.hpp
@@ -691,3 +691,23 @@ namespace hpx::lcos {
         }
     };
 }    // namespace hpx::lcos
+
+#if defined(HPX_HAVE_CXX26_REFLECTION)
+#include <hpx/modules/actions_base.hpp>
+
+namespace hpx::lcos {
+
+    /// \brief Reflection-based packaged_action alias.
+    ///
+    /// Allows using hpx::lcos::reflect_packaged_action<^^func> directly
+    /// without defining an explicit action type.
+    ///
+    /// \tparam F  A std::meta::info reflection of a free function.
+    template <std::meta::info F>
+        requires(std::meta::is_namespace_member(F) && std::meta::is_function(F))
+    using reflect_packaged_action =
+        packaged_action<hpx::actions::reflect_action<F>,
+            typename hpx::actions::reflect_action<F>::result_type>;
+
+}    // namespace hpx::lcos
+#endif    // HPX_HAVE_CXX26_REFLECTION


### PR DESCRIPTION
Closes parity gaps identified in #7509:

- `post_cb`: adds `hpx::post_cb<^^F>(target, policy, cb, ts...)` forwarding to `hpx::post_p_cb<reflect_action<F>>`.
- `async_continue`: adds `hpx::async_continue<^^F>(cont, gid, ts...)` and `hpx::async_continue<^^F>(cont, policy, ts...)`.
- `dataflow`: adds `hpx::dataflow<^^F>(ts...)` forwarding to `hpx::dataflow(reflect_action<F>{}, ts...)`.

All follow the same pattern as the existing reflection overloads in `async.hpp`, `sync.hpp`, `post.hpp`, and `async_callback.hpp`. Guarded by `HPX_HAVE_CXX26_REFLECTION`.