### PR TITLE
openshmem parcelport

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1399,6 +1399,25 @@ if(HPX_WITH_NETWORKING)
   endif()
 
   hpx_option(
+    HPX_WITH_PARCELPORT_OPENSHMEM BOOL "Enable the OpenSHMEM based parcelport." OFF
+    CATEGORY "Parcelport"
+  )
+  if(HPX_WITH_PARCELPORT_OPENSHMEM)
+    hpx_add_config_define(HPX_HAVE_PARCELPORT_OPENSHMEM)
+    hpx_option(
+      HPX_WITH_PARCELPORT_OPENSHMEM_MTU INT
+      "Set the MTU for the OpenSHMEM parcelport (default: 65536)."
+      65536
+      CATEGORY "Parcelport"
+    )
+    if(HPX_WITH_PARCELPORT_OPENSHMEM_MTU)
+      hpx_add_config_define(
+        HPX_HAVE_PARCELPORT_OPENSHMEM_MTU ${HPX_WITH_PARCELPORT_OPENSHMEM_MTU}
+      )
+    endif()
+  endif()
+
+  hpx_option(
     HPX_WITH_PARCELPORT_TCP BOOL "Enable the TCP based parcelport." ON
     CATEGORY "Parcelport"
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1399,15 +1399,14 @@ if(HPX_WITH_NETWORKING)
   endif()
 
   hpx_option(
-    HPX_WITH_PARCELPORT_OPENSHMEM BOOL "Enable the OpenSHMEM based parcelport." OFF
-    CATEGORY "Parcelport"
+    HPX_WITH_PARCELPORT_OPENSHMEM BOOL "Enable the OpenSHMEM based parcelport."
+    OFF CATEGORY "Parcelport"
   )
   if(HPX_WITH_PARCELPORT_OPENSHMEM)
     hpx_add_config_define(HPX_HAVE_PARCELPORT_OPENSHMEM)
     hpx_option(
       HPX_WITH_PARCELPORT_OPENSHMEM_MTU INT
-      "Set the MTU for the OpenSHMEM parcelport (default: 65536)."
-      65536
+      "Set the MTU for the OpenSHMEM parcelport (default: 65536)." 65536
       CATEGORY "Parcelport"
     )
     if(HPX_WITH_PARCELPORT_OPENSHMEM_MTU)

--- a/cmake/FindOpenSHMEM.cmake
+++ b/cmake/FindOpenSHMEM.cmake
@@ -1,0 +1,52 @@
+# Copyright (c) 2025 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+macro(find_openshmem)
+  # Only Open MPI's OpenSHMEM is supported. The package is located through
+  # pkg-config (pkg_check_modules uses PKG_CONFIG_PATH and the standard
+  # install locations), i.e. via the oshmem-c.pc, oshmem.pc or oshmem-cxx.pc
+  # module files. oshmem-c/oshmem are preferred because they carry the
+  # -loshmem link flag.
+  find_package(PkgConfig QUIET)
+  if(NOT PKG_CONFIG_FOUND)
+    hpx_error("pkg-config was not found; OpenSHMEM detection requires it")
+  endif()
+
+  set(_oshmem_pkg_names oshmem-c oshmem oshmem-cxx)
+  foreach(_pkg ${_oshmem_pkg_names})
+    pkg_check_modules(OSHMEM QUIET IMPORTED_TARGET GLOBAL ${_pkg})
+    if(OSHMEM_FOUND)
+      set(OpenSHMEM_PKG ${_pkg})
+      break()
+    endif()
+  endforeach()
+
+  set(OpenSHMEM_FOUND ${OSHMEM_FOUND})
+
+  if(NOT OpenSHMEM_FOUND)
+    hpx_error(
+      "Could not find Open MPI OpenSHMEM. Tried: ${_oshmem_pkg_names}. "
+      "Please set PKG_CONFIG_PATH to the directory containing the oshmem.pc "
+      "module files."
+    )
+  endif()
+
+  if(NOT OSHMEM_INCLUDE_DIRS OR NOT (OSHMEM_LIBRARY_DIRS OR OSHMEM_LIBRARIES))
+    hpx_error(
+      "Could not find OSHMEM_INCLUDE_DIRS or OSHMEM_LIBRARIES/OSHMEM_LIBRARY_DIRS"
+    )
+  endif()
+
+  if(NOT TARGET OpenSHMEM::openshmem)
+    add_library(OpenSHMEM::openshmem INTERFACE IMPORTED)
+    set_target_properties(OpenSHMEM::openshmem PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${OSHMEM_INCLUDE_DIRS}"
+      INTERFACE_LINK_LIBRARIES "${OSHMEM_LIBRARIES}"
+    )
+  endif()
+
+  message(STATUS "Found OpenSHMEM (${OpenSHMEM_PKG}): ${OSHMEM_INCLUDE_DIRS}")
+endmacro()

--- a/cmake/FindOpenSHMEM.cmake
+++ b/cmake/FindOpenSHMEM.cmake
@@ -6,10 +6,10 @@
 
 macro(find_openshmem)
   # Only Open MPI's OpenSHMEM is supported. The package is located through
-  # pkg-config (pkg_check_modules uses PKG_CONFIG_PATH and the standard
-  # install locations), i.e. via the oshmem-c.pc, oshmem.pc or oshmem-cxx.pc
-  # module files. oshmem-c/oshmem are preferred because they carry the
-  # -loshmem link flag.
+  # pkg-config (pkg_check_modules uses PKG_CONFIG_PATH and the standard install
+  # locations), i.e. via the oshmem-c.pc, oshmem.pc or oshmem-cxx.pc module
+  # files. oshmem-c/oshmem are preferred because they carry the -loshmem link
+  # flag.
   find_package(PkgConfig QUIET)
   if(NOT PKG_CONFIG_FOUND)
     hpx_error("pkg-config was not found; OpenSHMEM detection requires it")
@@ -42,9 +42,10 @@ macro(find_openshmem)
 
   if(NOT TARGET OpenSHMEM::openshmem)
     add_library(OpenSHMEM::openshmem INTERFACE IMPORTED)
-    set_target_properties(OpenSHMEM::openshmem PROPERTIES
-      INTERFACE_INCLUDE_DIRECTORIES "${OSHMEM_INCLUDE_DIRS}"
-      INTERFACE_LINK_LIBRARIES "${OSHMEM_LIBRARIES}"
+    set_target_properties(
+      OpenSHMEM::openshmem
+      PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${OSHMEM_INCLUDE_DIRS}"
+                 INTERFACE_LINK_LIBRARIES "${OSHMEM_LIBRARIES}"
     )
   endif()
 

--- a/cmake/HPX_SetupOpenSHMEM.cmake
+++ b/cmake/HPX_SetupOpenSHMEM.cmake
@@ -1,0 +1,32 @@
+# Copyright (c) 2025 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+include(HPX_Message)
+include(${CMAKE_CURRENT_LIST_DIR}/FindOpenSHMEM.cmake)
+
+macro(hpx_setup_openshmem)
+  if(NOT TARGET OpenSHMEM::openshmem)
+    find_openshmem()
+
+    if(NOT OpenSHMEM_FOUND)
+      hpx_error("OpenSHMEM was not found")
+    endif()
+
+    hpx_add_config_define(HPX_HAVE_PARCELPORT_OPENSHMEM)
+
+    set(HPX_OPENSHMEM_LIBRARIES
+        "${OSHMEM_LIBRARIES}"
+        CACHE INTERNAL "OpenSHMEM libraries" FORCE
+    )
+    set(HPX_OPENSHMEM_INCLUDE_DIRS
+        "${OSHMEM_INCLUDE_DIRS}"
+        CACHE INTERNAL "OpenSHMEM include directories" FORCE
+    )
+
+    hpx_info("OpenSHMEM libraries: ${OSHMEM_LIBRARIES}")
+    hpx_info("OpenSHMEM include dirs: ${OSHMEM_INCLUDE_DIRS}")
+  endif()
+endmacro()

--- a/libs/core/CMakeLists.txt
+++ b/libs/core/CMakeLists.txt
@@ -61,6 +61,7 @@ set(_hpx_core_modules
     logging
     memory
     mpi_base
+    openshmem_base
     pack_traversal
     plugin
     prefix

--- a/libs/core/config/include/hpx/config.hpp
+++ b/libs/core/config/include/hpx/config.hpp
@@ -111,6 +111,14 @@
 #  define HPX_HAVE_PARCELPORT_MPI_BACKGROUND_THREADS std::size_t(-1)
 #endif
 
+#if !defined(HPX_PARCEL_OPENSHMEM_MTU)
+#  define HPX_PARCEL_OPENSHMEM_MTU 65536
+#endif
+
+#if !defined(HPX_PARCEL_GASNET_MTU)
+#  define HPX_PARCEL_GASNET_MTU 65536
+#endif
+
 ///////////////////////////////////////////////////////////////////////////////
 /// This defines the number of outgoing (parcel-) connections kept alive (to
 /// each of the other localities). This value can be changed at runtime by

--- a/libs/core/openshmem_base/CMakeLists.txt
+++ b/libs/core/openshmem_base/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 The STE||AR-Group
+# Copyright (c) 2026 Christopher Taylor
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/openshmem_base/CMakeLists.txt
+++ b/libs/core/openshmem_base/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Copyright (c) 2025 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+if(HPX_WITH_NETWORKING AND HPX_WITH_PARCELPORT_OPENSHMEM)
+  include(HPX_SetupOpenSHMEM)
+  hpx_setup_openshmem()
+  set(additional_dependencies OpenSHMEM::openshmem)
+else()
+  return()
+endif()
+
+set(openshmem_base_headers hpx/openshmem_base/openshmem_environment.hpp)
+
+set(openshmem_base_sources openshmem_environment.cpp)
+
+include(HPX_AddModule)
+add_hpx_module(
+  core openshmem_base
+  GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
+  SOURCES ${openshmem_base_sources}
+  HEADERS ${openshmem_base_headers}
+  MODULE_DEPENDENCIES
+    hpx_concepts
+    hpx_errors
+    hpx_format
+    hpx_logging
+    hpx_runtime_configuration
+    hpx_string_util
+    hpx_synchronization
+    hpx_util
+  DEPENDENCIES ${additional_dependencies}
+)

--- a/libs/core/openshmem_base/include/hpx/openshmem_base/openshmem_environment.hpp
+++ b/libs/core/openshmem_base/include/hpx/openshmem_base/openshmem_environment.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2025 The STE||AR-Group
+//  Copyright (c) 2026 Christopher Taylor
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/openshmem_base/include/hpx/openshmem_base/openshmem_environment.hpp
+++ b/libs/core/openshmem_base/include/hpx/openshmem_base/openshmem_environment.hpp
@@ -1,0 +1,57 @@
+//  Copyright (c) 2025 The STE||AR-Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_OPENSHMEM)
+
+#include <hpx/modules/runtime_configuration.hpp>
+#include <hpx/modules/synchronization.hpp>
+
+#include <cstdlib>
+#include <string>
+
+#include <shmem.h>
+
+#include <hpx/config/warnings_prefix.hpp>
+
+namespace hpx::util {
+
+    HPX_CXX_CORE_EXPORT struct HPX_CORE_EXPORT openshmem_environment
+    {
+        static bool check_openshmem_environment(
+            runtime_configuration const& cfg);
+
+        static void init(int* argc, char*** argv, runtime_configuration& cfg);
+
+        static void finalize() noexcept;
+
+        static bool enabled() noexcept;
+
+        static bool has_called_init() noexcept;
+
+        static int rank() noexcept;
+
+        static int size() noexcept;
+
+        static std::string get_processor_name();
+
+        using mutex_type = hpx::spinlock;
+        using scoped_lock = std::unique_lock<mutex_type>;
+
+    private:
+        static mutex_type mtx_;
+
+        static bool enabled_;
+        static bool has_called_init_;
+    };
+}    // namespace hpx::util
+
+#include <hpx/config/warnings_suffix.hpp>
+
+#endif

--- a/libs/core/openshmem_base/src/openshmem_environment.cpp
+++ b/libs/core/openshmem_base/src/openshmem_environment.cpp
@@ -1,0 +1,119 @@
+//  Copyright (c) 2025 The STE||AR-Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_OPENSHMEM)
+#include <hpx/modules/runtime_configuration.hpp>
+#include <hpx/modules/util.hpp>
+#include <hpx/openshmem_base/openshmem_environment.hpp>
+
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace hpx::util {
+
+    openshmem_environment::mutex_type openshmem_environment::mtx_{};
+
+    bool openshmem_environment::enabled_ = false;
+    bool openshmem_environment::has_called_init_ = false;
+
+    bool openshmem_environment::check_openshmem_environment(
+        runtime_configuration const& cfg)
+    {
+        return hpx::util::get_entry_as<bool>(
+            cfg, "hpx.parcel.openshmem.enable", false);
+    }
+
+    void openshmem_environment::init(
+        int*, char***, runtime_configuration& cfg)
+    {
+        if (enabled_)
+            return;
+
+        has_called_init_ = false;
+
+        enabled_ = check_openshmem_environment(cfg);
+        if (!enabled_)
+        {
+            cfg.add_entry("hpx.parcel.openshmem.enable", "0");
+            return;
+        }
+
+        int provided = 0;
+        int ret = shmem_init_thread(SHMEM_THREAD_MULTIPLE, &provided);
+        if (ret != 0)
+        {
+            enabled_ = false;
+            throw std::runtime_error("Failed to initialize OpenSHMEM");
+        }
+
+        if (provided != SHMEM_THREAD_MULTIPLE)
+        {
+            std::cerr << "Warning: OpenSHMEM did not provide "
+                         "SHMEM_THREAD_MULTIPLE. "
+                      << "Provided level: " << provided << std::endl;
+        }
+
+        has_called_init_ = true;
+
+        cfg.set_num_localities(static_cast<std::uint32_t>(shmem_n_pes()));
+
+        int const this_rank = rank();
+        if (this_rank == 0)
+        {
+            cfg.mode_ = hpx::runtime_mode::console;
+        }
+        else
+        {
+            cfg.mode_ = hpx::runtime_mode::worker;
+        }
+
+        cfg.add_entry(
+            "hpx.parcel.openshmem.rank", std::to_string(this_rank));
+        cfg.add_entry(
+            "hpx.parcel.openshmem.processorname", get_processor_name());
+    }
+
+    void openshmem_environment::finalize() noexcept
+    {
+        scoped_lock l(mtx_);
+        if (enabled_ && has_called_init_)
+        {
+            has_called_init_ = false;
+            shmem_finalize();
+        }
+    }
+
+    bool openshmem_environment::enabled() noexcept
+    {
+        return enabled_;
+    }
+
+    bool openshmem_environment::has_called_init() noexcept
+    {
+        return has_called_init_;
+    }
+
+    int openshmem_environment::rank() noexcept
+    {
+        return shmem_my_pe();
+    }
+
+    int openshmem_environment::size() noexcept
+    {
+        return shmem_n_pes();
+    }
+
+    std::string openshmem_environment::get_processor_name()
+    {
+        return std::to_string(shmem_my_pe());
+    }
+}    // namespace hpx::util
+
+#endif

--- a/libs/core/openshmem_base/src/openshmem_environment.cpp
+++ b/libs/core/openshmem_base/src/openshmem_environment.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2025 The STE||AR-Group
+//  Copyright (c) 2026 Christopher Taylor
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/openshmem_base/src/openshmem_environment.cpp
+++ b/libs/core/openshmem_base/src/openshmem_environment.cpp
@@ -30,8 +30,7 @@ namespace hpx::util {
             cfg, "hpx.parcel.openshmem.enable", false);
     }
 
-    void openshmem_environment::init(
-        int*, char***, runtime_configuration& cfg)
+    void openshmem_environment::init(int*, char***, runtime_configuration& cfg)
     {
         if (enabled_)
             return;
@@ -74,8 +73,7 @@ namespace hpx::util {
             cfg.mode_ = hpx::runtime_mode::worker;
         }
 
-        cfg.add_entry(
-            "hpx.parcel.openshmem.rank", std::to_string(this_rank));
+        cfg.add_entry("hpx.parcel.openshmem.rank", std::to_string(this_rank));
         cfg.add_entry(
             "hpx.parcel.openshmem.processorname", get_processor_name());
     }

--- a/libs/core/openshmem_base/src/openshmem_environment.cpp
+++ b/libs/core/openshmem_base/src/openshmem_environment.cpp
@@ -30,7 +30,8 @@ namespace hpx::util {
             cfg, "hpx.parcel.openshmem.enable", false);
     }
 
-    void openshmem_environment::init(int*, char***, runtime_configuration& cfg)
+    void openshmem_environment::init(
+        int*, char***, runtime_configuration& cfg)
     {
         if (enabled_)
             return;

--- a/libs/full/CMakeLists.txt
+++ b/libs/full/CMakeLists.txt
@@ -35,6 +35,7 @@ set(_hpx_full_modules
     parcelport_lci
     parcelport_lcw
     parcelport_mpi
+    parcelport_openshmem
     parcelport_tcp
     parcelports
     parcelset

--- a/libs/full/command_line_handling/CMakeLists.txt
+++ b/libs/full/command_line_handling/CMakeLists.txt
@@ -51,7 +51,8 @@ if(HPX_WITH_NETWORKING AND HPX_WITH_PARCELPORT_OPENSHMEM)
   include(HPX_SetupOpenSHMEM)
   hpx_setup_openshmem()
   set(additional_dependencies ${additional_dependencies} OpenSHMEM::openshmem
-                             hpx_openshmem_base)
+                              hpx_openshmem_base
+  )
 endif()
 
 include(HPX_AddModule)

--- a/libs/full/command_line_handling/CMakeLists.txt
+++ b/libs/full/command_line_handling/CMakeLists.txt
@@ -47,6 +47,12 @@ if(HPX_WITH_PARCELPORT_GASNET)
   endif()
   set(additional_dependencies ${additional_dependencies} PkgConfig::GASNET)
 endif()
+if(HPX_WITH_NETWORKING AND HPX_WITH_PARCELPORT_OPENSHMEM)
+  include(HPX_SetupOpenSHMEM)
+  hpx_setup_openshmem()
+  set(additional_dependencies ${additional_dependencies} OpenSHMEM::openshmem
+                             hpx_openshmem_base)
+endif()
 
 include(HPX_AddModule)
 add_hpx_module(

--- a/libs/full/command_line_handling/src/command_line_handling.cpp
+++ b/libs/full/command_line_handling/src/command_line_handling.cpp
@@ -24,6 +24,9 @@
 #if defined(HPX_HAVE_MODULE_GASNET_BASE)
 #include <hpx/modules/gasnet_base.hpp>
 #endif
+#if defined(HPX_HAVE_MODULE_OPENSHMEM_BASE)
+#include <hpx/modules/openshmem_base.hpp>
+#endif
 #include <hpx/modules/program_options.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/topology.hpp>
@@ -993,6 +996,16 @@ namespace hpx::util {
             reconfigure(cfgmap, prevm);
         }
 
+#if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_OPENSHMEM)
+        // getting localities from OpenSHMEM environment (support oshrun)
+        if (util::openshmem_environment::check_openshmem_environment(rtcfg_))
+        {
+            util::openshmem_environment::init(&argc, &argv, rtcfg_);
+            num_localities_ =
+                static_cast<std::size_t>(util::openshmem_environment::size());
+            node_ = static_cast<std::size_t>(util::openshmem_environment::rank());
+        }
+#endif
 #if (defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_MPI)) ||      \
     defined(HPX_HAVE_MODULE_MPI_BASE)
         // getting localities from MPI environment (support mpirun)

--- a/libs/full/parcelport_gasnet/src/parcelport_gasnet.cpp
+++ b/libs/full/parcelport_gasnet/src/parcelport_gasnet.cpp
@@ -1,7 +1,6 @@
-//  Copyright (c) 2023      Christopher Taylor
+//  Copyright (c) 2026 Tactical Computing Labs, LLC (Christopher Taylor)
+//  Copyright (c) 2023 Christopher Taylor
 //  Copyright (c) 2007-2026 Hartmut Kaiser
-//  Copyright (c) 2014-2015 Thomas Heller
-//  Copyright (c)      2020 Google
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -22,25 +21,24 @@
 #include <hpx/modules/synchronization.hpp>
 #include <hpx/modules/util.hpp>
 
-#include <hpx/modules/parcelset.hpp>
-#include <hpx/modules/parcelset_base.hpp>
-#include <hpx/modules/plugin_factories.hpp>
 #include <hpx/parcelport_gasnet/locality.hpp>
+#include <hpx/parcelport_gasnet/mailbox.hpp>
+#include <hpx/parcelport_gasnet/parcelport_gasnet.hpp>
 #include <hpx/parcelport_gasnet/receiver.hpp>
 #include <hpx/parcelport_gasnet/sender.hpp>
+#include <hpx/parcelport_gasnet/sender_connection.hpp>
+#include <hpx/parcelset/parcelport_impl.hpp>
+#include <hpx/plugin_factories/parcelport_factory.hpp>
 
 #include <asio/io_context.hpp>
-#include <asio/version.hpp>
-#if ASIO_VERSION >= 103400
 #include <asio/post.hpp>
-#endif
+#include <asio/version.hpp>
 
 #include <atomic>
 #include <cstddef>
-#include <exception>
+#include <cstdint>
 #include <memory>
 #include <string>
-#include <system_error>
 #include <type_traits>
 
 #include <hpx/config/warnings_prefix.hpp>
@@ -57,8 +55,8 @@ namespace hpx::parcelset {
         using connection_type = policies::gasnet::sender_connection;
         using send_early_parcel = std::true_type;
         using do_background_work = std::true_type;
-        using send_immediate_parcels = std::false_type;
-        using is_connectionless = std::false_type;
+        using send_immediate_parcels = std::true_type;
+        using is_connectionless = std::true_type;
 
         static constexpr char const* type() noexcept
         {
@@ -78,56 +76,54 @@ namespace hpx::parcelset {
 
     namespace policies::gasnet {
 
-        int acquire_tag(sender* s) noexcept
+        // Credit/wakeup AM handler (SHORT, 2-arg request). Runs inside the
+        // transport's poll/dispatch on the single progress thread and writes
+        // the LOCAL copy of the produced/consumed counter that our progress
+        // loop reads -- the GASNet-EX equivalent of the OpenSHMEM remote
+        // atomic_set. Dispatches through the file-scope static mailbox pointer
+        // set once during initialization.
+        void credit_am_handler(
+            gex_Token_t /*token*/, gex_AM_Arg_t a0, gex_AM_Arg_t a1) noexcept
         {
-            return s->acquire_tag();
-        }
-
-        void add_connection(
-            sender* s, std::shared_ptr<sender_connection> const& ptr)
-        {
-            s->add(ptr);
+            mailbox* m = get_gasnet_mailbox_ptr();
+            if (m != nullptr)
+            {
+                m->handle_credit(
+                    static_cast<std::uint32_t>(a0),
+                    static_cast<std::uint32_t>(a1));
+            }
         }
 
         class HPX_EXPORT parcelport : public parcelport_impl<parcelport>
         {
             using base_type = parcelport_impl<parcelport>;
 
-            static parcelset::locality here()
+            static parcelset::locality here(std::size_t my_pe)
             {
                 return parcelset::locality(
-                    locality(util::gasnet_environment::enabled() ?
-                            util::gasnet_environment::rank() :
-                            -1));
+                    locality(static_cast<std::int32_t>(my_pe)));
             }
 
-            static std::size_t max_connections(
-                util::runtime_configuration const& ini)
+            static std::size_t mtu(util::runtime_configuration const& ini)
             {
-                return hpx::util::get_entry_as<std::size_t>(ini,
-                    "hpx.parcel.gasnet.max_connections",
-                    HPX_PARCEL_MAX_CONNECTIONS);
-            }
-
-            static std::size_t background_threads(
-                [[maybe_unused]] util::runtime_configuration const& ini)
-            {
-                /*
-                return hpx::util::get_entry_as<std::size_t>(ini,
-                    "hpx.parcel.gasnet.background_threads",
-                    HPX_HAVE_PARCELPORT_GASNET_BACKGROUND_THREADS);
-                */
-                return 1UL;
+                return hpx::util::get_entry_as<std::size_t>(
+                    ini, "hpx.parcel.gasnet.mtu", HPX_PARCEL_GASNET_MTU);
             }
 
         public:
+            using sender_type = sender;
             parcelport(util::runtime_configuration const& ini,
                 threads::policies::callback_notifier const& notifier)
-              : base_type(ini, here(), notifier)
+              : base_type(ini, here(0), notifier)
               , stopped_(false)
+              , num_pes_(gasnet_environment::size())
+              , my_pe_(gasnet_environment::rank())
+              , mtu_(mtu(ini))
+              , mailboxes_(num_pes_, my_pe_, mtu_)
+              , sender_(&mailboxes_)
               , receiver_(*this)
-              , background_threads_(background_threads(ini))
             {
+                here_ = here(my_pe_);
             }
 
             parcelport(parcelport const&) = delete;
@@ -135,80 +131,131 @@ namespace hpx::parcelset {
             parcelport& operator=(parcelport const&) = delete;
             parcelport& operator=(parcelport&&) = delete;
 
-            ~parcelport()
-            {
-                util::gasnet_environment::finalize();
-            }
+            ~parcelport() override = default;
 
-            // Start the handling of connections.
             bool do_run()
             {
-                receiver_.run();
-                sender_.run();
+                gex_TM_t tm = gasnet_environment::get_team();
+                gex_EP_t ep = gasnet_environment::get_endpoint();
 
-                for (std::size_t i = 0; i != io_service_pool_.size(); ++i)
+                // Point the AM handler at our mailbox before any inbound
+                // credit message can be dispatched by a poll.
+                get_gasnet_mailbox_ptr() = &mailboxes_;
+
+                // (1) Register the credit/wakeup AM handler on our endpoint.
+                //     gex_AM_Entry_t.gex_index == 0 means "assign an index";
+                //     GEX returns the absolute client index (>= 128) which we
+                //     read back and use in all gex_AM_RequestShort2 calls.
+                gex_AM_Entry_t htable[1];
+                htable[0].gex_index = 0;
+                htable[0].gex_fnptr = (gex_AM_Fn_t) &credit_am_handler;
+                htable[0].gex_flags = GEX_FLAG_AM_REQUEST | GEX_FLAG_AM_SHORT;
+                htable[0].gex_nargs = 2;
+                htable[0].gex_cdata = nullptr;
+                htable[0].gex_name = "hpx_gasnet_credit";
+
+                int rc = gex_EP_RegisterHandlers(ep, htable, 1);
+                if (rc != GASNET_OK)
                 {
-#if ASIO_VERSION >= 103400
-                    ::asio::post(
-                        io_service_pool_.get_io_service(static_cast<int>(i)),
-                        hpx::bind(&parcelport::io_service_work, this));
-#else
-                    io_service_pool_.get_io_service(static_cast<int>(i))
-                        .post(hpx::bind(&parcelport::io_service_work, this));
-#endif
+                    HPX_THROW_EXCEPTION(error::network_error,
+                        "gasnet::parcelport::do_run",
+                        "gex_EP_RegisterHandlers failed: " +
+                            std::string(gasnet_ErrorName(rc)));
                 }
+                mailboxes_.set_credit_handler(htable[0].gex_index);
+
+                // (2) Collectively publish the bound segment so every peer
+                //     has RMA credentials for one-sided puts into it.
+                //     This call is collective over the team and therefore
+                //     also synchronizes the whole base-exchange handshake.
+                gex_EP_t eps[1] = {ep};
+                rc = gex_EP_PublishBoundSegment(tm, eps, 1, 0);
+                if (rc != GASNET_OK)
+                {
+                    HPX_THROW_EXCEPTION(error::network_error,
+                        "gasnet::parcelport::do_run",
+                        "gex_EP_PublishBoundSegment failed: " +
+                            std::string(gasnet_ErrorName(rc)));
+                }
+
+                // (3) Query each peer's segment base (its owner-address). The
+                //     GEX address model uses absolute remote addresses, so we
+                //     reconstruct base_of(peer) + offset for every RMA put.
+                gex_Rank_t const npes = gex_TM_QuerySize(tm);
+                for (gex_Rank_t r = 0; r != npes; ++r)
+                {
+                    void* owneraddr = nullptr;
+                    void* localaddr = nullptr;
+                    uintptr_t segsize = 0;
+
+                    gex_Event_t ev = gex_EP_QueryBoundSegmentNB(
+                        tm, r, &owneraddr, &localaddr, &segsize, 0);
+                    gex_Event_Wait(ev);
+
+                    if (owneraddr == nullptr || segsize == 0)
+                    {
+                        HPX_THROW_EXCEPTION(error::network_error,
+                            "gasnet::parcelport::do_run",
+                            "gex_EP_QueryBoundSegmentNB returned no segment "
+                            "for peer " +
+                                std::to_string(r));
+                    }
+                    mailboxes_.set_remote_base(static_cast<std::size_t>(r),
+                        reinterpret_cast<std::uintptr_t>(owneraddr));
+                }
+
+                sender_.run();
+                receiver_.run();
+
+                // All GASNet-EX calls must stay on a single thread (we drive
+                // the transport without internal locking), so only the first
+                // io_service of the pool runs the progress loop (io_pool_size
+                // is forced to 1 by the configuration below).
+#if ASIO_VERSION >= 103400
+                ::asio::post(
+                    io_service_pool_.get_io_service(0),
+                    hpx::bind(&parcelport::io_service_work, this));
+#else
+                io_service_pool_.get_io_service(0)
+                    .post(hpx::bind(&parcelport::io_service_work, this));
+#endif
                 return true;
             }
 
-            // Stop the handling of connections.
             void do_stop()
             {
-                while (do_background_work(0, parcelport_background_mode::all))
+                // Wait for the progress thread to drain all queued work. We
+                // must not drive send/receive from this thread as that would
+                // call into GASNet outside the single progress thread.
+                std::size_t max_iter = 1000;
+                while (sender_.has_pending() || receiver_.has_pending())
                 {
-                    if (threads::get_self_ptr())
-                        hpx::this_thread::suspend(
-                            hpx::threads::thread_schedule_state::pending,
-                            "gasnet::parcelport::do_stop");
+                    if (!threads::get_self_ptr() || max_iter-- == 0)
+                        break;
+                    hpx::this_thread::suspend(
+                        hpx::threads::thread_schedule_state::pending,
+                        "gasnet::parcelport::do_stop");
                 }
 
-                bool expected = false;
-                if (stopped_.compare_exchange_strong(expected, true))
-                {
-                    stopped_ = true;
-
-                    int retval;
-                    gasnet_barrier_notify(0, GASNET_BARRIERFLAG_ANONYMOUS);
-                    if ((retval = gasnet_barrier_wait(
-                             0, GASNET_BARRIERFLAG_ANONYMOUS)) != GASNET_OK)
-                    {
-                        // throw exception
-                        HPX_THROW_EXCEPTION(error::invalid_status,
-                            "hpx::util::gasnet_environment::init",
-                            "GASNET failed ",
-                            std::string{gasnet_ErrorName(retval)}, " ",
-                            std::string{gasnet_ErrorDesc(retval)});
-                    }
-                }
+                stopped_.store(true, std::memory_order_release);
             }
 
-            /// Return the name of this locality
             std::string get_locality_name() const override
             {
-                return util::gasnet_environment::get_processor_name();
+                return std::to_string(my_pe_);
             }
 
             std::shared_ptr<sender_connection> create_connection(
                 parcelset::locality const& l, error_code&)
             {
-                int dest_rank = l.get<locality>().rank();
-                return sender_.create_connection(dest_rank, this);
+                int const dest_rank = l.get<locality>().rank();
+                return sender_.create_connection(dest_rank, &mailboxes_);
             }
 
             parcelset::locality agas_locality(
                 util::runtime_configuration const&) const override
             {
-                return parcelset::locality(
-                    locality(util::gasnet_environment::enabled() ? 0 : -1));
+                return parcelset::locality(locality(0));
             }
 
             parcelset::locality create_locality() const override
@@ -216,120 +263,144 @@ namespace hpx::parcelset {
                 return parcelset::locality(locality());
             }
 
+            // All GASNet-EX calls happen on the single progress thread
+            // (io_service_work). HPX threads must not call into the GASNet
+            // transport, so this is a no-op.
             bool background_work(
-                std::size_t num_thread, parcelport_background_mode mode)
+                std::size_t, parcelport_background_mode)
             {
-                if (stopped_.load(std::memory_order_acquire) ||
-                    num_thread >= background_threads_)
-                {
-                    return false;
-                }
+                return false;
+            }
 
-                bool has_work = false;
-                if (mode & parcelport_background_mode::send)
-                {
-                    has_work = sender_.background_work();
-                }
-                if (mode & parcelport_background_mode::receive)
-                {
-                    has_work = receiver_.background_work() || has_work;
-                }
-                return has_work;
+            constexpr bool can_send_immediate() const noexcept
+            {
+                return true;
+            }
+
+            mailbox const& get_mailboxes() const noexcept
+            {
+                return mailboxes_;
+            }
+
+            mailbox& get_mailboxes() noexcept
+            {
+                return mailboxes_;
+            }
+
+            constexpr std::size_t num_pes() const noexcept
+            {
+                return num_pes_;
+            }
+
+            constexpr std::size_t my_pe() const noexcept
+            {
+                return my_pe_;
+            }
+
+            constexpr std::size_t mtu() const noexcept
+            {
+                return mtu_;
+            }
+
+            bool send_immediate(parcelset::parcelport* pp,
+                parcelset::locality const& dest,
+                sender::parcel_buffer_type buffer,
+                sender::callback_fn_type&& callbackFn)
+            {
+                (void) pp;
+                return sender_.send_immediate(
+                    dest, HPX_MOVE(buffer), HPX_MOVE(callbackFn));
             }
 
         private:
-            std::atomic<bool> stopped_;
-
-            sender sender_;
-            receiver<parcelport> receiver_;
-
             void io_service_work()
             {
                 std::size_t k = 0;
-                // We only execute work on the IO service while HPX is starting
-                while (hpx::is_starting())
+                std::size_t busy_loop = 0;
+                constexpr std::size_t max_busy_loop = 1000;
+
+                while (!stopped_.load(std::memory_order_acquire))
                 {
-                    bool has_work = sender_.background_work();
-                    has_work = receiver_.background_work() || has_work;
+                    // Check for incoming data first (dispatch inbound credit
+                    // AMs + non-blocking scan + fast receive_()) so that
+                    // incoming parcels are not starved by a blocking send on
+                    // the other side.
+                    bool has_work = receiver_.background_work();
+                    has_work = sender_.background_work() || has_work;
                     if (has_work)
                     {
                         k = 0;
+                        busy_loop = 0;
                     }
                     else
                     {
-                        ++k;
-                        util::detail::yield_k(k,
-                            "hpx::parcelset::policies::gasnet::parcelport::"
-                            "io_service_work");
+                        if (busy_loop < max_busy_loop)
+                        {
+                            ++busy_loop;
+                        }
+                        else
+                        {
+                            // Deliberate hot spin (no OS yield): mirrors the
+                            // validated openshmem harness, where the receiver
+                            // continuously pumps the transport so an inbound
+                            // credit AM / RMA store is reliably observed.
+                            ++k;
+                        }
                     }
                 }
             }
 
-            std::size_t background_threads_;
+            std::atomic<bool> stopped_;
 
-            void early_write_handler(std::error_code const& ec, parcel const& p)
-            {
-                if (ec)
-                {
-                    // all errors during early parcel handling are fatal
-                    std::exception_ptr exception = hpx::detail::get_exception(
-                        hpx::exception(ec), "gasnet::early_write_handler",
-                        __FILE__, __LINE__,
-                        "error while handling early parcel: " + ec.message() +
-                            "(" + std::to_string(ec.value()) + ")" +
-                            parcelset::dump_parcel(p));
+            std::size_t num_pes_;
+            std::size_t my_pe_;
+            std::size_t mtu_;
+            mailbox mailboxes_;
 
-                    hpx::report_error(exception);
-                }
-            }
+            sender sender_;
+            receiver<parcelport> receiver_;
         };
     }    // namespace policies::gasnet
 }    // namespace hpx::parcelset
 
-namespace hpx::traits {
+#include <hpx/config/warnings_suffix.hpp>
 
-    // Inject additional configuration data into the factory registry for this
-    // type. This information ends up in the system wide configuration database
-    // under the plugin specific section:
-    //
-    //      [hpx.parcel.gasnet]
-    //      ...
-    //      priority = 1
-    //
-    template <>
-    struct plugin_config_data<hpx::parcelset::policies::gasnet::parcelport>
+template <>
+struct hpx::traits::plugin_config_data<
+    hpx::parcelset::policies::gasnet::parcelport>
+{
+    static constexpr char const* priority() noexcept
     {
-        static constexpr char const* priority() noexcept
-        {
-            return "1";
-        }
+        return "100";
+    }
 
-        static void init(
-            int* argc, char*** argv, util::command_line_handling& cfg)
-        {
-            util::gasnet_environment::init(argc, argv, cfg.rtcfg_);
-            cfg.num_localities_ =
-                static_cast<std::size_t>(util::gasnet_environment::size());
-            cfg.node_ =
-                static_cast<std::size_t>(util::gasnet_environment::rank());
-        }
+    static void init(int* argc, char*** argv, util::command_line_handling& cfg)
+    {
+        util::gasnet_environment::init(argc, argv, cfg.rtcfg_);
+        cfg.num_localities_ =
+            static_cast<std::size_t>(util::gasnet_environment::size());
+        cfg.node_ =
+            static_cast<std::size_t>(util::gasnet_environment::rank());
+    }
 
-        // by default no additional initialization using the resource
-        // partitioner is required
-        static constexpr void init(hpx::resource::partitioner&) noexcept {}
+    static constexpr void init(hpx::resource::partitioner&) noexcept {}
 
-        static void destroy() noexcept
-        {
-            util::gasnet_environment::finalize();
-        }
+    static void destroy() noexcept
+    {
+        util::gasnet_environment::finalize();
+    }
 
-        static constexpr char const* call() noexcept
-        {
-            return "";
-        }
-    };
-}    // namespace hpx::traits
+    static constexpr char const* call() noexcept
+    {
+        return "mtu = "
+               "${HPX_HAVE_PARCELPORT_GASNET_MTU:65536}\n"
+               // All GASNet-EX calls must happen on a single thread, so the
+               // pool must not be larger than one.
+               "io_pool_size = 1\n";
+    }
+};
 
-HPX_REGISTER_PARCELPORT(hpx::parcelset::policies::gasnet::parcelport, gasnet)
+HPX_REGISTER_PARCELPORT(
+    hpx::parcelset::policies::gasnet::parcelport, gasnet)
 
 #endif

--- a/libs/full/parcelport_gasnet/src/parcelport_gasnet.cpp
+++ b/libs/full/parcelport_gasnet/src/parcelport_gasnet.cpp
@@ -1,6 +1,7 @@
-//  Copyright (c) 2026 Tactical Computing Labs, LLC (Christopher Taylor)
-//  Copyright (c) 2023 Christopher Taylor
+//  Copyright (c) 2023      Christopher Taylor
 //  Copyright (c) 2007-2026 Hartmut Kaiser
+//  Copyright (c) 2014-2015 Thomas Heller
+//  Copyright (c)      2020 Google
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -21,24 +22,25 @@
 #include <hpx/modules/synchronization.hpp>
 #include <hpx/modules/util.hpp>
 
+#include <hpx/modules/parcelset.hpp>
+#include <hpx/modules/parcelset_base.hpp>
+#include <hpx/modules/plugin_factories.hpp>
 #include <hpx/parcelport_gasnet/locality.hpp>
-#include <hpx/parcelport_gasnet/mailbox.hpp>
-#include <hpx/parcelport_gasnet/parcelport_gasnet.hpp>
 #include <hpx/parcelport_gasnet/receiver.hpp>
 #include <hpx/parcelport_gasnet/sender.hpp>
-#include <hpx/parcelport_gasnet/sender_connection.hpp>
-#include <hpx/parcelset/parcelport_impl.hpp>
-#include <hpx/plugin_factories/parcelport_factory.hpp>
 
 #include <asio/io_context.hpp>
-#include <asio/post.hpp>
 #include <asio/version.hpp>
+#if ASIO_VERSION >= 103400
+#include <asio/post.hpp>
+#endif
 
 #include <atomic>
 #include <cstddef>
-#include <cstdint>
+#include <exception>
 #include <memory>
 #include <string>
+#include <system_error>
 #include <type_traits>
 
 #include <hpx/config/warnings_prefix.hpp>
@@ -55,8 +57,8 @@ namespace hpx::parcelset {
         using connection_type = policies::gasnet::sender_connection;
         using send_early_parcel = std::true_type;
         using do_background_work = std::true_type;
-        using send_immediate_parcels = std::true_type;
-        using is_connectionless = std::true_type;
+        using send_immediate_parcels = std::false_type;
+        using is_connectionless = std::false_type;
 
         static constexpr char const* type() noexcept
         {
@@ -76,54 +78,56 @@ namespace hpx::parcelset {
 
     namespace policies::gasnet {
 
-        // Credit/wakeup AM handler (SHORT, 2-arg request). Runs inside the
-        // transport's poll/dispatch on the single progress thread and writes
-        // the LOCAL copy of the produced/consumed counter that our progress
-        // loop reads -- the GASNet-EX equivalent of the OpenSHMEM remote
-        // atomic_set. Dispatches through the file-scope static mailbox pointer
-        // set once during initialization.
-        void credit_am_handler(
-            gex_Token_t /*token*/, gex_AM_Arg_t a0, gex_AM_Arg_t a1) noexcept
+        int acquire_tag(sender* s) noexcept
         {
-            mailbox* m = get_gasnet_mailbox_ptr();
-            if (m != nullptr)
-            {
-                m->handle_credit(
-                    static_cast<std::uint32_t>(a0),
-                    static_cast<std::uint32_t>(a1));
-            }
+            return s->acquire_tag();
+        }
+
+        void add_connection(
+            sender* s, std::shared_ptr<sender_connection> const& ptr)
+        {
+            s->add(ptr);
         }
 
         class HPX_EXPORT parcelport : public parcelport_impl<parcelport>
         {
             using base_type = parcelport_impl<parcelport>;
 
-            static parcelset::locality here(std::size_t my_pe)
+            static parcelset::locality here()
             {
                 return parcelset::locality(
-                    locality(static_cast<std::int32_t>(my_pe)));
+                    locality(util::gasnet_environment::enabled() ?
+                            util::gasnet_environment::rank() :
+                            -1));
             }
 
-            static std::size_t mtu(util::runtime_configuration const& ini)
+            static std::size_t max_connections(
+                util::runtime_configuration const& ini)
             {
-                return hpx::util::get_entry_as<std::size_t>(
-                    ini, "hpx.parcel.gasnet.mtu", HPX_PARCEL_GASNET_MTU);
+                return hpx::util::get_entry_as<std::size_t>(ini,
+                    "hpx.parcel.gasnet.max_connections",
+                    HPX_PARCEL_MAX_CONNECTIONS);
+            }
+
+            static std::size_t background_threads(
+                [[maybe_unused]] util::runtime_configuration const& ini)
+            {
+                /*
+                return hpx::util::get_entry_as<std::size_t>(ini,
+                    "hpx.parcel.gasnet.background_threads",
+                    HPX_HAVE_PARCELPORT_GASNET_BACKGROUND_THREADS);
+                */
+                return 1UL;
             }
 
         public:
-            using sender_type = sender;
             parcelport(util::runtime_configuration const& ini,
                 threads::policies::callback_notifier const& notifier)
-              : base_type(ini, here(0), notifier)
+              : base_type(ini, here(), notifier)
               , stopped_(false)
-              , num_pes_(gasnet_environment::size())
-              , my_pe_(gasnet_environment::rank())
-              , mtu_(mtu(ini))
-              , mailboxes_(num_pes_, my_pe_, mtu_)
-              , sender_(&mailboxes_)
               , receiver_(*this)
+              , background_threads_(background_threads(ini))
             {
-                here_ = here(my_pe_);
             }
 
             parcelport(parcelport const&) = delete;
@@ -131,131 +135,80 @@ namespace hpx::parcelset {
             parcelport& operator=(parcelport const&) = delete;
             parcelport& operator=(parcelport&&) = delete;
 
-            ~parcelport() override = default;
+            ~parcelport()
+            {
+                util::gasnet_environment::finalize();
+            }
 
+            // Start the handling of connections.
             bool do_run()
             {
-                gex_TM_t tm = gasnet_environment::get_team();
-                gex_EP_t ep = gasnet_environment::get_endpoint();
-
-                // Point the AM handler at our mailbox before any inbound
-                // credit message can be dispatched by a poll.
-                get_gasnet_mailbox_ptr() = &mailboxes_;
-
-                // (1) Register the credit/wakeup AM handler on our endpoint.
-                //     gex_AM_Entry_t.gex_index == 0 means "assign an index";
-                //     GEX returns the absolute client index (>= 128) which we
-                //     read back and use in all gex_AM_RequestShort2 calls.
-                gex_AM_Entry_t htable[1];
-                htable[0].gex_index = 0;
-                htable[0].gex_fnptr = (gex_AM_Fn_t) &credit_am_handler;
-                htable[0].gex_flags = GEX_FLAG_AM_REQUEST | GEX_FLAG_AM_SHORT;
-                htable[0].gex_nargs = 2;
-                htable[0].gex_cdata = nullptr;
-                htable[0].gex_name = "hpx_gasnet_credit";
-
-                int rc = gex_EP_RegisterHandlers(ep, htable, 1);
-                if (rc != GASNET_OK)
-                {
-                    HPX_THROW_EXCEPTION(error::network_error,
-                        "gasnet::parcelport::do_run",
-                        "gex_EP_RegisterHandlers failed: " +
-                            std::string(gasnet_ErrorName(rc)));
-                }
-                mailboxes_.set_credit_handler(htable[0].gex_index);
-
-                // (2) Collectively publish the bound segment so every peer
-                //     has RMA credentials for one-sided puts into it.
-                //     This call is collective over the team and therefore
-                //     also synchronizes the whole base-exchange handshake.
-                gex_EP_t eps[1] = {ep};
-                rc = gex_EP_PublishBoundSegment(tm, eps, 1, 0);
-                if (rc != GASNET_OK)
-                {
-                    HPX_THROW_EXCEPTION(error::network_error,
-                        "gasnet::parcelport::do_run",
-                        "gex_EP_PublishBoundSegment failed: " +
-                            std::string(gasnet_ErrorName(rc)));
-                }
-
-                // (3) Query each peer's segment base (its owner-address). The
-                //     GEX address model uses absolute remote addresses, so we
-                //     reconstruct base_of(peer) + offset for every RMA put.
-                gex_Rank_t const npes = gex_TM_QuerySize(tm);
-                for (gex_Rank_t r = 0; r != npes; ++r)
-                {
-                    void* owneraddr = nullptr;
-                    void* localaddr = nullptr;
-                    uintptr_t segsize = 0;
-
-                    gex_Event_t ev = gex_EP_QueryBoundSegmentNB(
-                        tm, r, &owneraddr, &localaddr, &segsize, 0);
-                    gex_Event_Wait(ev);
-
-                    if (owneraddr == nullptr || segsize == 0)
-                    {
-                        HPX_THROW_EXCEPTION(error::network_error,
-                            "gasnet::parcelport::do_run",
-                            "gex_EP_QueryBoundSegmentNB returned no segment "
-                            "for peer " +
-                                std::to_string(r));
-                    }
-                    mailboxes_.set_remote_base(static_cast<std::size_t>(r),
-                        reinterpret_cast<std::uintptr_t>(owneraddr));
-                }
-
-                sender_.run();
                 receiver_.run();
+                sender_.run();
 
-                // All GASNet-EX calls must stay on a single thread (we drive
-                // the transport without internal locking), so only the first
-                // io_service of the pool runs the progress loop (io_pool_size
-                // is forced to 1 by the configuration below).
+                for (std::size_t i = 0; i != io_service_pool_.size(); ++i)
+                {
 #if ASIO_VERSION >= 103400
-                ::asio::post(
-                    io_service_pool_.get_io_service(0),
-                    hpx::bind(&parcelport::io_service_work, this));
+                    ::asio::post(
+                        io_service_pool_.get_io_service(static_cast<int>(i)),
+                        hpx::bind(&parcelport::io_service_work, this));
 #else
-                io_service_pool_.get_io_service(0)
-                    .post(hpx::bind(&parcelport::io_service_work, this));
+                    io_service_pool_.get_io_service(static_cast<int>(i))
+                        .post(hpx::bind(&parcelport::io_service_work, this));
 #endif
+                }
                 return true;
             }
 
+            // Stop the handling of connections.
             void do_stop()
             {
-                // Wait for the progress thread to drain all queued work. We
-                // must not drive send/receive from this thread as that would
-                // call into GASNet outside the single progress thread.
-                std::size_t max_iter = 1000;
-                while (sender_.has_pending() || receiver_.has_pending())
+                while (do_background_work(0, parcelport_background_mode::all))
                 {
-                    if (!threads::get_self_ptr() || max_iter-- == 0)
-                        break;
-                    hpx::this_thread::suspend(
-                        hpx::threads::thread_schedule_state::pending,
-                        "gasnet::parcelport::do_stop");
+                    if (threads::get_self_ptr())
+                        hpx::this_thread::suspend(
+                            hpx::threads::thread_schedule_state::pending,
+                            "gasnet::parcelport::do_stop");
                 }
 
-                stopped_.store(true, std::memory_order_release);
+                bool expected = false;
+                if (stopped_.compare_exchange_strong(expected, true))
+                {
+                    stopped_ = true;
+
+                    int retval;
+                    gasnet_barrier_notify(0, GASNET_BARRIERFLAG_ANONYMOUS);
+                    if ((retval = gasnet_barrier_wait(
+                             0, GASNET_BARRIERFLAG_ANONYMOUS)) != GASNET_OK)
+                    {
+                        // throw exception
+                        HPX_THROW_EXCEPTION(error::invalid_status,
+                            "hpx::util::gasnet_environment::init",
+                            "GASNET failed ",
+                            std::string{gasnet_ErrorName(retval)}, " ",
+                            std::string{gasnet_ErrorDesc(retval)});
+                    }
+                }
             }
 
+            /// Return the name of this locality
             std::string get_locality_name() const override
             {
-                return std::to_string(my_pe_);
+                return util::gasnet_environment::get_processor_name();
             }
 
             std::shared_ptr<sender_connection> create_connection(
                 parcelset::locality const& l, error_code&)
             {
-                int const dest_rank = l.get<locality>().rank();
-                return sender_.create_connection(dest_rank, &mailboxes_);
+                int dest_rank = l.get<locality>().rank();
+                return sender_.create_connection(dest_rank, this);
             }
 
             parcelset::locality agas_locality(
                 util::runtime_configuration const&) const override
             {
-                return parcelset::locality(locality(0));
+                return parcelset::locality(
+                    locality(util::gasnet_environment::enabled() ? 0 : -1));
             }
 
             parcelset::locality create_locality() const override
@@ -263,144 +216,120 @@ namespace hpx::parcelset {
                 return parcelset::locality(locality());
             }
 
-            // All GASNet-EX calls happen on the single progress thread
-            // (io_service_work). HPX threads must not call into the GASNet
-            // transport, so this is a no-op.
             bool background_work(
-                std::size_t, parcelport_background_mode)
+                std::size_t num_thread, parcelport_background_mode mode)
             {
-                return false;
-            }
+                if (stopped_.load(std::memory_order_acquire) ||
+                    num_thread >= background_threads_)
+                {
+                    return false;
+                }
 
-            constexpr bool can_send_immediate() const noexcept
-            {
-                return true;
-            }
-
-            mailbox const& get_mailboxes() const noexcept
-            {
-                return mailboxes_;
-            }
-
-            mailbox& get_mailboxes() noexcept
-            {
-                return mailboxes_;
-            }
-
-            constexpr std::size_t num_pes() const noexcept
-            {
-                return num_pes_;
-            }
-
-            constexpr std::size_t my_pe() const noexcept
-            {
-                return my_pe_;
-            }
-
-            constexpr std::size_t mtu() const noexcept
-            {
-                return mtu_;
-            }
-
-            bool send_immediate(parcelset::parcelport* pp,
-                parcelset::locality const& dest,
-                sender::parcel_buffer_type buffer,
-                sender::callback_fn_type&& callbackFn)
-            {
-                (void) pp;
-                return sender_.send_immediate(
-                    dest, HPX_MOVE(buffer), HPX_MOVE(callbackFn));
+                bool has_work = false;
+                if (mode & parcelport_background_mode::send)
+                {
+                    has_work = sender_.background_work();
+                }
+                if (mode & parcelport_background_mode::receive)
+                {
+                    has_work = receiver_.background_work() || has_work;
+                }
+                return has_work;
             }
 
         private:
+            std::atomic<bool> stopped_;
+
+            sender sender_;
+            receiver<parcelport> receiver_;
+
             void io_service_work()
             {
                 std::size_t k = 0;
-                std::size_t busy_loop = 0;
-                constexpr std::size_t max_busy_loop = 1000;
-
-                while (!stopped_.load(std::memory_order_acquire))
+                // We only execute work on the IO service while HPX is starting
+                while (hpx::is_starting())
                 {
-                    // Check for incoming data first (dispatch inbound credit
-                    // AMs + non-blocking scan + fast receive_()) so that
-                    // incoming parcels are not starved by a blocking send on
-                    // the other side.
-                    bool has_work = receiver_.background_work();
-                    has_work = sender_.background_work() || has_work;
+                    bool has_work = sender_.background_work();
+                    has_work = receiver_.background_work() || has_work;
                     if (has_work)
                     {
                         k = 0;
-                        busy_loop = 0;
                     }
                     else
                     {
-                        if (busy_loop < max_busy_loop)
-                        {
-                            ++busy_loop;
-                        }
-                        else
-                        {
-                            // Deliberate hot spin (no OS yield): mirrors the
-                            // validated openshmem harness, where the receiver
-                            // continuously pumps the transport so an inbound
-                            // credit AM / RMA store is reliably observed.
-                            ++k;
-                        }
+                        ++k;
+                        util::detail::yield_k(k,
+                            "hpx::parcelset::policies::gasnet::parcelport::"
+                            "io_service_work");
                     }
                 }
             }
 
-            std::atomic<bool> stopped_;
+            std::size_t background_threads_;
 
-            std::size_t num_pes_;
-            std::size_t my_pe_;
-            std::size_t mtu_;
-            mailbox mailboxes_;
+            void early_write_handler(std::error_code const& ec, parcel const& p)
+            {
+                if (ec)
+                {
+                    // all errors during early parcel handling are fatal
+                    std::exception_ptr exception = hpx::detail::get_exception(
+                        hpx::exception(ec), "gasnet::early_write_handler",
+                        __FILE__, __LINE__,
+                        "error while handling early parcel: " + ec.message() +
+                            "(" + std::to_string(ec.value()) + ")" +
+                            parcelset::dump_parcel(p));
 
-            sender sender_;
-            receiver<parcelport> receiver_;
+                    hpx::report_error(exception);
+                }
+            }
         };
     }    // namespace policies::gasnet
 }    // namespace hpx::parcelset
 
-#include <hpx/config/warnings_suffix.hpp>
+namespace hpx::traits {
 
-template <>
-struct hpx::traits::plugin_config_data<
-    hpx::parcelset::policies::gasnet::parcelport>
-{
-    static constexpr char const* priority() noexcept
+    // Inject additional configuration data into the factory registry for this
+    // type. This information ends up in the system wide configuration database
+    // under the plugin specific section:
+    //
+    //      [hpx.parcel.gasnet]
+    //      ...
+    //      priority = 1
+    //
+    template <>
+    struct plugin_config_data<hpx::parcelset::policies::gasnet::parcelport>
     {
-        return "100";
-    }
+        static constexpr char const* priority() noexcept
+        {
+            return "1";
+        }
 
-    static void init(int* argc, char*** argv, util::command_line_handling& cfg)
-    {
-        util::gasnet_environment::init(argc, argv, cfg.rtcfg_);
-        cfg.num_localities_ =
-            static_cast<std::size_t>(util::gasnet_environment::size());
-        cfg.node_ =
-            static_cast<std::size_t>(util::gasnet_environment::rank());
-    }
+        static void init(
+            int* argc, char*** argv, util::command_line_handling& cfg)
+        {
+            util::gasnet_environment::init(argc, argv, cfg.rtcfg_);
+            cfg.num_localities_ =
+                static_cast<std::size_t>(util::gasnet_environment::size());
+            cfg.node_ =
+                static_cast<std::size_t>(util::gasnet_environment::rank());
+        }
 
-    static constexpr void init(hpx::resource::partitioner&) noexcept {}
+        // by default no additional initialization using the resource
+        // partitioner is required
+        static constexpr void init(hpx::resource::partitioner&) noexcept {}
 
-    static void destroy() noexcept
-    {
-        util::gasnet_environment::finalize();
-    }
+        static void destroy() noexcept
+        {
+            util::gasnet_environment::finalize();
+        }
 
-    static constexpr char const* call() noexcept
-    {
-        return "mtu = "
-               "${HPX_HAVE_PARCELPORT_GASNET_MTU:65536}\n"
-               // All GASNet-EX calls must happen on a single thread, so the
-               // pool must not be larger than one.
-               "io_pool_size = 1\n";
-    }
-};
+        static constexpr char const* call() noexcept
+        {
+            return "";
+        }
+    };
+}    // namespace hpx::traits
 
-HPX_REGISTER_PARCELPORT(
-    hpx::parcelset::policies::gasnet::parcelport, gasnet)
+HPX_REGISTER_PARCELPORT(hpx::parcelset::policies::gasnet::parcelport, gasnet)
 
 #endif

--- a/libs/full/parcelport_openshmem/CMakeLists.txt
+++ b/libs/full/parcelport_openshmem/CMakeLists.txt
@@ -1,0 +1,44 @@
+# Copyright (c) 2025 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+if(NOT (HPX_WITH_NETWORKING AND HPX_WITH_PARCELPORT_OPENSHMEM))
+  return()
+endif()
+
+include(HPX_SetupOpenSHMEM)
+hpx_setup_openshmem()
+
+set(parcelport_openshmem_headers
+    hpx/parcelport_openshmem/locality.hpp
+    hpx/parcelport_openshmem/receiver.hpp
+    hpx/parcelport_openshmem/receiver_connection.hpp
+    hpx/parcelport_openshmem/sender.hpp
+    hpx/parcelport_openshmem/sender_connection.hpp
+)
+
+set(parcelport_openshmem_sources
+    locality.cpp
+    parcelport_openshmem.cpp
+    sender_connection.cpp
+)
+
+include(HPX_AddModule)
+add_hpx_module(
+  full parcelport_openshmem
+  GLOBAL_HEADER_GEN ON
+  SOURCES ${parcelport_openshmem_sources}
+  HEADERS ${parcelport_openshmem_headers}
+  DEPENDENCIES hpx_core hpx_dependencies_boost OpenSHMEM::openshmem
+  MODULE_DEPENDENCIES hpx_actions hpx_command_line_handling hpx_parcelset
+                      hpx_parcelset_base hpx_openshmem_base
+)
+
+set(HPX_STATIC_PARCELPORT_PLUGINS
+    ${HPX_STATIC_PARCELPORT_PLUGINS} parcelport_openshmem
+    CACHE INTERNAL "" FORCE
+)
+
+add_subdirectory(tests)

--- a/libs/full/parcelport_openshmem/CMakeLists.txt
+++ b/libs/full/parcelport_openshmem/CMakeLists.txt
@@ -19,10 +19,8 @@ set(parcelport_openshmem_headers
     hpx/parcelport_openshmem/sender_connection.hpp
 )
 
-set(parcelport_openshmem_sources
-    locality.cpp
-    parcelport_openshmem.cpp
-    sender_connection.cpp
+set(parcelport_openshmem_sources locality.cpp parcelport_openshmem.cpp
+                                 sender_connection.cpp
 )
 
 include(HPX_AddModule)

--- a/libs/full/parcelport_openshmem/CMakeLists.txt
+++ b/libs/full/parcelport_openshmem/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 The STE||AR-Group
+# Copyright (c) 2026 Christopher Taylor
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/locality.hpp
+++ b/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/locality.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2025 Hartmut Kaiser
+//  Copyright (c) 2026 Christopher Taylor
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/locality.hpp
+++ b/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/locality.hpp
@@ -1,0 +1,70 @@
+//  Copyright (c) 2025 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_OPENSHMEM)
+#include <hpx/modules/serialization.hpp>
+
+#include <cstdint>
+#include <iosfwd>
+
+namespace hpx::parcelset::policies::openshmem {
+
+    class locality
+    {
+    public:
+        constexpr locality() noexcept
+          : rank_(-1)
+        {
+        }
+
+        explicit constexpr locality(std::int32_t rank) noexcept
+          : rank_(rank)
+        {
+        }
+
+        [[nodiscard]] constexpr std::int32_t rank() const noexcept
+        {
+            return rank_;
+        }
+
+        [[nodiscard]] static constexpr char const* type() noexcept
+        {
+            return "openshmem";
+        }
+
+        [[nodiscard]] explicit constexpr operator bool() const noexcept
+        {
+            return rank_ != -1;
+        }
+
+        HPX_EXPORT void save(serialization::output_archive& ar) const;
+        HPX_EXPORT void load(serialization::input_archive& ar);
+
+    private:
+        friend constexpr bool operator==(
+            locality const& lhs, locality const& rhs) noexcept
+        {
+            return lhs.rank_ == rhs.rank_;
+        }
+
+        friend constexpr bool operator<(
+            locality const& lhs, locality const& rhs) noexcept
+        {
+            return lhs.rank_ < rhs.rank_;
+        }
+
+        friend HPX_EXPORT std::ostream& operator<<(
+            std::ostream& os, locality const& loc) noexcept;
+
+        std::int32_t rank_;
+    };
+}    // namespace hpx::parcelset::policies::openshmem
+
+#endif

--- a/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/locality.hpp
+++ b/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/locality.hpp
@@ -61,7 +61,7 @@ namespace hpx::parcelset::policies::openshmem {
         }
 
         friend HPX_EXPORT std::ostream& operator<<(
-            std::ostream& os, locality const& loc) noexcept;
+            std::ostream& os, locality const& loc);
 
         std::int32_t rank_;
     };

--- a/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/mailbox_array.hpp
+++ b/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/mailbox_array.hpp
@@ -1,0 +1,454 @@
+//  Copyright (c) 2025 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_OPENSHMEM)
+#include <hpx/assert.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <utility>
+
+#include <shmem.h>
+
+namespace hpx::parcelset::policies::openshmem {
+
+    // TX/RX page-arena + per-pair 64-bit credit-word protocol, ported from
+    // the VALIDATED tools/shmem_diag/shmem_mailbox_credits_with_pages.cpp.
+    //
+    // ONE zeroed symmetric allocation (shmem_calloc) holds everything:
+    //     tx       : npes * SLOTS * mtu   (my outbound staging/scratch pages)
+    //     rx       : npes * SLOTS * mtu   (my shared inbound landing pages)
+    //     produced : npes * npes * 4      (uint32, low-32 of per-pair word)
+    //     consumed : npes * npes * 4      (uint32, high-32 of per-pair word)
+    //   -> one 64-bit credit per (sender i, receiver j): low32 = produced,
+    //      high32 = consumed.  Payload lives in the tx/rx page pools which
+    //      are O(npes * SLOTS) and linear in the number of PEs; the npes^2
+    //      credit words are tiny 4-byte atomics (no npes^2 page grid).
+    //
+    // Slot-writer ownership (avoids torn writes with only atomic_set):
+    //     produced[i*npes+j] written by SENDER i onto j;  receiver j reads LOCAL
+    //     consumed[i*npes+j] written by RECEIVER j onto i; sender i reads LOCAL
+    //   -> each 32-bit half has a single writer; no RMW needed.
+    //
+    // Validated (2-PE) transport rule from tools/shmem_diag:
+    //   - each side reads its OWN counter LOCALLY (plain load)
+    //   - each side WRITES the peer's counter via atomic_set(..., peer)
+    //   - both sides atomic_fetch the peer purely to FORCE DELIVERY of the
+    //     peer's inbound stores into local symmetric memory
+    //   - data carried by BLOCKING putmem.  NO atomic_*_nbi / fetch_add.
+    //
+    // Receiver j's landing page for a page written by sender i lives in j's
+    // shared rx pool at offset (i*SLOTS + (p % SLOTS)) * mtu.  Each sender is
+    // assigned its own SLOTS-sized slot range, so concurrent senders never
+    // reuse the same landing slot (per-destination single-flight, which the
+    // parcelport enforces via active_dsts_, keeps this safe).
+    //
+    // One MTU-sized page == one chunk (message_header + payload), matching
+    // how sender_connection stages a chunk into an mtu slot.
+
+    class HPX_EXPORT mailbox_array
+    {
+    public:
+        // Number of in-flight pages (chunks) allowed per (sender,receiver)
+        // pair before the sender must wait for consumed credit.  Bounded by
+        // the rx page range assigned to each sender.
+        static constexpr std::size_t slots_per_dst = 8;
+
+        mailbox_array() = default;
+
+        mailbox_array(std::size_t num_pes, std::size_t my_pe, std::size_t mtu)
+          : num_pes_(num_pes)
+          , my_pe_(my_pe)
+          , mtu_(mtu)
+        {
+            std::size_t const pages = num_pes_ * slots_per_dst * mtu_;
+            std::size_t const words = num_pes_ * num_pes_;
+
+            // one zeroed allocation; zeroed produced/consumed = correct
+            // monotonic start state (0 pages produced/consumed).
+            std::size_t const bytes =
+                2 * pages + 2 * words * sizeof(std::uint32_t);
+
+            heap_ = shmem_calloc(bytes, 1);
+            if (!heap_)
+            {
+                std::fprintf(stderr,
+                    "openshmem: shmem_calloc(%zu) failed on PE %zu\n", bytes,
+                    my_pe_);
+                std::abort();
+            }
+
+            unsigned char* base = static_cast<unsigned char*>(heap_);
+            tx_beg_ = base;
+            tx_end_ = base + pages;
+            rx_beg_ = tx_end_;
+            rx_end_ = rx_beg_ + pages;
+            produced_beg_ = reinterpret_cast<std::uint32_t*>(rx_end_);
+            produced_end_ = produced_beg_ + words;
+            consumed_beg_ = produced_end_;
+            consumed_end_ = consumed_beg_ + words;
+
+            // Publish the zeroed state to all PEs before any peer drives
+            // progress against us.
+            shmem_barrier_all();
+
+            // Local-only mirror counters (never symmetric, never remote).
+            // produced_locals_[dst] = how many pages I have published to dst
+            // consumed_locals_[src] = how many pages I have consumed from src
+            //
+            // These persist across send()/receive_() calls.  The symmetric
+            // produced_beg_/consumed_beg_ copies are only updated by REMOTE
+            // atomic_set requests, so a PE's own local copy of a counter it
+            // writes stays stale — hence the mirrors.
+            produced_locals_ = new std::uint32_t[num_pes_];
+            consumed_locals_ = new std::uint32_t[num_pes_];
+            for (std::size_t i = 0; i < num_pes_; ++i)
+            {
+                produced_locals_[i] = 0;
+                consumed_locals_[i] = 0;
+            }
+        }
+
+        ~mailbox_array()
+        {
+            delete[] produced_locals_;
+            delete[] consumed_locals_;
+            if (heap_)
+            {
+                shmem_free(heap_);
+            }
+        }
+
+        mailbox_array(mailbox_array const&) = delete;
+        mailbox_array& operator=(mailbox_array const&) = delete;
+
+        mailbox_array(mailbox_array&& other) noexcept
+          : heap_(other.heap_)
+          , tx_beg_(other.tx_beg_)
+          , tx_end_(other.tx_end_)
+          , rx_beg_(other.rx_beg_)
+          , rx_end_(other.rx_end_)
+          , produced_beg_(other.produced_beg_)
+          , produced_end_(other.produced_end_)
+          , consumed_beg_(other.consumed_beg_)
+          , consumed_end_(other.consumed_end_)
+          , produced_locals_(other.produced_locals_)
+          , consumed_locals_(other.consumed_locals_)
+          , num_pes_(other.num_pes_)
+          , my_pe_(other.my_pe_)
+          , mtu_(other.mtu_)
+        {
+            other.heap_ = nullptr;
+            other.tx_beg_ = nullptr;
+            other.tx_end_ = nullptr;
+            other.rx_beg_ = nullptr;
+            other.rx_end_ = nullptr;
+            other.produced_beg_ = nullptr;
+            other.produced_end_ = nullptr;
+            other.consumed_beg_ = nullptr;
+            other.consumed_end_ = nullptr;
+            other.produced_locals_ = nullptr;
+            other.consumed_locals_ = nullptr;
+        }
+
+        mailbox_array& operator=(mailbox_array&& other) noexcept
+        {
+            if (this != &other)
+            {
+                if (heap_)
+                {
+                    shmem_free(heap_);
+                }
+                delete[] produced_locals_;
+                delete[] consumed_locals_;
+                heap_ = other.heap_;
+                tx_beg_ = other.tx_beg_;
+                tx_end_ = other.tx_end_;
+                rx_beg_ = other.rx_beg_;
+                rx_end_ = other.rx_end_;
+                produced_beg_ = other.produced_beg_;
+                produced_end_ = other.produced_end_;
+                consumed_beg_ = other.consumed_beg_;
+                consumed_end_ = other.consumed_end_;
+                produced_locals_ = other.produced_locals_;
+                consumed_locals_ = other.consumed_locals_;
+                num_pes_ = other.num_pes_;
+                my_pe_ = other.my_pe_;
+                mtu_ = other.mtu_;
+                other.heap_ = nullptr;
+                other.tx_beg_ = nullptr;
+                other.tx_end_ = nullptr;
+                other.rx_beg_ = nullptr;
+                other.rx_end_ = nullptr;
+                other.produced_beg_ = nullptr;
+                other.produced_end_ = nullptr;
+                other.consumed_beg_ = nullptr;
+                other.consumed_end_ = nullptr;
+                other.produced_locals_ = nullptr;
+                other.consumed_locals_ = nullptr;
+            }
+            return *this;
+        }
+
+        // Return the symmetric scratch page that a sender uses to stage the
+        // chunk for the CURRENT credit slot of (dst_pe).  Each ring slot has
+        // its own dedicated staging page, mirroring the validated
+        // shmem_mailbox_credits_with_pages harness (per-slot TX pages).
+        //
+        // shmem_putmem is asynchronous, so a SINGLE shared staging buffer
+        // would be overwritten by the next stage_chunk() while the previous
+        // putmem is still being read by the transport, sending a blend of
+        // two chunks ("memory aliasing" of the staging buffer) -> corrupted
+        // headers (garbage num_chunks -> segfault / duplicate AGAS
+        // bind_prefix) under the back-to-back send pressure of a 4-PE AGAS
+        // bootstrap.  Keying the staging page by (dst, slot) prevents the
+        // reuse until that slot is handed back by the receiver's credit,
+        // which guarantees the prior putmem has been drained.
+        unsigned char* tx_page(std::size_t dst_pe) const
+        {
+            std::size_t const slot =
+                produced_locals_[dst_pe] % slots_per_dst;
+            return tx_beg_ + (dst_pe * slots_per_dst + slot) * mtu_;
+        }
+
+        unsigned char* get_buffer(std::size_t pe) const
+        {
+            return tx_page(pe);
+        }
+
+        // Compatibility accessors for the old signal/ack doorbell model.
+        // The credit protocol no longer uses these; they are kept only so
+        // the class shape stays close to the original (and the local-send
+        // path can be adapted without them).
+        int* get_notify(std::size_t pe) const
+        {
+            return reinterpret_cast<int*>(&produced_beg_[pe]);
+        }
+
+        int* get_signal(std::size_t pe) const
+        {
+            return reinterpret_cast<int*>(&produced_beg_[pe]);
+        }
+
+        int* get_ack(std::size_t pe) const
+        {
+            return reinterpret_cast<int*>(&consumed_beg_[pe]);
+        }
+
+        // Non-blocking scan: return the index of the first PE that has at
+        // least one page we have not yet consumed, or -1 if none.
+        //
+        // Uses shmem_uint32_atomic_fetch, a REMOTE atomic read of src's
+        // produced counter, which (a) returns src's latest published value
+        // and (b) drives delivery of src's inbound stores into our local
+        // memory — the mechanism that makes a plain later local load see the
+        // data.  Without this remote read, an idle receiver never triggers
+        // delivery and would deadlock.
+        int try_detect_pe_notification() const noexcept
+        {
+            for (std::size_t src = 0; src < num_pes_; ++src)
+            {
+                if (src == my_pe_)
+                {
+                    continue;
+                }
+                std::size_t const w = src * num_pes_ + my_pe_;
+
+                // Pull delivery of src's inbound stores (putmem + produced
+                // atomic_set) into OUR local symmetric memory, then read the
+                // published value LOCALLY — the validated harness idiom.  A
+                // remote shmem_uint32_atomic_fetch return value would read
+                // src's own copy of the slot (which is 0), not our copy.
+                progress_to(src);
+                std::uint32_t const produced = produced_beg_[w];
+                std::uint32_t const consumed = consumed_locals_[src];
+                if (produced > consumed)
+                {
+                    return static_cast<int>(src);
+                }
+            }
+            return -1;
+        }
+
+        // progress_to(peer): a remote atomic_fetch to the peer PUSHES the
+        // peer's inbound stores into our local symmetric memory (the
+        // validated delivery rule).  Called inside every blocking wait.
+        void progress_to(std::size_t const peer) const noexcept
+        {
+            std::size_t const w = my_pe_ * num_pes_ + peer;
+            shmem_uint32_atomic_fetch(&produced_beg_[w],
+                static_cast<int>(peer));
+            shmem_uint32_atomic_fetch(&consumed_beg_[w],
+                static_cast<int>(peer));
+        }
+
+        // Blocking send of one mtu-sized page (chunk) to dst_pe.
+        // Copies 'count' bytes from our staging page (get_buffer()) into
+        // dst's shared rx slot range, publishes produced, and applies the
+        // credit wait (may keep up to slots_per_dst pages in flight).
+        void send(std::size_t const dst_pe,
+            std::size_t const count) noexcept
+        {
+            HPX_ASSERT(count <= mtu_);
+
+            // Works for both remote (dst != me) and local (dst == me, a
+            // self-putmem into our own rx pool) destinations.
+
+            std::size_t const w = my_pe_ * num_pes_ + dst_pe;
+
+            // our mirrors of the two halves
+            std::uint32_t produced = produced_locals_[dst_pe];   // mine
+            // dst's consumed counter: for a local send it is our own drain
+            // mirror (same thread); otherwise the delivered remote copy.
+            std::uint32_t consumed =
+                (dst_pe == my_pe_) ?
+                consumed_locals_[dst_pe] :
+                consumed_beg_[w];
+
+            // CREDIT WAIT: may write while produced - consumed < slots_per_dst
+            while (static_cast<int>(produced - consumed) >=
+                static_cast<int>(slots_per_dst))
+            {
+                if (dst_pe != my_pe_)
+                {
+                    progress_to(dst_pe);           // deliver dst's consumed
+                    consumed = consumed_beg_[w];   // read LOCAL (delivered)
+                }
+                else
+                {
+                    consumed = consumed_locals_[dst_pe];    // our drain mirror
+                }
+            }
+
+            std::size_t const slot = produced % slots_per_dst;
+            // Staging source: my per-dst staging page (tx mirror of the rx
+            // slot), keyed by dst_pe so two different destinations use
+            // disjoint staging pages (matches tx_page()).
+            std::size_t const stage_slot =
+                (dst_pe * slots_per_dst + slot) * mtu_;
+            // Landing target: dst's shared rx pool, keyed by MY pe (the
+            // sender), so each sender has its own disjoint per-src ring and
+            // different senders cannot collide on the same guard pages (the
+            // cause of duplicate delivery at 4 PEs).
+            std::size_t const rx_slot =
+                (my_pe_ * slots_per_dst + slot) * mtu_;
+
+            // data: blocking putmem staging -> dst's rx page.
+            shmem_putmem(rx_beg_ + rx_slot, tx_beg_ + stage_slot, count,
+                static_cast<int>(dst_pe));
+
+            // publish produced (low-32; WE own it)
+            produced = produced + 1;
+            shmem_uint32_atomic_set(
+                &produced_beg_[w], produced, static_cast<int>(dst_pe));
+            produced_locals_[dst_pe] = produced;    // update our mirror
+            shmem_fence();
+
+            // DELIVERY PUSH: issue a remote atomic_fetch to the peer right
+            // after publishing produced, so our inbound stores (the
+            // atomic_set we just posted onto dst) are forced into dst's local
+            // view — the same ping-pong the validated harness relies on when
+            // both sides continuously fetch each other. Without this, an idle
+            // receiver's local load/scan may never observe dst's copy.
+            if (dst_pe != my_pe_)
+            {
+                progress_to(dst_pe);
+            }
+        }
+
+        // Blocking receive of one page (chunk) from src_pe.  Copies 'count'
+        // bytes off our shared rx page into out_buf, then returns the credit
+        // (publishes consumed) so src may reuse the slot.
+        bool receive_(std::size_t const src_pe, unsigned char* const out_buf,
+            std::size_t const count) noexcept
+        {
+            HPX_ASSERT(count <= mtu_);
+
+            std::size_t const w = src_pe * num_pes_ + my_pe_;
+
+            std::uint32_t const consumed = consumed_locals_[src_pe];   // mine
+
+            // wait for src to publish page 'consumed' (data ready)
+            while (produced_beg_[w] <= consumed)
+            {
+                progress_to(src_pe);               // deliver src's produced
+            }
+
+            std::size_t const slot = consumed % slots_per_dst;
+            // Read from src's OWN per-src ring in our shared rx pool
+            // ((src_pe * slots + slot) * mtu_).  The sender keys its landing
+            // ring by its own pe (== our src_pe), so each sender has a
+            // disjoint ring and a chunk from one source is never
+            // aliased/overwritten by a different source (the duplicate
+            // delivery / duplicate_component_id bug at 4 PEs).
+            std::size_t const rx_slot =
+                (src_pe * slots_per_dst + slot) * mtu_;
+
+            std::memcpy(out_buf, rx_beg_ + rx_slot, count);
+
+            // return the credit: publish consumed (high-32; WE own it) onto src
+            shmem_uint32_atomic_set(
+                &consumed_beg_[w], consumed + 1, static_cast<int>(src_pe));
+            consumed_locals_[src_pe] = consumed + 1;    // update our mirror
+            shmem_fence();
+
+            return true;
+        }
+
+        bool receive(unsigned char* const output,
+            std::size_t const count) noexcept
+        {
+            int const pe = try_detect_pe_notification();
+            if (pe < 0)
+            {
+                return false;
+            }
+            return receive_(static_cast<std::size_t>(pe), output, count);
+        }
+
+        constexpr std::size_t mtu() const noexcept
+        {
+            return mtu_;
+        }
+
+        constexpr std::size_t num_pes() const noexcept
+        {
+            return num_pes_;
+        }
+
+        constexpr std::size_t my_pe() const noexcept
+        {
+            return my_pe_;
+        }
+
+    private:
+        void* heap_ = nullptr;
+
+        unsigned char* tx_beg_ = nullptr;
+        unsigned char* tx_end_ = nullptr;
+        unsigned char* rx_beg_ = nullptr;
+        unsigned char* rx_end_ = nullptr;
+        std::uint32_t* produced_beg_ = nullptr;
+        std::uint32_t* produced_end_ = nullptr;
+        std::uint32_t* consumed_beg_ = nullptr;
+        std::uint32_t* consumed_end_ = nullptr;
+        std::uint32_t* produced_locals_ = nullptr;
+        std::uint32_t* consumed_locals_ = nullptr;
+
+        std::size_t num_pes_ = 0;
+        std::size_t my_pe_ = 0;
+        std::size_t mtu_ = 0;
+    };
+}    // namespace hpx::parcelset::policies::openshmem
+
+#endif

--- a/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/mailbox_array.hpp
+++ b/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/mailbox_array.hpp
@@ -35,16 +35,16 @@ namespace hpx::parcelset::policies::openshmem {
     //      credit words are tiny 4-byte atomics (no npes^2 page grid).
     //
     // Slot-writer ownership (avoids torn writes with only atomic_set):
-    //     produced[i*npes+j] written by SENDER i onto j;  receiver j reads LOCAL
-    //     consumed[i*npes+j] written by RECEIVER j onto i; sender i reads LOCAL
+    //     produced[i*npes+j] written by sender (tx) i onto j;  receiver j reads local
+    //     consumed[i*npes+j] written by receiver (rx) j onto i; sender i reads local
     //   -> each 32-bit half has a single writer; no RMW needed.
     //
-    // Validated (2-PE) transport rule from tools/shmem_diag:
-    //   - each side reads its OWN counter LOCALLY (plain load)
-    //   - each side WRITES the peer's counter via atomic_set(..., peer)
-    //   - both sides atomic_fetch the peer purely to FORCE DELIVERY of the
-    //     peer's inbound stores into local symmetric memory
-    //   - data carried by BLOCKING putmem.  NO atomic_*_nbi / fetch_add.
+    // Validated (2-PE) transport rule:
+    //   - each side reads its associated counter locally (plain load)
+    //   - each side remotely writes the peer's counter via atomic_set(..., peer)
+    //   - both sides atomic_fetch the peer purely to force delivery of the
+    //     peer's inbound stores into local symmetric memory (send queue)
+    //   - data carried by blocking putmem.  NO atomic_*_nbi / fetch_add.
     //
     // Receiver j's landing page for a page written by sender i lives in j's
     // shared rx pool at offset (i*SLOTS + (p % SLOTS)) * mtu.  Each sender is
@@ -200,19 +200,8 @@ namespace hpx::parcelset::policies::openshmem {
         }
 
         // Return the symmetric scratch page that a sender uses to stage the
-        // chunk for the CURRENT credit slot of (dst_pe). Each ring slot has
-        // its own dedicated staging page, mirroring the validated
-        // shmem_mailbox_credits_with_pages harness (per-slot TX pages).
-        //
-        // shmem_putmem is asynchronous, so a single shared staging buffer
-        // would be overwritten by the next stage_chunk() while the previous
-        // putmem is still being read by the transport, sending a blend of
-        // two chunks ("memory aliasing" of the staging buffer) -> corrupted
-        // headers (garbage num_chunks -> segfault / duplicate AGAS
-        // bind_prefix) under the back-to-back send pressure of a 4-PE AGAS
-        // bootstrap.  Keying the staging page by (dst, slot) prevents the
-        // reuse until that slot is handed back by the receiver's credit,
-        // which guarantees the prior putmem has been drained.
+        // chunk for the current credit slot of (dst_pe). Each ring slot has
+        // its own dedicated staging page (per-slot TX pages).
         unsigned char* tx_page(std::size_t dst_pe) const
         {
             std::size_t const slot =
@@ -223,25 +212,6 @@ namespace hpx::parcelset::policies::openshmem {
         unsigned char* get_buffer(std::size_t pe) const
         {
             return tx_page(pe);
-        }
-
-        // Compatibility accessors for the old signal/ack doorbell model.
-        // The credit protocol no longer uses these; they are kept only so
-        // the class shape stays close to the original (and the local-send
-        // path can be adapted without them).
-        int* get_notify(std::size_t pe) const
-        {
-            return reinterpret_cast<int*>(&produced_beg_[pe]);
-        }
-
-        int* get_signal(std::size_t pe) const
-        {
-            return reinterpret_cast<int*>(&produced_beg_[pe]);
-        }
-
-        int* get_ack(std::size_t pe) const
-        {
-            return reinterpret_cast<int*>(&consumed_beg_[pe]);
         }
 
         // Non-blocking scan: return the index of the first PE that has at
@@ -280,8 +250,8 @@ namespace hpx::parcelset::policies::openshmem {
         }
 
         // progress_to(peer): a remote atomic_fetch to the peer "pushes" the
-        // peer's inbound stores into our local symmetric memory (the
-        // validated delivery rule).  Called inside every blocking wait.
+        // peer's inbound stores into our local symmetric memory (the delivery
+        // rule).  Called inside every blocking wait.
         void progress_to(std::size_t const peer) const noexcept
         {
             std::size_t const w = my_pe_ * num_pes_ + peer;
@@ -302,11 +272,11 @@ namespace hpx::parcelset::policies::openshmem {
 
             // Works for both remote (dst != me) and local (dst == me, a
             // self-putmem into our own rx pool) destinations.
-
             std::size_t const w = my_pe_ * num_pes_ + dst_pe;
 
-            // our mirrors of the two halves
+            // mirrors of the two halves
             std::uint32_t produced = produced_locals_[dst_pe];   // mine
+
             // dst's consumed counter: for a local send it is our own drain
             // mirror (same thread); otherwise the delivered remote copy.
             std::uint32_t consumed =
@@ -314,14 +284,14 @@ namespace hpx::parcelset::policies::openshmem {
                 consumed_locals_[dst_pe] :
                 consumed_beg_[w];
 
-            // CREDIT WAIT: may write while produced - consumed < slots_per_dst
+            // credit wait: may write while produced - consumed < slots_per_dst
             while (static_cast<int>(produced - consumed) >=
                 static_cast<int>(slots_per_dst))
             {
                 if (dst_pe != my_pe_)
                 {
                     progress_to(dst_pe);           // deliver dst's consumed
-                    consumed = consumed_beg_[w];   // read LOCAL (delivered)
+                    consumed = consumed_beg_[w];   // read local (delivered)
                 }
                 else
                 {
@@ -330,12 +300,14 @@ namespace hpx::parcelset::policies::openshmem {
             }
 
             std::size_t const slot = produced % slots_per_dst;
+
             // Staging source: my per-dst staging page (tx mirror of the rx
             // slot), keyed by dst_pe so two different destinations use
             // disjoint staging pages (matches tx_page()).
             std::size_t const stage_slot =
                 (dst_pe * slots_per_dst + slot) * mtu_;
-            // Landing target: dst's shared rx pool, keyed by MY pe (the
+
+            // Landing target: dst's shared rx pool, keyed by self PE (the
             // sender), so each sender has its own disjoint per-src ring and
             // different senders cannot collide on the same guard pages (the
             // cause of duplicate delivery at 4 PEs).
@@ -346,7 +318,7 @@ namespace hpx::parcelset::policies::openshmem {
             shmem_putmem(rx_beg_ + rx_slot, tx_beg_ + stage_slot, count,
                 static_cast<int>(dst_pe));
 
-            // publish produced (low-32; WE own it)
+            // publish produced (low-32; self owns it)
             produced = produced + 1;
             shmem_uint32_atomic_set(
                 &produced_beg_[w], produced, static_cast<int>(dst_pe));
@@ -395,7 +367,7 @@ namespace hpx::parcelset::policies::openshmem {
 
             std::memcpy(out_buf, rx_beg_ + rx_slot, count);
 
-            // return the credit: publish consumed (high-32; WE own it) onto src
+            // return the credit: publish consumed (high-32; self owns it) onto src
             shmem_uint32_atomic_set(
                 &consumed_beg_[w], consumed + 1, static_cast<int>(src_pe));
             consumed_locals_[src_pe] = consumed + 1;    // update our mirror

--- a/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/mailbox_array.hpp
+++ b/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/mailbox_array.hpp
@@ -204,7 +204,8 @@ namespace hpx::parcelset::policies::openshmem {
         // its own dedicated staging page (per-slot TX pages).
         unsigned char* tx_page(std::size_t dst_pe) const
         {
-            std::size_t const slot = produced_locals_[dst_pe] % slots_per_dst;
+            std::size_t const slot =
+                produced_locals_[dst_pe] % slots_per_dst;
             return tx_beg_ + (dst_pe * slots_per_dst + slot) * mtu_;
         }
 

--- a/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/mailbox_array.hpp
+++ b/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/mailbox_array.hpp
@@ -204,8 +204,7 @@ namespace hpx::parcelset::policies::openshmem {
         // its own dedicated staging page (per-slot TX pages).
         unsigned char* tx_page(std::size_t dst_pe) const
         {
-            std::size_t const slot =
-                produced_locals_[dst_pe] % slots_per_dst;
+            std::size_t const slot = produced_locals_[dst_pe] % slots_per_dst;
             return tx_beg_ + (dst_pe * slots_per_dst + slot) * mtu_;
         }
 
@@ -255,18 +254,17 @@ namespace hpx::parcelset::policies::openshmem {
         void progress_to(std::size_t const peer) const noexcept
         {
             std::size_t const w = my_pe_ * num_pes_ + peer;
-            shmem_uint32_atomic_fetch(&produced_beg_[w],
-                static_cast<int>(peer));
-            shmem_uint32_atomic_fetch(&consumed_beg_[w],
-                static_cast<int>(peer));
+            shmem_uint32_atomic_fetch(
+                &produced_beg_[w], static_cast<int>(peer));
+            shmem_uint32_atomic_fetch(
+                &consumed_beg_[w], static_cast<int>(peer));
         }
 
         // Blocking send of one mtu-sized page (chunk) to dst_pe.
         // Copies 'count' bytes from our staging page (get_buffer()) into
         // dst's shared rx slot range, publishes produced, and applies the
         // credit wait (may keep up to slots_per_dst pages in flight).
-        void send(std::size_t const dst_pe,
-            std::size_t const count) noexcept
+        void send(std::size_t const dst_pe, std::size_t const count) noexcept
         {
             HPX_ASSERT(count <= mtu_);
 
@@ -275,12 +273,11 @@ namespace hpx::parcelset::policies::openshmem {
             std::size_t const w = my_pe_ * num_pes_ + dst_pe;
 
             // mirrors of the two halves
-            std::uint32_t produced = produced_locals_[dst_pe];   // mine
+            std::uint32_t produced = produced_locals_[dst_pe];    // mine
 
             // dst's consumed counter: for a local send it is our own drain
             // mirror (same thread); otherwise the delivered remote copy.
-            std::uint32_t consumed =
-                (dst_pe == my_pe_) ?
+            std::uint32_t consumed = (dst_pe == my_pe_) ?
                 consumed_locals_[dst_pe] :
                 consumed_beg_[w];
 
@@ -290,8 +287,8 @@ namespace hpx::parcelset::policies::openshmem {
             {
                 if (dst_pe != my_pe_)
                 {
-                    progress_to(dst_pe);           // deliver dst's consumed
-                    consumed = consumed_beg_[w];   // read local (delivered)
+                    progress_to(dst_pe);            // deliver dst's consumed
+                    consumed = consumed_beg_[w];    // read local (delivered)
                 }
                 else
                 {
@@ -311,8 +308,7 @@ namespace hpx::parcelset::policies::openshmem {
             // sender), so each sender has its own disjoint per-src ring and
             // different senders cannot collide on the same guard pages (the
             // cause of duplicate delivery at 4 PEs).
-            std::size_t const rx_slot =
-                (my_pe_ * slots_per_dst + slot) * mtu_;
+            std::size_t const rx_slot = (my_pe_ * slots_per_dst + slot) * mtu_;
 
             // data: blocking putmem staging -> dst's rx page.
             shmem_putmem(rx_beg_ + rx_slot, tx_beg_ + stage_slot, count,
@@ -347,12 +343,12 @@ namespace hpx::parcelset::policies::openshmem {
 
             std::size_t const w = src_pe * num_pes_ + my_pe_;
 
-            std::uint32_t const consumed = consumed_locals_[src_pe];   // mine
+            std::uint32_t const consumed = consumed_locals_[src_pe];    // mine
 
             // wait for src to publish page 'consumed' (data ready)
             while (produced_beg_[w] <= consumed)
             {
-                progress_to(src_pe);               // deliver src's produced
+                progress_to(src_pe);    // deliver src's produced
             }
 
             std::size_t const slot = consumed % slots_per_dst;
@@ -362,8 +358,7 @@ namespace hpx::parcelset::policies::openshmem {
             // disjoint ring and a chunk from one source is never
             // aliased/overwritten by a different source (the duplicate
             // delivery / duplicate_component_id bug at 4 PEs).
-            std::size_t const rx_slot =
-                (src_pe * slots_per_dst + slot) * mtu_;
+            std::size_t const rx_slot = (src_pe * slots_per_dst + slot) * mtu_;
 
             std::memcpy(out_buf, rx_beg_ + rx_slot, count);
 
@@ -376,8 +371,8 @@ namespace hpx::parcelset::policies::openshmem {
             return true;
         }
 
-        bool receive(unsigned char* const output,
-            std::size_t const count) noexcept
+        bool receive(
+            unsigned char* const output, std::size_t const count) noexcept
         {
             int const pe = try_detect_pe_notification();
             if (pe < 0)

--- a/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/mailbox_array.hpp
+++ b/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/mailbox_array.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2025 Hartmut Kaiser
+//  Copyright (c) 2026 Christopher Taylor
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -22,8 +22,7 @@
 
 namespace hpx::parcelset::policies::openshmem {
 
-    // TX/RX page-arena + per-pair 64-bit credit-word protocol, ported from
-    // the VALIDATED tools/shmem_diag/shmem_mailbox_credits_with_pages.cpp.
+    // TX/RX page-arena + per-pair 64-bit credit-word protocol
     //
     // ONE zeroed symmetric allocation (shmem_calloc) holds everything:
     //     tx       : npes * SLOTS * mtu   (my outbound staging/scratch pages)
@@ -201,11 +200,11 @@ namespace hpx::parcelset::policies::openshmem {
         }
 
         // Return the symmetric scratch page that a sender uses to stage the
-        // chunk for the CURRENT credit slot of (dst_pe).  Each ring slot has
+        // chunk for the CURRENT credit slot of (dst_pe). Each ring slot has
         // its own dedicated staging page, mirroring the validated
         // shmem_mailbox_credits_with_pages harness (per-slot TX pages).
         //
-        // shmem_putmem is asynchronous, so a SINGLE shared staging buffer
+        // shmem_putmem is asynchronous, so a single shared staging buffer
         // would be overwritten by the next stage_chunk() while the previous
         // putmem is still being read by the transport, sending a blend of
         // two chunks ("memory aliasing" of the staging buffer) -> corrupted
@@ -248,7 +247,7 @@ namespace hpx::parcelset::policies::openshmem {
         // Non-blocking scan: return the index of the first PE that has at
         // least one page we have not yet consumed, or -1 if none.
         //
-        // Uses shmem_uint32_atomic_fetch, a REMOTE atomic read of src's
+        // Uses shmem_uint32_atomic_fetch, a remote atomic read of src's
         // produced counter, which (a) returns src's latest published value
         // and (b) drives delivery of src's inbound stores into our local
         // memory — the mechanism that makes a plain later local load see the
@@ -265,10 +264,10 @@ namespace hpx::parcelset::policies::openshmem {
                 std::size_t const w = src * num_pes_ + my_pe_;
 
                 // Pull delivery of src's inbound stores (putmem + produced
-                // atomic_set) into OUR local symmetric memory, then read the
-                // published value LOCALLY — the validated harness idiom.  A
-                // remote shmem_uint32_atomic_fetch return value would read
-                // src's own copy of the slot (which is 0), not our copy.
+                // atomic_set) into the local symmetric memory, then read the
+                // published value locally.  A remote shmem_uint32_atomic_fetch
+                // return value would read src's own copy of the slot (which
+                // is 0), not our copy.
                 progress_to(src);
                 std::uint32_t const produced = produced_beg_[w];
                 std::uint32_t const consumed = consumed_locals_[src];
@@ -280,7 +279,7 @@ namespace hpx::parcelset::policies::openshmem {
             return -1;
         }
 
-        // progress_to(peer): a remote atomic_fetch to the peer PUSHES the
+        // progress_to(peer): a remote atomic_fetch to the peer "pushes" the
         // peer's inbound stores into our local symmetric memory (the
         // validated delivery rule).  Called inside every blocking wait.
         void progress_to(std::size_t const peer) const noexcept
@@ -354,7 +353,7 @@ namespace hpx::parcelset::policies::openshmem {
             produced_locals_[dst_pe] = produced;    // update our mirror
             shmem_fence();
 
-            // DELIVERY PUSH: issue a remote atomic_fetch to the peer right
+            // delivery (push): issue a remote atomic_fetch to the peer right
             // after publishing produced, so our inbound stores (the
             // atomic_set we just posted onto dst) are forced into dst's local
             // view — the same ping-pong the validated harness relies on when
@@ -385,7 +384,7 @@ namespace hpx::parcelset::policies::openshmem {
             }
 
             std::size_t const slot = consumed % slots_per_dst;
-            // Read from src's OWN per-src ring in our shared rx pool
+            // Read from src's per-src ring in our shared rx pool
             // ((src_pe * slots + slot) * mtu_).  The sender keys its landing
             // ring by its own pe (== our src_pe), so each sender has a
             // disjoint ring and a chunk from one source is never

--- a/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/receiver.hpp
+++ b/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/receiver.hpp
@@ -20,9 +20,9 @@
 
 #include <shmem.h>
 
-namespace hpx::parcelset::policies::openshmem {
-
 #include <hpx/parcelport_openshmem/mailbox_array.hpp>
+
+namespace hpx::parcelset::policies::openshmem {
 
     template <typename Parcelport>
     struct receiver

--- a/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/receiver.hpp
+++ b/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/receiver.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2025 Hartmut Kaiser
+//  Copyright (c) 2025 Christopher Taylor
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/receiver.hpp
+++ b/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/receiver.hpp
@@ -1,0 +1,126 @@
+//  Copyright (c) 2025 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_OPENSHMEM)
+#include <hpx/assert.hpp>
+#include <hpx/modules/thread_support.hpp>
+#include <hpx/parcelport_openshmem/receiver_connection.hpp>
+
+#include <cstddef>
+#include <deque>
+#include <memory>
+#include <set>
+
+#include <shmem.h>
+
+namespace hpx::parcelset::policies::openshmem {
+
+#include <hpx/parcelport_openshmem/mailbox_array.hpp>
+
+    template <typename Parcelport>
+    struct receiver
+    {
+        using connection_type = receiver_connection<Parcelport>;
+        using connection_ptr = std::shared_ptr<connection_type>;
+        using connection_list = std::deque<connection_ptr>;
+
+        explicit constexpr receiver(Parcelport& pp) noexcept
+          : pp_(pp)
+        {
+        }
+
+        void run() noexcept {}
+
+        // True if there are still partially received connections being
+        // processed (used by do_stop()). Called only from do_stop() (never
+        // from the progress thread), so a blocking lock is safe and avoids
+        // spurious "empty" results under contention.
+        bool has_pending() noexcept
+        {
+            std::unique_lock l(connections_mtx_);
+            return !connections_.empty();
+        }
+
+        bool background_work() noexcept
+        {
+            bool has_work = false;
+
+            connection_ptr connection = accept();
+            if (connection)
+            {
+                receive_messages(HPX_MOVE(connection));
+                return true;
+            }
+
+            if (!connection)
+            {
+                std::unique_lock l(connections_mtx_, std::try_to_lock);
+                if (l.owns_lock() && !connections_.empty())
+                {
+                    connection = HPX_MOVE(connections_.front());
+                    connections_.pop_front();
+                }
+            }
+
+            if (connection)
+            {
+                receive_messages(HPX_MOVE(connection));
+                has_work = true;
+            }
+
+            return has_work;
+        }
+
+        void receive_messages(connection_ptr connection) noexcept
+        {
+            int const src = connection->src();
+            if (!connection->receive())
+            {
+                std::unique_lock l(connections_mtx_);
+                connections_.push_back(HPX_MOVE(connection));
+            }
+            else
+            {
+                std::unique_lock l(active_mtx_);
+                active_connections_.erase(src);
+            }
+        }
+
+        connection_ptr accept() noexcept
+        {
+            auto& mailboxes = pp_.get_mailboxes();
+
+            int const pe = mailboxes.try_detect_pe_notification();
+            if (pe < 0)
+                return connection_ptr();
+
+            std::size_t const src = static_cast<std::size_t>(pe);
+            {
+                std::unique_lock l(active_mtx_);
+                if (active_connections_.count(src))
+                    return connection_ptr();
+                active_connections_.insert(src);
+            }
+
+            return std::make_shared<connection_type>(
+                pe, mailboxes, &pp_);
+        }
+
+        Parcelport& pp_;
+
+        hpx::spinlock connections_mtx_;
+        connection_list connections_;
+
+        hpx::spinlock active_mtx_;
+        std::set<int> active_connections_;
+    };
+}    // namespace hpx::parcelset::policies::openshmem
+
+#endif

--- a/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/receiver.hpp
+++ b/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/receiver.hpp
@@ -109,8 +109,7 @@ namespace hpx::parcelset::policies::openshmem {
                 active_connections_.insert(src);
             }
 
-            return std::make_shared<connection_type>(
-                pe, mailboxes, &pp_);
+            return std::make_shared<connection_type>(pe, mailboxes, &pp_);
         }
 
         Parcelport& pp_;

--- a/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/receiver_connection.hpp
+++ b/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/receiver_connection.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2025 Hartmut Kaiser
+//  Copyright (c) 2026 Christopher Taylor
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/receiver_connection.hpp
+++ b/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/receiver_connection.hpp
@@ -1,0 +1,285 @@
+//  Copyright (c) 2025 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_OPENSHMEM)
+#include <hpx/assert.hpp>
+#include <hpx/parcelset/decode_parcels.hpp>
+#include <hpx/parcelset/parcel_buffer.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <utility>
+#include <vector>
+
+namespace hpx::parcelset::policies::openshmem {
+
+    namespace detail {
+
+        struct message_header
+        {
+            std::uint64_t size;
+            std::uint64_t data_size;
+            std::uint32_t num_chunks;
+            std::uint32_t chunk_index;
+            std::uint32_t total_size_low;
+            std::uint32_t total_size_high;
+        };
+
+        static_assert(sizeof(message_header) % 8 == 0,
+            "message_header must be 8-byte aligned");
+    }    // namespace detail
+
+#include <hpx/parcelport_openshmem/mailbox_array.hpp>
+#include <hpx/parcelset/decode_parcels.hpp>
+
+    template <typename Parcelport>
+    struct receiver_connection
+    {
+    private:
+        enum class connection_state : std::uint8_t
+        {
+            initialized = 1,
+            rcvd_header = 2,
+            collecting = 3,
+            decoded = 4
+        };
+
+        using buffer_type = parcel_buffer<>;
+
+    public:
+        receiver_connection(
+            int src, mailbox_array& mailboxes, Parcelport* pp)
+          : state_(connection_state::initialized)
+          , src_(src)
+          , mailboxes_(mailboxes)
+          , pp_(pp)
+          , expected_chunks_(0)
+          , received_chunks_(0)
+          , recv_buf_(mailboxes.mtu())
+        {
+        }
+
+        constexpr int src() const noexcept
+        {
+            return src_;
+        }
+
+        bool is_multi_chunk() const noexcept
+        {
+            return expected_chunks_ > 1;
+        }
+
+        bool receive() noexcept
+        {
+            switch (state_)
+            {
+            case connection_state::initialized:
+                return receive_header();
+
+            case connection_state::rcvd_header:
+                return decode_or_collect();
+
+            case connection_state::collecting:
+                return collect_chunks();
+
+            case connection_state::decoded:
+                return true;
+
+            default:
+                return false;
+            }
+        }
+
+    private:
+        bool receive_header() noexcept
+        {
+            std::size_t const src_pe =
+                static_cast<std::size_t>(src_);
+
+            if (!mailboxes_.receive_(src_pe, recv_buf_.data(), mailboxes_.mtu()))
+            {
+                return false;
+            }
+
+            detail::message_header header;
+            std::memcpy(&header, recv_buf_.data(), sizeof(header));
+
+            if (header.num_chunks == 0)
+            {
+                return false;
+            }
+
+            buffer_.size_ = header.size;
+            buffer_.data_size_ = header.data_size;
+            buffer_.num_chunks_ = std::make_pair(0u, 0u);
+
+            expected_chunks_ = header.num_chunks;
+            received_chunks_ = 0;
+
+            std::size_t const header_size = sizeof(detail::message_header);
+
+            if (header.num_chunks == 1)
+            {
+                if (header.size > 0)
+                {
+                    buffer_.data_.resize(header.size);
+                    std::memcpy(buffer_.data_.data(),
+                        recv_buf_.data() + header_size, header.size);
+                }
+
+                state_ = connection_state::rcvd_header;
+                return decode_parcels(0);
+            }
+
+            std::size_t const mtu = mailboxes_.mtu();
+            std::size_t const payload_size = mtu - header_size;
+
+            std::uint64_t const total_size =
+                (static_cast<std::uint64_t>(header.total_size_high) << 32) |
+                header.total_size_low;
+
+            chunks_.clear();
+            chunks_.resize(header.num_chunks);
+
+            if (header.chunk_index >= chunks_.size())
+            {
+                return false;
+            }
+
+            std::size_t const chunk_size =
+                (header.chunk_index == header.num_chunks - 1) ?
+                (total_size - (header.chunk_index * payload_size)) :
+                payload_size;
+
+            chunks_[header.chunk_index].resize(chunk_size);
+            std::memcpy(chunks_[header.chunk_index].data(),
+                recv_buf_.data() + header_size, chunk_size);
+            received_chunks_++;
+
+            if (received_chunks_ == expected_chunks_)
+            {
+                return reassemble_and_decode();
+            }
+
+            state_ = connection_state::collecting;
+            return false;
+        }
+
+        bool decode_or_collect() noexcept
+        {
+            if (expected_chunks_ > 1)
+            {
+                return collect_chunks();
+            }
+            return decode_parcels(0);
+        }
+
+        bool collect_chunks() noexcept
+        {
+            std::size_t const src_pe =
+                static_cast<std::size_t>(src_);
+
+            if (!mailboxes_.receive_(src_pe, recv_buf_.data(), mailboxes_.mtu()))
+            {
+                return false;
+            }
+
+            detail::message_header header;
+            std::memcpy(&header, recv_buf_.data(), sizeof(header));
+
+            std::size_t const header_size = sizeof(detail::message_header);
+            std::size_t const mtu = mailboxes_.mtu();
+            std::size_t const payload_size = mtu - header_size;
+
+            std::uint64_t const total_size =
+                (static_cast<std::uint64_t>(header.total_size_high) << 32) |
+                header.total_size_low;
+
+            if (chunks_.empty())
+            {
+                chunks_.resize(header.num_chunks);
+                expected_chunks_ = header.num_chunks;
+            }
+
+            if (header.chunk_index < chunks_.size())
+            {
+                std::size_t const chunk_size =
+                    (header.chunk_index == header.num_chunks - 1) ?
+                    (total_size - (header.chunk_index * payload_size)) :
+                    payload_size;
+
+                if (chunks_[header.chunk_index].empty())
+                {
+                    chunks_[header.chunk_index].resize(chunk_size);
+                    std::memcpy(chunks_[header.chunk_index].data(),
+                        recv_buf_.data() + header_size, chunk_size);
+                    received_chunks_++;
+                }
+            }
+
+            if (received_chunks_ == expected_chunks_)
+            {
+                return reassemble_and_decode();
+            }
+
+            return false;
+        }
+
+        bool reassemble_and_decode() noexcept
+        {
+            std::size_t total_size = 0;
+            for (auto const& chunk : chunks_)
+            {
+                total_size += chunk.size();
+            }
+
+            buffer_.data_.resize(total_size);
+            std::size_t offset = 0;
+            for (auto const& chunk : chunks_)
+            {
+                std::memcpy(
+                    buffer_.data_.data() + offset, chunk.data(), chunk.size());
+                offset += chunk.size();
+            }
+
+            chunks_.clear();
+
+            return decode_parcels(0);
+        }
+
+        bool decode_parcels(std::size_t num_thread) noexcept
+        {
+            HPX_ASSERT(!buffer_.data_.empty());
+
+            std::vector<parcel> parcels = hpx::parcelset::decode_parcels(
+                *pp_, HPX_MOVE(buffer_), num_thread);
+
+            hpx::parcelset::handle_received_parcels(
+                HPX_MOVE(parcels), num_thread);
+
+            state_ = connection_state::decoded;
+            return true;
+        }
+
+        connection_state state_;
+        int src_;
+        mailbox_array& mailboxes_;
+        Parcelport* pp_;
+
+        buffer_type buffer_;
+        std::vector<std::vector<char>> chunks_;
+        std::uint32_t expected_chunks_;
+        std::uint32_t received_chunks_;
+        std::vector<unsigned char> recv_buf_;
+    };
+}    // namespace hpx::parcelset::policies::openshmem
+
+#endif

--- a/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/receiver_connection.hpp
+++ b/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/receiver_connection.hpp
@@ -55,8 +55,7 @@ namespace hpx::parcelset::policies::openshmem {
         using buffer_type = parcel_buffer<>;
 
     public:
-        receiver_connection(
-            int src, mailbox_array& mailboxes, Parcelport* pp)
+        receiver_connection(int src, mailbox_array& mailboxes, Parcelport* pp)
           : state_(connection_state::initialized)
           , src_(src)
           , mailboxes_(mailboxes)
@@ -101,10 +100,10 @@ namespace hpx::parcelset::policies::openshmem {
     private:
         bool receive_header() noexcept
         {
-            std::size_t const src_pe =
-                static_cast<std::size_t>(src_);
+            std::size_t const src_pe = static_cast<std::size_t>(src_);
 
-            if (!mailboxes_.receive_(src_pe, recv_buf_.data(), mailboxes_.mtu()))
+            if (!mailboxes_.receive_(
+                    src_pe, recv_buf_.data(), mailboxes_.mtu()))
             {
                 return false;
             }
@@ -184,10 +183,10 @@ namespace hpx::parcelset::policies::openshmem {
 
         bool collect_chunks() noexcept
         {
-            std::size_t const src_pe =
-                static_cast<std::size_t>(src_);
+            std::size_t const src_pe = static_cast<std::size_t>(src_);
 
-            if (!mailboxes_.receive_(src_pe, recv_buf_.data(), mailboxes_.mtu()))
+            if (!mailboxes_.receive_(
+                    src_pe, recv_buf_.data(), mailboxes_.mtu()))
             {
                 return false;
             }

--- a/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/sender.hpp
+++ b/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/sender.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2025 Hartmut Kaiser
+//  Copyright (c) 2026 Christopher Taylor
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/sender.hpp
+++ b/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/sender.hpp
@@ -1,0 +1,130 @@
+//  Copyright (c) 2025 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_OPENSHMEM)
+#include <hpx/assert.hpp>
+#include <hpx/modules/errors.hpp>
+#include <hpx/modules/functional.hpp>
+#include <hpx/modules/synchronization.hpp>
+#include <hpx/modules/thread_support.hpp>
+#include <hpx/parcelport_openshmem/sender_connection.hpp>
+#include <hpx/parcelset/parcelset_fwd.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <deque>
+#include <iterator>
+#include <list>
+#include <memory>
+#include <mutex>
+#include <utility>
+#include <vector>
+
+namespace hpx::parcelset::policies::openshmem {
+
+    struct sender_connection;
+
+    struct sender
+    {
+        using connection_type = sender_connection;
+        using connection_ptr = std::shared_ptr<connection_type>;
+        using connection_list = std::deque<connection_ptr>;
+
+        explicit sender(void* mailboxes) noexcept
+          : mailboxes_(mailboxes)
+        {
+        }
+
+        sender(sender const&) = delete;
+        sender(sender&&) = delete;
+        sender& operator=(sender const&) = delete;
+        sender& operator=(sender&&) = delete;
+
+        constexpr static void run() noexcept {}
+
+        connection_ptr create_connection(int dest, void* pp)
+        {
+            return std::make_shared<connection_type>(
+                this, dest, static_cast<mailbox_array*>(pp));
+        }
+
+        // Enqueue a connection to be driven by the single progress thread.
+        // Safe to call from any HPX thread.
+        void add(connection_ptr const& ptr)
+        {
+            std::unique_lock l(connections_mtx_);
+            connections_.push_back(ptr);
+        }
+
+        // True if the progress thread still has queued work to drain (used
+        // by do_stop()). A connection that is in flight is always re-queued
+        // after each poll, so checking the queue is sufficient. Called only
+        // from do_stop() (never from the progress thread), so a blocking
+        // lock is safe and avoids spurious "empty" results under contention.
+        bool has_pending() noexcept
+        {
+            std::unique_lock l(connections_mtx_);
+            return !connections_.empty();
+        }
+
+        // Drive one connection to completion.  Called only from the single
+        // progress thread.  poll_send() blocks until all chunks are sent
+        // and acked (the shmem_memcpy protocol), then delivers the
+        // completion callback.  Returns true if any progress was made.
+        bool background_work() noexcept
+        {
+            connection_ptr connection;
+            {
+                std::unique_lock l(connections_mtx_, std::try_to_lock);
+                if (l && !connections_.empty())
+                {
+                    connection = HPX_MOVE(connections_.front());
+                    connections_.pop_front();
+                }
+            }
+
+            if (!connection)
+            {
+                return false;
+            }
+
+            // poll_send() blocks until the entire multi-chunk transfer
+            // completes (each chunk: putmem + signal + wait ack).
+            connection->poll_send();
+            return true;
+        }
+
+        using parcel_buffer_type = parcel_buffer<>;
+        using callback_fn_type =
+            hpx::move_only_function<void(error_code const&)>;
+
+        // Enqueue a parcel for sending; the actual transfer happens on the
+        // single progress thread. Returns immediately (non-blocking), which
+        // is required since this may be called from any HPX thread while
+        // all shmem_* calls must stay on the progress thread.
+        bool send_immediate(parcelset::locality const& dest,
+            parcel_buffer_type buffer, callback_fn_type&& callbackFn)
+        {
+            int dest_rank = dest.get<locality>().rank();
+            auto connection = create_connection(dest_rank, mailboxes_);
+            connection->buffer_ = HPX_MOVE(buffer);
+            connection->async_write(HPX_MOVE(callbackFn), nullptr);
+            add(connection);
+            return true;
+        }
+
+    private:
+        void* mailboxes_;
+        hpx::spinlock connections_mtx_;
+        connection_list connections_;
+    };
+}    // namespace hpx::parcelset::policies::openshmem
+
+#endif

--- a/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/sender.hpp
+++ b/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/sender.hpp
@@ -76,8 +76,8 @@ namespace hpx::parcelset::policies::openshmem {
 
         // Drive one connection to completion.  Called only from the single
         // progress thread.  poll_send() blocks until all chunks are sent
-        // and acked (the shmem_memcpy protocol), then delivers the
-        // completion callback.  Returns true if any progress was made.
+        // and acked, then delivers the completion callback. Returns true
+        // if any progress was made.
         bool background_work() noexcept
         {
             connection_ptr connection;

--- a/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/sender_connection.hpp
+++ b/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/sender_connection.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2025 Hartmut Kaiser
+//  Copyright (c) 2026 Christopher Taylor
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/sender_connection.hpp
+++ b/libs/full/parcelport_openshmem/include/hpx/parcelport_openshmem/sender_connection.hpp
@@ -1,0 +1,114 @@
+//  Copyright (c) 2025 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_OPENSHMEM)
+#include <hpx/assert.hpp>
+#include <hpx/modules/functional.hpp>
+#include <hpx/modules/parcelset_base.hpp>
+#include <hpx/parcelport_openshmem/locality.hpp>
+#include <hpx/parcelset/parcelport_connection.hpp>
+#include <hpx/parcelset/parcelset_fwd.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#include <hpx/parcelport_openshmem/mailbox_array.hpp>
+
+namespace hpx::parcelset::policies::openshmem {
+
+    struct sender;
+
+    struct sender_connection
+      : parcelset::parcelport_connection<sender_connection>
+    {
+    private:
+        using sender_type = sender;
+
+        using base_type = parcelset::parcelport_connection<sender_connection>;
+
+    public:
+        sender_connection(sender_type* s, int dst, void* mailboxes)
+          : sender_(s)
+          , dst_(dst)
+          , mailboxes_(static_cast<mailbox_array*>(mailboxes))
+          , there_(parcelset::locality(locality(dst_)))
+        {
+        }
+
+        constexpr parcelset::locality const& destination() const noexcept
+        {
+            return there_;
+        }
+
+        constexpr int dst() const noexcept
+        {
+            return dst_;
+        }
+
+        static constexpr void verify_(
+            parcelset::locality const& /* parcel_locality_id */) noexcept
+        {
+        }
+
+        using handler_type = hpx::move_only_function<void(error_code const&)>;
+        using post_handler_type = hpx::move_only_function<void(
+            error_code const&, parcelset::locality const&,
+            std::shared_ptr<sender_connection>)>;
+
+        // Store the completion handlers and prepare the parcel for sending.
+        // The actual sending is driven by poll_send() from the single
+        // progress thread, which keeps all shmem_* calls on that thread
+        // (required by SHMEM_THREAD_SERIALIZED).
+        void async_write(handler_type&& handler,
+            post_handler_type&& parcel_postprocess) noexcept
+        {
+            HPX_ASSERT(!handler_);
+            HPX_ASSERT(!buffer_.data_.empty());
+
+            handler_ = HPX_MOVE(handler);
+            postprocess_handler_ = HPX_MOVE(parcel_postprocess);
+
+            prepare();
+        }
+
+        // Blocking send driver.  Sends all chunks (each via the blocking
+        // mailbox_array::send()) and returns true when the connection is
+        // complete.  Must be called from the single progress thread only.
+        bool poll_send() noexcept;
+
+    private:
+        void prepare() noexcept;
+        void stage_chunk() noexcept;
+        void finish() noexcept;
+        void handle_local_send() noexcept;
+
+        friend struct sender;
+
+        sender_type* sender_;
+        int dst_;
+        mailbox_array* mailboxes_;
+
+        parcelset::locality there_;
+
+        handler_type handler_;
+        post_handler_type postprocess_handler_;
+
+        std::uint32_t num_chunks_ = 0;
+        std::uint32_t chunk_idx_ = 0;
+        std::size_t total_data_size_ = 0;
+        std::size_t available_payload_ = 0;
+    };
+}    // namespace hpx::parcelset::policies::openshmem
+
+#endif

--- a/libs/full/parcelport_openshmem/src/locality.cpp
+++ b/libs/full/parcelport_openshmem/src/locality.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2025 Hartmut Kaiser
+//  Copyright (c) 2026 Christopher Taylor
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/full/parcelport_openshmem/src/locality.cpp
+++ b/libs/full/parcelport_openshmem/src/locality.cpp
@@ -1,0 +1,36 @@
+//  Copyright (c) 2025 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_OPENSHMEM)
+#include <hpx/modules/serialization.hpp>
+#include <hpx/modules/util.hpp>
+#include <hpx/parcelport_openshmem/locality.hpp>
+
+#include <ostream>
+
+namespace hpx::parcelset::policies::openshmem {
+
+    void locality::save(serialization::output_archive& ar) const
+    {
+        ar << rank_;
+    }
+
+    void locality::load(serialization::input_archive& ar)
+    {
+        ar >> rank_;
+    }
+
+    std::ostream& operator<<(std::ostream& os, locality const& loc) noexcept
+    {
+        hpx::util::ios_flags_saver ifs(os);
+        os << loc.rank_;
+        return os;
+    }
+}    // namespace hpx::parcelset::policies::openshmem
+
+#endif

--- a/libs/full/parcelport_openshmem/src/locality.cpp
+++ b/libs/full/parcelport_openshmem/src/locality.cpp
@@ -25,7 +25,7 @@ namespace hpx::parcelset::policies::openshmem {
         ar >> rank_;
     }
 
-    std::ostream& operator<<(std::ostream& os, locality const& loc) noexcept
+    std::ostream& operator<<(std::ostream& os, locality const& loc)
     {
         hpx::util::ios_flags_saver ifs(os);
         os << loc.rank_;

--- a/libs/full/parcelport_openshmem/src/parcelport_openshmem.cpp
+++ b/libs/full/parcelport_openshmem/src/parcelport_openshmem.cpp
@@ -27,6 +27,10 @@
 #include <hpx/parcelset/parcelport_impl.hpp>
 #include <hpx/plugin_factories/parcelport_factory.hpp>
 
+#include <asio/io_context.hpp>
+#include <asio/post.hpp>
+#include <asio/version.hpp>
+
 #include <atomic>
 #include <cstddef>
 #include <cstdint>

--- a/libs/full/parcelport_openshmem/src/parcelport_openshmem.cpp
+++ b/libs/full/parcelport_openshmem/src/parcelport_openshmem.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2025 Hartmut Kaiser
+//  Copyright (c) 2026 Christopher Taylor
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/full/parcelport_openshmem/src/parcelport_openshmem.cpp
+++ b/libs/full/parcelport_openshmem/src/parcelport_openshmem.cpp
@@ -248,13 +248,12 @@ namespace hpx::parcelset {
                         }
                         else
                         {
-                            // Deliberate hot spin (no OS yield): mirrors the
-                            // validated shmem_mailbox_credits_with_pages
-                            // harness, where the receiver continuously pumps
-                            // the transport so a remote atomic_set produced is
-                            // reliably pulled into this PE's view. Yielding
-                            // starves OSHMEM/UCX progress and the pending
-                            // cross-PE store is never observed.
+                            // Deliberate hot spin (no OS yield).
+                            // The receiver continuously pumps the transport
+                            // so a remote atomic_set produced is reliably
+                            // pulled into this PE's view. Yielding starves
+                            // OpenSHMEM progress and the pending cross-PE
+                            // store is never observed.
                             ++k;
                         }
                     }

--- a/libs/full/parcelport_openshmem/src/parcelport_openshmem.cpp
+++ b/libs/full/parcelport_openshmem/src/parcelport_openshmem.cpp
@@ -125,12 +125,11 @@ namespace hpx::parcelset {
                 // the pool runs the progress loop (io_pool_size is forced to
                 // 1 by the configuration below).
 #if ASIO_VERSION >= 103400
-                ::asio::post(
-                    io_service_pool_.get_io_service(0),
+                ::asio::post(io_service_pool_.get_io_service(0),
                     hpx::bind(&parcelport::io_service_work, this));
 #else
-                io_service_pool_.get_io_service(0)
-                    .post(hpx::bind(&parcelport::io_service_work, this));
+                io_service_pool_.get_io_service(0).post(
+                    hpx::bind(&parcelport::io_service_work, this));
 #endif
                 return true;
             }
@@ -179,8 +178,7 @@ namespace hpx::parcelset {
             // All shmem_* calls happen on the single progress thread
             // (io_service_work). HPX threads must not call into the shmem
             // transport, so this is a no-op.
-            bool background_work(
-                std::size_t, parcelport_background_mode)
+            bool background_work(std::size_t, parcelport_background_mode)
             {
                 return false;
             }

--- a/libs/full/parcelport_openshmem/src/parcelport_openshmem.cpp
+++ b/libs/full/parcelport_openshmem/src/parcelport_openshmem.cpp
@@ -1,0 +1,318 @@
+//  Copyright (c) 2025 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_OPENSHMEM)
+#include <hpx/modules/command_line_handling.hpp>
+#include <hpx/modules/errors.hpp>
+#include <hpx/modules/execution_base.hpp>
+#include <hpx/modules/functional.hpp>
+#include <hpx/modules/parcelset_base.hpp>
+#include <hpx/modules/plugin.hpp>
+#include <hpx/modules/resource_partitioner.hpp>
+#include <hpx/modules/runtime_configuration.hpp>
+#include <hpx/modules/runtime_local.hpp>
+#include <hpx/modules/synchronization.hpp>
+#include <hpx/modules/util.hpp>
+#include <hpx/openshmem_base/openshmem_environment.hpp>
+#include <hpx/parcelport_openshmem/locality.hpp>
+#include <hpx/parcelport_openshmem/mailbox_array.hpp>
+#include <hpx/parcelport_openshmem/receiver.hpp>
+#include <hpx/parcelport_openshmem/sender.hpp>
+#include <hpx/parcelport_openshmem/sender_connection.hpp>
+#include <hpx/parcelset/parcelport_impl.hpp>
+#include <hpx/plugin_factories/parcelport_factory.hpp>
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <type_traits>
+
+#include <shmem.h>
+
+#include <hpx/config/warnings_prefix.hpp>
+
+namespace hpx::parcelset {
+
+    namespace policies::openshmem {
+        class HPX_EXPORT parcelport;
+    }    // namespace policies::openshmem
+
+    template <>
+    struct connection_handler_traits<policies::openshmem::parcelport>
+    {
+        using connection_type = policies::openshmem::sender_connection;
+        using send_early_parcel = std::true_type;
+        using do_background_work = std::true_type;
+        using send_immediate_parcels = std::true_type;
+        using is_connectionless = std::true_type;
+
+        static constexpr char const* type() noexcept
+        {
+            return "openshmem";
+        }
+
+        static constexpr char const* pool_name() noexcept
+        {
+            return "parcel-pool-openshmem";
+        }
+
+        static constexpr char const* pool_name_postfix() noexcept
+        {
+            return "-openshmem";
+        }
+    };
+
+    namespace policies::openshmem {
+
+        class HPX_EXPORT parcelport : public parcelport_impl<parcelport>
+        {
+            using base_type = parcelport_impl<parcelport>;
+
+            static parcelset::locality here(std::size_t my_pe)
+            {
+                return parcelset::locality(
+                    locality(static_cast<std::int32_t>(my_pe)));
+            }
+
+            static std::size_t mtu(util::runtime_configuration const& ini)
+            {
+                return hpx::util::get_entry_as<std::size_t>(
+                    ini, "hpx.parcel.openshmem.mtu", HPX_PARCEL_OPENSHMEM_MTU);
+            }
+
+        public:
+            using sender_type = sender;
+            parcelport(util::runtime_configuration const& ini,
+                threads::policies::callback_notifier const& notifier)
+              : base_type(ini, here(0), notifier)
+              , stopped_(false)
+              , num_pes_(static_cast<std::size_t>(shmem_n_pes()))
+              , my_pe_(static_cast<std::size_t>(shmem_my_pe()))
+              , mtu_(mtu(ini))
+              , mailboxes_(num_pes_, my_pe_, mtu_)
+              , sender_(&mailboxes_)
+              , receiver_(*this)
+            {
+                here_ = here(my_pe_);
+            }
+
+            parcelport(parcelport const&) = delete;
+            parcelport(parcelport&&) = delete;
+            parcelport& operator=(parcelport const&) = delete;
+            parcelport& operator=(parcelport&&) = delete;
+
+            ~parcelport() override = default;
+
+            bool do_run()
+            {
+                sender_.run();
+                receiver_.run();
+
+                // All shmem_* calls must stay on a single thread to satisfy
+                // SHMEM_THREAD_SERIALIZED, so only the first io_service of
+                // the pool runs the progress loop (io_pool_size is forced to
+                // 1 by the configuration below).
+#if ASIO_VERSION >= 103400
+                ::asio::post(
+                    io_service_pool_.get_io_service(0),
+                    hpx::bind(&parcelport::io_service_work, this));
+#else
+                io_service_pool_.get_io_service(0)
+                    .post(hpx::bind(&parcelport::io_service_work, this));
+#endif
+                return true;
+            }
+
+            void do_stop()
+            {
+                // Wait for the progress thread to drain all queued work. We
+                // must not drive send/receive from this thread as that would
+                // call shmem_* outside the single progress thread.
+                std::size_t max_iter = 1000;
+                while (sender_.has_pending() || receiver_.has_pending())
+                {
+                    if (!threads::get_self_ptr() || max_iter-- == 0)
+                        break;
+                    hpx::this_thread::suspend(
+                        hpx::threads::thread_schedule_state::pending,
+                        "openshmem::parcelport::do_stop");
+                }
+
+                stopped_.store(true, std::memory_order_release);
+            }
+
+            std::string get_locality_name() const override
+            {
+                return std::to_string(my_pe_);
+            }
+
+            std::shared_ptr<sender_connection> create_connection(
+                parcelset::locality const& l, error_code&)
+            {
+                int const dest_rank = l.get<locality>().rank();
+                return sender_.create_connection(dest_rank, &mailboxes_);
+            }
+
+            parcelset::locality agas_locality(
+                util::runtime_configuration const&) const override
+            {
+                return parcelset::locality(locality(0));
+            }
+
+            parcelset::locality create_locality() const override
+            {
+                return parcelset::locality(locality());
+            }
+
+            // All shmem_* calls happen on the single progress thread
+            // (io_service_work). HPX threads must not call into the shmem
+            // transport, so this is a no-op.
+            bool background_work(
+                std::size_t, parcelport_background_mode)
+            {
+                return false;
+            }
+
+            constexpr bool can_send_immediate() const noexcept
+            {
+                return true;
+            }
+
+            mailbox_array const& get_mailboxes() const noexcept
+            {
+                return mailboxes_;
+            }
+
+            mailbox_array& get_mailboxes() noexcept
+            {
+                return mailboxes_;
+            }
+
+            constexpr std::size_t num_pes() const noexcept
+            {
+                return num_pes_;
+            }
+
+            constexpr std::size_t my_pe() const noexcept
+            {
+                return my_pe_;
+            }
+
+            constexpr std::size_t mtu() const noexcept
+            {
+                return mtu_;
+            }
+
+            bool send_immediate(parcelset::parcelport* pp,
+                parcelset::locality const& dest,
+                sender::parcel_buffer_type buffer,
+                sender::callback_fn_type&& callbackFn)
+            {
+                (void) pp;
+                return sender_.send_immediate(
+                    dest, HPX_MOVE(buffer), HPX_MOVE(callbackFn));
+            }
+
+        private:
+            void io_service_work()
+            {
+                std::size_t k = 0;
+                std::size_t busy_loop = 0;
+                constexpr std::size_t max_busy_loop = 1000;
+
+                while (!stopped_.load(std::memory_order_acquire))
+                {
+                    // Check for incoming data first (non-blocking scan +
+                    // fast receive_()) so that incoming parcels are not
+                    // starved by a blocking send on the other side.
+                    bool has_work = receiver_.background_work();
+                    has_work = sender_.background_work() || has_work;
+                    if (has_work)
+                    {
+                        k = 0;
+                        busy_loop = 0;
+                    }
+                    else
+                    {
+                        if (busy_loop < max_busy_loop)
+                        {
+                            ++busy_loop;
+                        }
+                        else
+                        {
+                            // Deliberate hot spin (no OS yield): mirrors the
+                            // validated shmem_mailbox_credits_with_pages
+                            // harness, where the receiver continuously pumps
+                            // the transport so a remote atomic_set produced is
+                            // reliably pulled into this PE's view. Yielding
+                            // starves OSHMEM/UCX progress and the pending
+                            // cross-PE store is never observed.
+                            ++k;
+                        }
+                    }
+                }
+            }
+
+            std::atomic<bool> stopped_;
+
+            std::size_t num_pes_;
+            std::size_t my_pe_;
+            std::size_t mtu_;
+            mailbox_array mailboxes_;
+
+            sender sender_;
+            receiver<parcelport> receiver_;
+        };
+    }    // namespace policies::openshmem
+}    // namespace hpx::parcelset
+
+#include <hpx/config/warnings_suffix.hpp>
+
+template <>
+struct hpx::traits::plugin_config_data<
+    hpx::parcelset::policies::openshmem::parcelport>
+{
+    static constexpr char const* priority() noexcept
+    {
+        return "100";
+    }
+
+    static void init(int* argc, char*** argv, util::command_line_handling& cfg)
+    {
+        util::openshmem_environment::init(argc, argv, cfg.rtcfg_);
+        cfg.num_localities_ =
+            static_cast<std::size_t>(util::openshmem_environment::size());
+        cfg.node_ =
+            static_cast<std::size_t>(util::openshmem_environment::rank());
+    }
+
+    static constexpr void init(hpx::resource::partitioner&) noexcept {}
+
+    static void destroy() noexcept
+    {
+        util::openshmem_environment::finalize();
+    }
+
+    static constexpr char const* call() noexcept
+    {
+        return "mtu = "
+               "${HPX_HAVE_PARCELPORT_OPENSHMEM_MTU:65536}\n"
+               // SHMEM_THREAD_SERIALIZED requires all shmem_* calls to
+               // happen on a single thread, so the pool must not be larger
+               // than one.
+               "io_pool_size = 1\n";
+    }
+};
+
+HPX_REGISTER_PARCELPORT(
+    hpx::parcelset::policies::openshmem::parcelport, openshmem)
+
+#endif

--- a/libs/full/parcelport_openshmem/src/sender_connection.cpp
+++ b/libs/full/parcelport_openshmem/src/sender_connection.cpp
@@ -49,8 +49,7 @@ namespace hpx::parcelset::policies::openshmem {
         available_payload_ = mailboxes.mtu() - detail::header_size;
 
         num_chunks_ = static_cast<std::uint32_t>(
-            (total_data_size_ + available_payload_ - 1) /
-            available_payload_);
+            (total_data_size_ + available_payload_ - 1) / available_payload_);
         if (num_chunks_ == 0)
         {
             num_chunks_ = 1;
@@ -71,8 +70,8 @@ namespace hpx::parcelset::policies::openshmem {
             (total_data_size_ - offset) :
             available_payload_;
 
-        unsigned char* buffer = mailboxes.get_buffer(
-            static_cast<std::size_t>(dst_));
+        unsigned char* buffer =
+            mailboxes.get_buffer(static_cast<std::size_t>(dst_));
 
         detail::message_header header{buffer_.size_, buffer_.data_size_,
             num_chunks_, chunk_idx_,
@@ -108,8 +107,7 @@ namespace hpx::parcelset::policies::openshmem {
                 (total_data_size_ - offset) :
                 available_payload_;
 
-            mailboxes_->send(
-                static_cast<std::size_t>(dst_),
+            mailboxes_->send(static_cast<std::size_t>(dst_),
                 detail::header_size + chunk_size);
         }
 
@@ -152,8 +150,8 @@ namespace hpx::parcelset::policies::openshmem {
                 (total_data_size - offset) :
                 available_payload;
 
-            unsigned char* buffer = mailboxes.get_buffer(
-                static_cast<std::size_t>(dst_));
+            unsigned char* buffer =
+                mailboxes.get_buffer(static_cast<std::size_t>(dst_));
 
             detail::message_header header{buffer_.size_, buffer_.data_size_,
                 num_chunks, chunk_idx,

--- a/libs/full/parcelport_openshmem/src/sender_connection.cpp
+++ b/libs/full/parcelport_openshmem/src/sender_connection.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2025 Hartmut Kaiser
+//  Copyright (c) 2026 Christopher Taylor
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/full/parcelport_openshmem/src/sender_connection.cpp
+++ b/libs/full/parcelport_openshmem/src/sender_connection.cpp
@@ -89,7 +89,6 @@ namespace hpx::parcelset::policies::openshmem {
 
     // Blocking send: stage each chunk and call mailboxes_.send() which
     // transfers the data and waits for the receiver's ack before returning.
-    // This is the shmem_memcpy xmt() protocol.
     bool sender_connection::poll_send() noexcept
     {
         if (dst_ == static_cast<int>(mailboxes_->my_pe()))

--- a/libs/full/parcelport_openshmem/src/sender_connection.cpp
+++ b/libs/full/parcelport_openshmem/src/sender_connection.cpp
@@ -1,0 +1,183 @@
+//  Copyright (c) 2025 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCELPORT_OPENSHMEM)
+#include <hpx/parcelport_openshmem/sender_connection.hpp>
+
+#include <cstring>
+
+#include <shmem.h>
+
+namespace hpx::parcelset::policies::openshmem {
+
+    namespace detail {
+
+        struct message_header
+        {
+            std::uint64_t size;
+            std::uint64_t data_size;
+            std::uint32_t num_chunks;
+            std::uint32_t chunk_index;
+            std::uint32_t total_size_low;
+            std::uint32_t total_size_high;
+        };
+
+        static_assert(sizeof(message_header) % 8 == 0,
+            "message_header must be 8-byte aligned");
+
+        constexpr std::size_t header_size = sizeof(message_header);
+    }    // namespace detail
+
+    void sender_connection::prepare() noexcept
+    {
+        auto& mailboxes = *mailboxes_;
+
+        buffer_.size_ = buffer_.data_.size();
+        buffer_.data_size_ = buffer_.data_.size();
+        buffer_.num_chunks_ =
+            std::make_pair(static_cast<std::uint32_t>(buffer_.chunks_.size()),
+                static_cast<std::uint32_t>(buffer_.chunks_.size()));
+
+        buffer_.transmission_chunks_.clear();
+
+        total_data_size_ = buffer_.size_;
+        available_payload_ = mailboxes.mtu() - detail::header_size;
+
+        num_chunks_ = static_cast<std::uint32_t>(
+            (total_data_size_ + available_payload_ - 1) /
+            available_payload_);
+        if (num_chunks_ == 0)
+        {
+            num_chunks_ = 1;
+        }
+
+        chunk_idx_ = 0;
+    }
+
+    // Stage one chunk: copy header + payload into the local buffer slot.
+    // The actual shmem transfer is done by the caller via send().
+    void sender_connection::stage_chunk() noexcept
+    {
+        auto& mailboxes = *mailboxes_;
+
+        std::size_t const offset = chunk_idx_ * available_payload_;
+        std::size_t const chunk_size =
+            (offset + available_payload_ > total_data_size_) ?
+            (total_data_size_ - offset) :
+            available_payload_;
+
+        unsigned char* buffer = mailboxes.get_buffer(
+            static_cast<std::size_t>(dst_));
+
+        detail::message_header header{buffer_.size_, buffer_.data_size_,
+            num_chunks_, chunk_idx_,
+            static_cast<std::uint32_t>(total_data_size_ & 0xFFFFFFFF),
+            static_cast<std::uint32_t>(total_data_size_ >> 32)};
+
+        std::memcpy(buffer, &header, sizeof(header));
+        if (chunk_size > 0)
+        {
+            std::memcpy(buffer + sizeof(header), buffer_.data_.data() + offset,
+                chunk_size);
+        }
+    }
+
+    // Blocking send: stage each chunk and call mailboxes_.send() which
+    // transfers the data and waits for the receiver's ack before returning.
+    // This is the shmem_memcpy xmt() protocol.
+    bool sender_connection::poll_send() noexcept
+    {
+        if (dst_ == static_cast<int>(mailboxes_->my_pe()))
+        {
+            handle_local_send();
+            return true;
+        }
+
+        for (std::uint32_t i = 0; i < num_chunks_; ++i)
+        {
+            chunk_idx_ = i;
+            stage_chunk();
+
+            std::size_t const offset = i * available_payload_;
+            std::size_t const chunk_size =
+                (offset + available_payload_ > total_data_size_) ?
+                (total_data_size_ - offset) :
+                available_payload_;
+
+            mailboxes_->send(
+                static_cast<std::size_t>(dst_),
+                detail::header_size + chunk_size);
+        }
+
+        finish();
+        return true;
+    }
+
+    void sender_connection::finish() noexcept
+    {
+        error_code ec;
+        handler_(ec);
+
+        hpx::move_only_function<void(error_code const&,
+            parcelset::locality const&, std::shared_ptr<sender_connection>)>
+            postprocess_handler;
+        std::swap(postprocess_handler, postprocess_handler_);
+        if (postprocess_handler)
+        {
+            postprocess_handler(ec, there_, shared_from_this());
+        }
+    }
+
+    void sender_connection::handle_local_send() noexcept
+    {
+        auto& mailboxes = *mailboxes_;
+
+        std::size_t const mtu = mailboxes.mtu();
+        std::size_t const available_payload = mtu - detail::header_size;
+
+        std::size_t const total_data_size = buffer_.size_;
+        std::uint32_t const num_chunks = static_cast<std::uint32_t>(
+            (total_data_size + available_payload - 1) / available_payload);
+
+        std::size_t offset = 0;
+
+        for (std::uint32_t chunk_idx = 0; chunk_idx < num_chunks; ++chunk_idx)
+        {
+            std::size_t const chunk_size =
+                (offset + available_payload > total_data_size) ?
+                (total_data_size - offset) :
+                available_payload;
+
+            unsigned char* buffer = mailboxes.get_buffer(
+                static_cast<std::size_t>(dst_));
+
+            detail::message_header header{buffer_.size_, buffer_.data_size_,
+                num_chunks, chunk_idx,
+                static_cast<std::uint32_t>(total_data_size & 0xFFFFFFFF),
+                static_cast<std::uint32_t>(total_data_size >> 32)};
+
+            std::memcpy(buffer, &header, sizeof(header));
+            if (chunk_size > 0)
+            {
+                std::memcpy(buffer + sizeof(header),
+                    buffer_.data_.data() + offset, chunk_size);
+            }
+
+            // publish this chunk into our own rx pool via the credit protocol
+            mailboxes.send(static_cast<std::size_t>(dst_),
+                detail::header_size + chunk_size);
+
+            offset += chunk_size;
+        }
+
+        finish();
+    }
+
+}    // namespace hpx::parcelset::policies::openshmem
+
+#endif


### PR DESCRIPTION
## Proposed Changes

  - adds openshmem parcelport support
 
## Any background context you want to provide?

The following cmake configuration of HPX is used to build the parcelport.

```
cmake -DHPX_WITH_MALLOC=tcmalloc -DHPX_WITH_PARCELPORT_OPENSHMEM=ON -DHPX_WITH_NETWORKING=ON -DHPX_WITH_FETCH_ASIO=ON -DCMAKE_CXX_COMPILER=oshcxx -DCMAKE_C_COMPILER=oshcc ..
```

Tested using the following programs.

```
oshrun -n 2 --mca osc ucx -x SMA_SYMMETRIC_SIZE=1G $NFS/hello_world_distributed --hpx:ini=hpx.parcel.openshmem.enable=1
```

```
oshrun -n 2 --mca osc ucx -x SMA_SYMMETRIC_SIZE=1G $NFS/fibonacci_futures_distributed --hpx:ini=hpx.parcel.openshmem.enable=1
```

OpenMPI's OpenSHMEM implementation is the core dependency. The OpenMPI UCX backend is a fixed requirement currently for OpenMPI's OpenSHMEM. OpenMPI's OpenSHMEM was compiled with the following configuration.

```
configure --with-threads=pthreads --disable-dlopen --with-munge --with-hwloc --with-zlib --with-libevent --enable-oshmem --with-ucx=$UCX_INSTALL_PATH --with-pmix=$PMIX_INSTALL_PATH --with-slurm=$SLURM_INSTALL_PATH --enable-orterun-prefix-by-default --enable-mca-no-build=dstore_hash,pml_ucx --enable-shared --enable-static --enable-oshmem-fortran=no
```

UCX was compiled with this configuration:

```
configure --enable-mt
```

## Checklist

Not all points below apply to all pull requests.

- [ x ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
