### PR TITLE
config: skip the decltype form of HPX_FORWARD under nvcc

### DIFF
--- a/libs/core/config/include/hpx/config/forward.hpp
+++ b/libs/core/config/include/hpx/config/forward.hpp
@@ -8,14 +8,14 @@
 
 #include <hpx/config/defines.hpp>
 
-#if defined(HPX_HAVE_BUILTIN_FORWARD_MOVE)
+// nvcc's cudafe strips the && from static_cast<decltype(x)&&>, so route CUDA
+// through std::forward, which avoids that pattern.
+#if defined(HPX_HAVE_BUILTIN_FORWARD_MOVE) || defined(__CUDACC__)
 #include <utility>
 
 #define HPX_FORWARD(T, ...) std::forward<T>(__VA_ARGS__)
 
-// nvcc's cudafe rewrites static_cast<decltype(x)&&> and drops the &&, so this
-// form silently produces an lvalue under CUDA compilation. Skip it under nvcc.
-#elif defined(HPX_HAVE_CXX_LAMBDA_CAPTURE_DECLTYPE) && !defined(__CUDACC__)
+#elif defined(HPX_HAVE_CXX_LAMBDA_CAPTURE_DECLTYPE)
 
 #define HPX_FORWARD(T, ...) static_cast<decltype(__VA_ARGS__)&&>(__VA_ARGS__)
 

--- a/libs/core/config/include/hpx/config/forward.hpp
+++ b/libs/core/config/include/hpx/config/forward.hpp
@@ -13,7 +13,9 @@
 
 #define HPX_FORWARD(T, ...) std::forward<T>(__VA_ARGS__)
 
-#elif defined(HPX_HAVE_CXX_LAMBDA_CAPTURE_DECLTYPE)
+// nvcc's cudafe rewrites static_cast<decltype(x)&&> and drops the &&, so this
+// form silently produces an lvalue under CUDA compilation. Skip it under nvcc.
+#elif defined(HPX_HAVE_CXX_LAMBDA_CAPTURE_DECLTYPE) && !defined(__CUDACC__)
 
 #define HPX_FORWARD(T, ...) static_cast<decltype(__VA_ARGS__)&&>(__VA_ARGS__)
 


### PR DESCRIPTION
Fixes #7517

## Proposed Changes

  - Add `!defined(__CUDACC__)` to the `HPX_HAVE_CXX_LAMBDA_CAPTURE_DECLTYPE` branch in `forward.hpp` so CUDA builds fall through to `static_cast<T&&>`.

## Any background context you want to provide?

After the change, a `.cu` including `<hpx/collectives.hpp>` compiles clean, and the copy counter goes from 1 move 1 copy to 2 moves 0 copies. Non-CUDA builds pick the same branch as before.

`HPX_MOVE` isn't affected — its `&&` is on `remove_reference_t<...>`, not on a `decltype`, so cudafe leaves it alone.

## Checklist

Not all points below apply to all pull requests.
- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
