### PR TITLE
Bound the Dijkstra termination probe retry when the token cannot be delivered

### DIFF
--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/detail/dijkstra_termination_token.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/detail/dijkstra_termination_token.hpp
@@ -8,9 +8,35 @@
 
 #include <hpx/config.hpp>
 
+#include <cstddef>
 #include <cstdint>
 
 namespace hpx::components::server::detail {
+
+    /// \brief Whether the initiator should initiate another termination probe.
+    ///
+    /// A probe that leaves the initiator black means some locality was still
+    /// active, and rule 3 requires a further probe; that repetition is
+    /// deliberately unbounded. A probe that could not be handed to any
+    /// locality is a different case: the ring is missing a locality, so
+    /// repeating the probe cannot deliver it. Those are bounded, letting
+    /// shutdown proceed with a diagnostic instead of probing until the process
+    /// is killed.
+    ///
+    /// \param initiator_black           Whether the probe left the initiator
+    ///                                  black, i.e. the probe was unsuccessful.
+    /// \param undeliverable_probes      Number of consecutive probes that
+    ///                                  could not be handed to any locality.
+    /// \param max_undeliverable_probes  Bound on that count.
+    ///
+    /// \return true if another probe should be initiated.
+    constexpr bool dijkstra_should_reprobe(bool const initiator_black,
+        std::size_t const undeliverable_probes,
+        std::size_t const max_undeliverable_probes) noexcept
+    {
+        return initiator_black &&
+            undeliverable_probes < max_undeliverable_probes;
+    }
 
     /// \brief Pure ring-walk decision logic used while forwarding the Dijkstra
     ///        termination detection token.

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/detail/dijkstra_termination_token.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/detail/dijkstra_termination_token.hpp
@@ -26,7 +26,8 @@ namespace hpx::components::server::detail {
     /// \param initiator_black           Whether the probe left the initiator
     ///                                  black, i.e. the probe was unsuccessful.
     /// \param undeliverable_probes      Number of consecutive probes that
-    ///                                  could not be handed to any locality.
+    ///                                  could not be handed to any locality
+    ///                                  other than the initiator itself.
     /// \param max_undeliverable_probes  Bound on that count.
     ///
     /// \return true if another probe should be initiated.
@@ -67,11 +68,17 @@ namespace hpx::components::server::detail {
     /// \param send_token              Callable used to attempt handing off
     ///                                the token to a candidate locality.
     ///
-    /// \return true if the token was handed off to some locality strictly
-    ///         between \p locality_id and \p initiating_locality_id, false if
-    ///         the walk reached \p initiating_locality_id without a successful
-    ///         send (the caller is then responsible for the fallback of sending
-    ///         directly to \p initiating_locality_id).
+    /// \return true if the token was handed off, false if the walk reached
+    ///         \p initiating_locality_id without a successful send (the caller
+    ///         is then responsible for the fallback of sending directly to
+    ///         \p initiating_locality_id).
+    ///
+    /// \note   The initiator is itself the last candidate of the walk when
+    ///         \p initiating_locality_id is 0, because the ring wraps through
+    ///         it. That send is local and always succeeds, so a true return
+    ///         does not on its own mean the token reached another locality;
+    ///         a caller that needs to know must check the target it was
+    ///         handed to.
     HPX_CXX_EXPORT template <typename SendToken>
     bool dijkstra_forward_token(std::uint32_t& locality_id,
         std::uint32_t const initiating_locality_id, SendToken&& send_token)

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/detail/dijkstra_termination_token.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/detail/dijkstra_termination_token.hpp
@@ -31,8 +31,8 @@ namespace hpx::components::server::detail {
     /// \param max_undeliverable_probes  Bound on that count.
     ///
     /// \return true if another probe should be initiated.
-    constexpr bool dijkstra_should_reprobe(bool const initiator_black,
-        std::size_t const undeliverable_probes,
+    HPX_CXX_EXPORT constexpr bool dijkstra_should_reprobe(
+        bool const initiator_black, std::size_t const undeliverable_probes,
         std::size_t const max_undeliverable_probes) noexcept
     {
         return initiator_black &&

--- a/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
+++ b/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
@@ -446,6 +446,16 @@ namespace hpx::components::server {
 
         std::size_t count = 0;    // keep track of number of trials
 
+        // A probe that could not be handed to any locality will not be
+        // delivered by repeating it, the ring is simply missing a locality.
+        // Bound those retries the way dijkstra_termination already bounds its
+        // own fallback, so an unreachable locality ends shutdown with a
+        // diagnostic instead of probing until the job hits its wall clock. A
+        // probe that is delivered and returns black is an ordinary
+        // unsuccessful probe under rule 3 and stays unbounded.
+        constexpr std::size_t max_undeliverable_probes = 3;
+        std::size_t undeliverable_probes = 0;
+
         {
             do
             {
@@ -488,6 +498,8 @@ namespace hpx::components::server {
 
                     if (token_sent)
                     {
+                        undeliverable_probes = 0;
+
                         LRT_(info).format(
                             "runtime_support::dijkstra_termination_detection: "
                             "wait for token to come back to us.");
@@ -497,6 +509,8 @@ namespace hpx::components::server {
                     }
                     else
                     {
+                        ++undeliverable_probes;
+
                         // No response will ever arrive to count down the latch;
                         // force it to zero and mark this probe unsuccessful so
                         // another round runs.
@@ -515,7 +529,19 @@ namespace hpx::components::server {
 
                 ++count;
 
-                if (dijkstra_color_)
+                if (undeliverable_probes == max_undeliverable_probes)
+                {
+                    // Report this loudly rather than blocking shutdown: the
+                    // caller only logs the trial count, so giving up here lets
+                    // the runtime shut down instead of probing forever.
+                    LRT_(error).format(
+                        "runtime_support::dijkstra_termination_detection: "
+                        "could not deliver the termination token to any "
+                        "locality in {} consecutive probes; giving up so "
+                        "shutdown can proceed.",
+                        max_undeliverable_probes);
+                }
+                else if (dijkstra_color_)
                 {
                     LRT_(info).format(
                         "runtime_support::dijkstra_termination_detection: "
@@ -523,7 +549,8 @@ namespace hpx::components::server {
                         "initiate next probe.");
                 }
 
-            } while (dijkstra_color_);
+            } while (detail::dijkstra_should_reprobe(dijkstra_color_,
+                undeliverable_probes, max_undeliverable_probes));
 
             // We need the lock here to ensure the mutual exclusion of
             // hpx::latch::count_down and hpx::latch::~latch

--- a/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
+++ b/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
@@ -446,7 +446,7 @@ namespace hpx::components::server {
 
         std::size_t count = 0;    // keep track of number of trials
 
-        // A probe that could not be handed to any locality will not be
+        // A probe that could not be handed to any other locality will not be
         // delivered by repeating it, the ring is simply missing a locality.
         // Bound those retries the way dijkstra_termination already bounds its
         // own fallback, so an unreachable locality ends shutdown with a
@@ -480,13 +480,25 @@ namespace hpx::components::server {
                     target_id = num_localities;
 
                 {
+                    // The ring walk ends at the initiator, so its last hop
+                    // hands the token back to this locality, and the fallback
+                    // below targets this locality as well. Both of those sends
+                    // are local and therefore always succeed, so a probe that
+                    // reached nobody still reports a successful handoff. Track
+                    // whether some other locality accepted the token and count
+                    // undeliverable probes off that instead.
+                    bool reached_other_locality = false;
+
                     // accommodate for disconnected localities
                     bool token_sent = detail::dijkstra_forward_token(target_id,
                         initiating_locality_id,
                         [&](std::uint32_t const target_locality_id) {
-                            return send_dijkstra_termination_token(
+                            bool const sent = send_dijkstra_termination_token(
                                 target_locality_id, initiating_locality_id,
                                 num_localities, dijkstra_color_);
+                            reached_other_locality |= sent &&
+                                target_locality_id != initiating_locality_id;
+                            return sent;
                         });
 
                     if (!token_sent)
@@ -496,10 +508,17 @@ namespace hpx::components::server {
                             num_localities, dijkstra_color_);
                     }
 
-                    if (token_sent)
+                    if (reached_other_locality)
                     {
                         undeliverable_probes = 0;
+                    }
+                    else
+                    {
+                        ++undeliverable_probes;
+                    }
 
+                    if (token_sent)
+                    {
                         LRT_(info).format(
                             "runtime_support::dijkstra_termination_detection: "
                             "wait for token to come back to us.");
@@ -509,8 +528,6 @@ namespace hpx::components::server {
                     }
                     else
                     {
-                        ++undeliverable_probes;
-
                         // No response will ever arrive to count down the latch;
                         // force it to zero and mark this probe unsuccessful so
                         // another round runs.

--- a/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
+++ b/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
@@ -460,6 +460,7 @@ namespace hpx::components::server {
         // unsuccessful probe under rule 3 and stays unbounded.
         constexpr std::size_t max_undeliverable_probes = 3;
         std::size_t undeliverable_probes = 0;
+        bool reprobe = false;
 
         {
             do
@@ -501,8 +502,11 @@ namespace hpx::components::server {
                             bool const sent = send_dijkstra_termination_token(
                                 target_locality_id, initiating_locality_id,
                                 num_localities, dijkstra_color_);
-                            reached_other_locality |= sent &&
-                                target_locality_id != initiating_locality_id;
+                            if (sent &&
+                                target_locality_id != initiating_locality_id)
+                            {
+                                reached_other_locality = true;
+                            }
                             return sent;
                         });
 
@@ -551,14 +555,27 @@ namespace hpx::components::server {
 
                 ++count;
 
-                if (undeliverable_probes == max_undeliverable_probes)
+                // Decide once whether to probe again and report off that same
+                // answer, so the diagnostic can never disagree with the loop.
+                reprobe = detail::dijkstra_should_reprobe(dijkstra_color_,
+                    undeliverable_probes, max_undeliverable_probes);
+
+                if (reprobe)
                 {
-                    // Report this loudly rather than blocking shutdown: the
-                    // caller only logs the trial count, so giving up here lets
-                    // the runtime shut down instead of probing forever.
-                    // Termination is abandoned here, not confirmed, which is a
-                    // deliberate best-effort relaxation for a ring that is
-                    // missing a locality.
+                    LRT_(info).format(
+                        "runtime_support::dijkstra_termination_detection: "
+                        "After the completion of an unsuccessful probe, "
+                        "initiate next probe.");
+                }
+                else if (dijkstra_color_)
+                {
+                    // Still black and out of undeliverable probes. Report this
+                    // loudly rather than blocking shutdown: the caller only
+                    // logs the trial count, so giving up here lets the runtime
+                    // shut down instead of probing forever. Termination is
+                    // abandoned here, not confirmed, which is a deliberate
+                    // best-effort relaxation for a ring that is missing a
+                    // locality.
                     LRT_(error).format(
                         "runtime_support::dijkstra_termination_detection: "
                         "could not deliver the termination token to any other "
@@ -566,16 +583,8 @@ namespace hpx::components::server {
                         "up so shutdown can proceed.",
                         max_undeliverable_probes, count);
                 }
-                else if (dijkstra_color_)
-                {
-                    LRT_(info).format(
-                        "runtime_support::dijkstra_termination_detection: "
-                        "After the completion of an unsuccessful probe, "
-                        "initiate next probe.");
-                }
 
-            } while (detail::dijkstra_should_reprobe(dijkstra_color_,
-                undeliverable_probes, max_undeliverable_probes));
+            } while (reprobe);
 
             // We need the lock here to ensure the mutual exclusion of
             // hpx::latch::count_down and hpx::latch::~latch

--- a/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
+++ b/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
@@ -551,12 +551,15 @@ namespace hpx::components::server {
                     // Report this loudly rather than blocking shutdown: the
                     // caller only logs the trial count, so giving up here lets
                     // the runtime shut down instead of probing forever.
+                    // Termination is abandoned here, not confirmed, which is a
+                    // deliberate best-effort relaxation for a ring that is
+                    // missing a locality.
                     LRT_(error).format(
                         "runtime_support::dijkstra_termination_detection: "
-                        "could not deliver the termination token to any "
-                        "locality in {} consecutive probes; giving up so "
-                        "shutdown can proceed.",
-                        max_undeliverable_probes);
+                        "could not deliver the termination token to any other "
+                        "locality in {} consecutive probes (trial {}); giving "
+                        "up so shutdown can proceed.",
+                        max_undeliverable_probes, count);
                 }
                 else if (dijkstra_color_)
                 {

--- a/libs/full/runtime_distributed/tests/unit/dijkstra_termination_forwarding.cpp
+++ b/libs/full/runtime_distributed/tests/unit/dijkstra_termination_forwarding.cpp
@@ -91,7 +91,11 @@ void test_one_dead_intermediate_locality()
 
 // 3. All intermediates dead down to the initiator -- the walk returns false
 //    once it reaches the initiating locality, leaving the fallback send to the
-//    initiator to the caller.
+//    initiator to the caller. Note that the initiator is the walk's own last
+//    candidate here (the calls end at 0), and this mock fails it like any
+//    other; in production that send is local and succeeds, which is why the
+//    return value alone cannot tell the caller whether the token left this
+//    locality. See test 9.
 void test_all_intermediates_dead_reaches_initiator()
 {
     std::uint32_t locality_id = 4;
@@ -275,9 +279,12 @@ void test_undeliverable_probes_are_bounded()
     }
 }
 
-// 9. The loop drives that predicate off a real ring walk: with nothing
-//    reachable every probe is undeliverable and the loop stops at the bound,
-//    while an intact ring delivers on the first probe and never approaches it.
+// 9. The loop drives that predicate off a real ring walk. The initiator is the
+//    walk's own last candidate when it is locality 0, because the ring wraps
+//    through it, and that send is local and always succeeds. A broken ring
+//    therefore still reports a successful handoff, so the bound has to count
+//    probes that reached no other locality rather than probes that failed to
+//    send. These cases pin that contract down.
 void test_bound_reached_only_when_nothing_is_reachable()
 {
     constexpr std::uint32_t initiating_locality_id = 0;
@@ -296,16 +303,34 @@ void test_bound_reached_only_when_nothing_is_reachable()
             if (0 == target)
                 target = num_localities;
 
-            if (dijkstra_forward_token(target, initiating_locality_id, send))
+            bool reached_other_locality = false;
+            bool token_sent =
+                dijkstra_forward_token(target, initiating_locality_id,
+                    [&](std::uint32_t const target_locality_id) {
+                        bool const sent = send(target_locality_id);
+                        reached_other_locality |= sent &&
+                            target_locality_id != initiating_locality_id;
+                        return sent;
+                    });
+
+            if (!token_sent)
+            {
+                token_sent = send(initiating_locality_id);
+            }
+
+            if (reached_other_locality)
             {
                 undeliverable = 0;
-                initiator_black = false;
             }
             else
             {
                 ++undeliverable;
-                initiator_black = true;
             }
+
+            // A probe that reached another locality comes back white; one that
+            // only ever reached the initiator leaves it black, which is the
+            // case the bound exists for.
+            initiator_black = !reached_other_locality;
             ++probes;
         } while (dijkstra_should_reprobe(
             initiator_black, undeliverable, max_probes));
@@ -314,10 +339,24 @@ void test_bound_reached_only_when_nothing_is_reachable()
     };
 
     {
-        mock_send send({});    // nothing reachable
+        mock_send send({});    // nothing reachable at all
         HPX_TEST_EQ(run_probes(send), max_probes);
         HPX_TEST(send.succeeded_calls_.empty());
         HPX_TEST(!send.calls_.empty());
+    }
+
+    {
+        // The case that actually happens: the ring is broken, but the walk's
+        // last hop and the fallback both target the initiator, whose own send
+        // is local and cannot fail. Every probe reports a successful handoff
+        // and must still count as undeliverable, or the loop never terminates.
+        mock_send send({initiating_locality_id});
+        HPX_TEST_EQ(run_probes(send), max_probes);
+        HPX_TEST(!send.succeeded_calls_.empty());
+        for (std::uint32_t const call : send.succeeded_calls_)
+        {
+            HPX_TEST_EQ(call, initiating_locality_id);
+        }
     }
 
     {

--- a/libs/full/runtime_distributed/tests/unit/dijkstra_termination_forwarding.cpp
+++ b/libs/full/runtime_distributed/tests/unit/dijkstra_termination_forwarding.cpp
@@ -119,17 +119,16 @@ void test_all_intermediates_dead_reaches_initiator()
     HPX_TEST_EQ(fallback_send.calls_[0], initiating_locality_id);
 }
 
-// 4. Fallback target itself unreachable -- characterizes the known gap that
-//    runtime_support::dijkstra_termination discards the return value of its
-//    final fallback send to the initiator, i.e. a total ring failure is never
-//    surfaced anywhere. dijkstra_forward_token itself has already done its job
-//    correctly (it truthfully reports "false: nobody along the ring accepted
-//    it"); the gap lives in the caller ignoring that report for the fallback
-//    call. This test pins down today's (buggy) behavior so that a future fix
-//    that propagates/logs the failure needs to consciously update this test
-//    rather than silently regressing.
+// 4. Fallback target itself unreachable -- the walk truthfully reports that
+//    nobody along the ring accepted the token, and
+//    runtime_support::dijkstra_termination then retries the direct send to the
+//    initiator max_fallback_attempts times before logging that the initiator
+//    will never see this token. Model that retry so the attempt count stays
+//    pinned to the production one.
 void test_fallback_to_initiator_also_unreachable()
 {
+    constexpr int max_fallback_attempts = 3;
+
     std::uint32_t locality_id = 4;
     constexpr std::uint32_t initiating_locality_id = 0;
 
@@ -138,18 +137,23 @@ void test_fallback_to_initiator_also_unreachable()
         dijkstra_forward_token(locality_id, initiating_locality_id, send);
     HPX_TEST(!result);
 
-    // the fallback send to the initiator also fails
+    // the fallback send to the initiator fails on every attempt
     mock_send fallback_send({});
-    bool const fallback_result = fallback_send(initiating_locality_id);
+    bool fallback_sent = false;
+    for (int attempt = 0; !fallback_sent && attempt != max_fallback_attempts;
+        ++attempt)
+    {
+        fallback_sent = fallback_send(initiating_locality_id);
+    }
 
-    HPX_TEST_EQ(fallback_send.calls_.size(), static_cast<std::size_t>(1));
-    HPX_TEST_EQ(fallback_send.calls_[0], initiating_locality_id);
+    HPX_TEST(!fallback_sent);
+    HPX_TEST_EQ(fallback_send.calls_.size(),
+        static_cast<std::size_t>(max_fallback_attempts));
+    for (std::uint32_t const call : fallback_send.calls_)
+    {
+        HPX_TEST_EQ(call, initiating_locality_id);
+    }
     HPX_TEST(fallback_send.succeeded_calls_.empty());
-
-    // Known gap: nothing currently consumes fallback_result on this path in
-    // runtime_support::dijkstra_termination, so a total ring failure is
-    // silently dropped instead of being propagated, logged, or retried.
-    HPX_TEST(!fallback_result);
 }
 
 // 5. Wrap-around when locality_id == 0 is handled by the caller before

--- a/libs/full/runtime_distributed/tests/unit/dijkstra_termination_forwarding.cpp
+++ b/libs/full/runtime_distributed/tests/unit/dijkstra_termination_forwarding.cpp
@@ -288,14 +288,19 @@ void test_undeliverable_probes_are_bounded()
 //    through it, and that send is local and always succeeds. A broken ring
 //    therefore still reports a successful handoff, so the bound has to count
 //    probes that reached no other locality rather than probes that failed to
-//    send. These cases pin that contract down.
+//    send. The bound then only has to fire for a busy initiator, since a
+//    passive one settles termination on the first probe: if nothing else is
+//    reachable, nothing else can still be running. These cases pin that down.
 void test_bound_reached_only_when_nothing_is_reachable()
 {
     constexpr std::uint32_t initiating_locality_id = 0;
     constexpr std::uint32_t num_localities = 4;
     constexpr std::size_t max_probes = 3;
 
-    auto const run_probes = [&](mock_send& send) {
+    // Whether the token comes back black is decided by the local thread
+    // manager inside send_dijkstra_termination_token, not by the ring walk, so
+    // it is an input here rather than something inferred from reachability.
+    auto const run_probes = [&](mock_send& send, bool const initiator_busy) {
         std::size_t undeliverable = 0;
         std::size_t probes = 0;
         bool initiator_black = false;
@@ -331,10 +336,7 @@ void test_bound_reached_only_when_nothing_is_reachable()
                 ++undeliverable;
             }
 
-            // A probe that reached another locality comes back white; one that
-            // only ever reached the initiator leaves it black, which is the
-            // case the bound exists for.
-            initiator_black = !reached_other_locality;
+            initiator_black = initiator_busy;
             ++probes;
         } while (dijkstra_should_reprobe(
             initiator_black, undeliverable, max_probes));
@@ -344,7 +346,7 @@ void test_bound_reached_only_when_nothing_is_reachable()
 
     {
         mock_send send({});    // nothing reachable at all
-        HPX_TEST_EQ(run_probes(send), max_probes);
+        HPX_TEST_EQ(run_probes(send, true), max_probes);
         HPX_TEST(send.succeeded_calls_.empty());
         HPX_TEST(!send.calls_.empty());
     }
@@ -353,9 +355,10 @@ void test_bound_reached_only_when_nothing_is_reachable()
         // The case that actually happens: the ring is broken, but the walk's
         // last hop and the fallback both target the initiator, whose own send
         // is local and cannot fail. Every probe reports a successful handoff
-        // and must still count as undeliverable, or the loop never terminates.
+        // and must still count as undeliverable, or a busy initiator reprobes
+        // forever.
         mock_send send({initiating_locality_id});
-        HPX_TEST_EQ(run_probes(send), max_probes);
+        HPX_TEST_EQ(run_probes(send, true), max_probes);
         HPX_TEST(!send.succeeded_calls_.empty());
         for (std::uint32_t const call : send.succeeded_calls_)
         {
@@ -364,8 +367,17 @@ void test_bound_reached_only_when_nothing_is_reachable()
     }
 
     {
+        // Same broken ring, but this locality has gone passive. Nothing else
+        // is reachable, so nothing else can still be running, and the white
+        // token settles termination on the first probe. The bound is not
+        // needed here and must not delay shutdown.
+        mock_send send({initiating_locality_id});
+        HPX_TEST_EQ(run_probes(send, false), static_cast<std::size_t>(1));
+    }
+
+    {
         mock_send send({num_localities - 1});    // intact ring
-        HPX_TEST_EQ(run_probes(send), static_cast<std::size_t>(1));
+        HPX_TEST_EQ(run_probes(send, false), static_cast<std::size_t>(1));
         std::vector<std::uint32_t> const expected = {num_localities - 1};
         HPX_TEST(send.succeeded_calls_ == expected);
     }

--- a/libs/full/runtime_distributed/tests/unit/dijkstra_termination_forwarding.cpp
+++ b/libs/full/runtime_distributed/tests/unit/dijkstra_termination_forwarding.cpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 using hpx::components::server::detail::dijkstra_forward_token;
+using hpx::components::server::detail::dijkstra_should_reprobe;
 
 namespace {
 
@@ -244,6 +245,89 @@ void test_repeated_probe_restarts_cursor()
     }
 }
 
+// 8. Regression for the unbounded retry when the token cannot be handed to any
+//    locality (dijkstra_termination_detection). An undeliverable probe marks
+//    the initiator black again, so before this bound the retry loop reprobed
+//    forever and shutdown burned the whole job wall clock instead of failing
+//    with a diagnostic. dijkstra_should_reprobe is the loop's real exit
+//    condition, so these cases pin it directly.
+void test_undeliverable_probes_are_bounded()
+{
+    constexpr std::size_t max_probes = 3;
+
+    // A white initiator terminates regardless of the count.
+    HPX_TEST(!dijkstra_should_reprobe(false, 0, max_probes));
+    HPX_TEST(!dijkstra_should_reprobe(false, max_probes, max_probes));
+
+    // A black initiator keeps probing while probes are still being delivered.
+    HPX_TEST(dijkstra_should_reprobe(true, 0, max_probes));
+    HPX_TEST(dijkstra_should_reprobe(true, max_probes - 1, max_probes));
+
+    // Once the bound is reached the loop stops even though the initiator is
+    // still black. This is the case that used to spin forever.
+    HPX_TEST(!dijkstra_should_reprobe(true, max_probes, max_probes));
+
+    // Rule 3 repetition stays unbounded: an undeliverable count that never
+    // grows keeps reprobing however many probes have run.
+    for (std::size_t probe = 0; probe != 100; ++probe)
+    {
+        HPX_TEST(dijkstra_should_reprobe(true, 0, max_probes));
+    }
+}
+
+// 9. The loop drives that predicate off a real ring walk: with nothing
+//    reachable every probe is undeliverable and the loop stops at the bound,
+//    while an intact ring delivers on the first probe and never approaches it.
+void test_bound_reached_only_when_nothing_is_reachable()
+{
+    constexpr std::uint32_t initiating_locality_id = 0;
+    constexpr std::uint32_t num_localities = 4;
+    constexpr std::size_t max_probes = 3;
+
+    auto const run_probes = [&](mock_send& send) {
+        std::size_t undeliverable = 0;
+        std::size_t probes = 0;
+        bool initiator_black = false;
+        do
+        {
+            // The initiator's predecessor, recomputed per probe as the retry
+            // loop does.
+            std::uint32_t target = initiating_locality_id;
+            if (0 == target)
+                target = num_localities;
+
+            if (dijkstra_forward_token(target, initiating_locality_id, send))
+            {
+                undeliverable = 0;
+                initiator_black = false;
+            }
+            else
+            {
+                ++undeliverable;
+                initiator_black = true;
+            }
+            ++probes;
+        } while (dijkstra_should_reprobe(
+            initiator_black, undeliverable, max_probes));
+
+        return probes;
+    };
+
+    {
+        mock_send send({});    // nothing reachable
+        HPX_TEST_EQ(run_probes(send), max_probes);
+        HPX_TEST(send.succeeded_calls_.empty());
+        HPX_TEST(!send.calls_.empty());
+    }
+
+    {
+        mock_send send({num_localities - 1});    // intact ring
+        HPX_TEST_EQ(run_probes(send), static_cast<std::size_t>(1));
+        std::vector<std::uint32_t> const expected = {num_localities - 1};
+        HPX_TEST(send.succeeded_calls_ == expected);
+    }
+}
+
 int main()
 {
     test_immediate_neighbor_alive();
@@ -253,6 +337,8 @@ int main()
     test_wrap_around_before_forwarding();
     test_no_forwarding_when_already_at_initiator();
     test_repeated_probe_restarts_cursor();
+    test_undeliverable_probes_are_bounded();
+    test_bound_reached_only_when_nothing_is_reachable();
 
     return hpx::util::report_errors();
 }


### PR DESCRIPTION
`dijkstra_termination_detection` reprobes forever when the token reaches no locality. A probe that cannot be handed off sets the initiator black again, and the loop's only exit is `while (dijkstra_color_)`, so an unreachable locality keeps shutdown probing until the job hits its wall clock. That is what burns the 6h limit on the AMD CI jobs, where 122 tests each sit until their 300s ctest timeout.

Rule 3 repetition after a black token stays unbounded. Only undeliverable probes are bounded, at 3, matching `max_fallback_attempts` in `dijkstra_termination` below it, and giving up now logs instead of hanging.

Introduced by d5af2db319 (#7471). Fixes #7503.
