### PR TITLE
collectives, colocated, parcelset: drop whole-file device-code guards

### DIFF
--- a/libs/core/runtime_configuration/include/hpx/runtime_configuration/component_factory_base.hpp
+++ b/libs/core/runtime_configuration/include/hpx/runtime_configuration/component_factory_base.hpp
@@ -8,7 +8,6 @@
 
 #include <hpx/config.hpp>
 
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/runtime_configuration/component_registry_base.hpp>
 
 namespace hpx::components {
@@ -16,4 +15,3 @@ namespace hpx::components {
     HPX_CXX_CORE_EXPORT struct HPX_CORE_EXPORT component_factory_base;
 }    // namespace hpx::components
 
-#endif

--- a/libs/core/runtime_configuration/include/hpx/runtime_configuration/component_factory_base.hpp
+++ b/libs/core/runtime_configuration/include/hpx/runtime_configuration/component_factory_base.hpp
@@ -14,4 +14,3 @@ namespace hpx::components {
 
     HPX_CXX_CORE_EXPORT struct HPX_CORE_EXPORT component_factory_base;
 }    // namespace hpx::components
-

--- a/libs/full/async_colocated/include/hpx/async_colocated/post_colocated.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/post_colocated.hpp
@@ -8,7 +8,6 @@
 
 #include <hpx/config.hpp>
 
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/agas_base.hpp>
 #include <hpx/modules/async_base.hpp>
@@ -100,4 +99,3 @@ namespace hpx::detail {
     }
 }    // namespace hpx::detail
 
-#endif

--- a/libs/full/async_colocated/include/hpx/async_colocated/post_colocated.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/post_colocated.hpp
@@ -98,4 +98,3 @@ namespace hpx::detail {
             HPX_FORWARD(Continuation, cont), id, HPX_FORWARD(Ts, vs)...);
     }
 }    // namespace hpx::detail
-

--- a/libs/full/async_colocated/include/hpx/async_colocated/post_colocated.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/post_colocated.hpp
@@ -8,6 +8,7 @@
 
 #include <hpx/config.hpp>
 
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/agas_base.hpp>
 #include <hpx/modules/async_base.hpp>
@@ -98,3 +99,5 @@ namespace hpx::detail {
             HPX_FORWARD(Continuation, cont), id, HPX_FORWARD(Ts, vs)...);
     }
 }    // namespace hpx::detail
+
+#endif

--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -208,7 +208,6 @@ namespace hpx { namespace collectives {
 
 #include <hpx/config.hpp>
 
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/assert.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/async_distributed.hpp>
@@ -533,5 +532,4 @@ namespace hpx::collectives {
 ////////////////////////////////////////////////////////////////////////////////
 #define HPX_REGISTER_ALLGATHER(...)             /**/
 
-#endif    // !HPX_COMPUTE_DEVICE_CODE
 #endif    // DOXYGEN

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -222,7 +222,6 @@ namespace hpx { namespace collectives {
 
 #include <hpx/config.hpp>
 
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/assert.hpp>
 #include <hpx/modules/algorithms.hpp>
 #include <hpx/modules/async_base.hpp>
@@ -582,5 +581,4 @@ namespace hpx::collectives {
 ////////////////////////////////////////////////////////////////////////////////
 #define HPX_REGISTER_ALLREDUCE(...)             /**/
 
-#endif    // !HPX_COMPUTE_DEVICE_CODE
 #endif    // DOXYGEN

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -235,7 +235,6 @@ namespace hpx { namespace collectives {
 
 #include <hpx/config.hpp>
 
-
 #include <hpx/assert.hpp>
 #include <hpx/collectives/argument_types.hpp>
 #include <hpx/collectives/channel_communicator.hpp>

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -235,7 +235,6 @@ namespace hpx { namespace collectives {
 
 #include <hpx/config.hpp>
 
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 
 #include <hpx/assert.hpp>
 #include <hpx/collectives/argument_types.hpp>
@@ -955,5 +954,4 @@ namespace hpx::collectives {
 ////////////////////////////////////////////////////////////////////////////////
 #define HPX_REGISTER_ALLTOALL(...)             /**/
 
-#endif    // !HPX_COMPUTE_DEVICE_CODE
 #endif    // DOXYGEN

--- a/libs/full/collectives/include/hpx/collectives/barrier.hpp
+++ b/libs/full/collectives/include/hpx/collectives/barrier.hpp
@@ -92,7 +92,6 @@ namespace hpx { namespace distributed {
 
 #include <hpx/config.hpp>
 
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/assert.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/async_distributed.hpp>
@@ -385,5 +384,4 @@ namespace hpx::distributed {
 
 #include <hpx/config/warnings_suffix.hpp>
 
-#endif    // !HPX_COMPUTE_DEVICE_CODE
 #endif    // DOXYGEN

--- a/libs/full/collectives/include/hpx/collectives/broadcast.hpp
+++ b/libs/full/collectives/include/hpx/collectives/broadcast.hpp
@@ -388,7 +388,6 @@ namespace hpx { namespace collectives {
 
 #include <hpx/config.hpp>
 
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/assert.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/async_distributed.hpp>
@@ -905,5 +904,4 @@ namespace hpx::collectives {
 ////////////////////////////////////////////////////////////////////////////////
 #define HPX_REGISTER_BROADCAST(...)             /**/
 
-#endif    // !HPX_COMPUTE_DEVICE_CODE
 #endif    // DOXYGEN

--- a/libs/full/collectives/include/hpx/collectives/broadcast_direct.hpp
+++ b/libs/full/collectives/include/hpx/collectives/broadcast_direct.hpp
@@ -133,7 +133,6 @@ namespace hpx { namespace lcos {
 
 #include <hpx/config.hpp>
 
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/assert.hpp>
 #include <hpx/modules/actions.hpp>
 #include <hpx/modules/actions_base.hpp>
@@ -637,5 +636,4 @@ namespace hpx::lcos {
     }
 }    // namespace hpx::lcos
 
-#endif    //COMPUTE_DEVICE_CODE
 #endif    // DOXYGEN

--- a/libs/full/collectives/include/hpx/collectives/channel_communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/channel_communicator.hpp
@@ -128,7 +128,6 @@ namespace hpx { namespace collectives {
 
 #include <hpx/config.hpp>
 
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components.hpp>
@@ -322,5 +321,4 @@ namespace hpx::collectives {
     }    // namespace detail
 }    // namespace hpx::collectives
 
-#endif    // !HPX_COMPUTE_DEVICE_CODE
 #endif    // DOXYGEN

--- a/libs/full/collectives/include/hpx/collectives/create_communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/create_communicator.hpp
@@ -212,7 +212,6 @@ namespace hpx { namespace collectives {
 
 #include <hpx/config.hpp>
 
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/components.hpp>
 #include <hpx/modules/datastructures.hpp>
@@ -475,5 +474,4 @@ namespace hpx::collectives {
     inline constexpr bool is_communicator_v = is_communicator<T>::value;
 }    // namespace hpx::collectives
 
-#endif    // !HPX_COMPUTE_DEVICE_CODE
 #endif    // DOXYGEN

--- a/libs/full/collectives/include/hpx/collectives/detail/channel_communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/channel_communicator.hpp
@@ -8,7 +8,6 @@
 
 #include <hpx/config.hpp>
 
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 
 #include <hpx/assert.hpp>
 #include <hpx/modules/actions_base.hpp>
@@ -162,4 +161,3 @@ namespace hpx::collectives::detail {
     };
 }    // namespace hpx::collectives::detail
 
-#endif    // COMPUTE_HOST_CODE

--- a/libs/full/collectives/include/hpx/collectives/detail/channel_communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/channel_communicator.hpp
@@ -8,7 +8,6 @@
 
 #include <hpx/config.hpp>
 
-
 #include <hpx/assert.hpp>
 #include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components.hpp>
@@ -160,4 +159,3 @@ namespace hpx::collectives::detail {
         std::vector<client_type> clients_;
     };
 }    // namespace hpx::collectives::detail
-

--- a/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
@@ -8,8 +8,6 @@
 
 #include <hpx/config.hpp>
 
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
-
 #include <hpx/assert.hpp>
 #include <hpx/collectives/argument_types.hpp>
 #include <hpx/modules/actions_base.hpp>
@@ -572,5 +570,3 @@ namespace hpx::collectives::detail {
         bool auto_generation_used_ = false;
     };
 }    // namespace hpx::collectives::detail
-
-#endif    // COMPUTE_HOST_CODE

--- a/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
@@ -14,7 +14,6 @@
 
 #include <hpx/config.hpp>
 
-
 #include <hpx/assert.hpp>
 #include <hpx/collectives/create_communicator.hpp>
 #include <hpx/collectives/detail/flattened_data.hpp>
@@ -205,4 +204,3 @@ namespace hpx::collectives::detail {
     }
 
 }    // namespace hpx::collectives::detail
-

--- a/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
@@ -14,7 +14,6 @@
 
 #include <hpx/config.hpp>
 
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 
 #include <hpx/assert.hpp>
 #include <hpx/collectives/create_communicator.hpp>
@@ -207,4 +206,3 @@ namespace hpx::collectives::detail {
 
 }    // namespace hpx::collectives::detail
 
-#endif    // !HPX_COMPUTE_DEVICE_CODE

--- a/libs/full/collectives/include/hpx/collectives/detail/hierarchical_scan_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/hierarchical_scan_helpers.hpp
@@ -10,7 +10,6 @@
 
 #include <hpx/config.hpp>
 
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/assert.hpp>
 #include <hpx/collectives/argument_types.hpp>
 #include <hpx/collectives/create_communicator.hpp>
@@ -103,4 +102,3 @@ namespace hpx::collectives::detail {
             scatter_gen, detail::generation_mode::single_step);
     }
 }    // namespace hpx::collectives::detail
-#endif

--- a/libs/full/collectives/include/hpx/collectives/detail/pairwise_all_to_all_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/pairwise_all_to_all_helpers.hpp
@@ -16,7 +16,6 @@
 
 #include <hpx/config.hpp>
 
-
 #include <hpx/collectives/argument_types.hpp>
 #include <hpx/collectives/channel_communicator.hpp>
 #include <hpx/collectives/detail/hierarchical_helpers.hpp>
@@ -212,4 +211,3 @@ namespace hpx::collectives::detail {
                 });
     }
 }    // namespace hpx::collectives::detail
-

--- a/libs/full/collectives/include/hpx/collectives/detail/pairwise_all_to_all_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/pairwise_all_to_all_helpers.hpp
@@ -16,7 +16,6 @@
 
 #include <hpx/config.hpp>
 
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 
 #include <hpx/collectives/argument_types.hpp>
 #include <hpx/collectives/channel_communicator.hpp>
@@ -214,4 +213,3 @@ namespace hpx::collectives::detail {
     }
 }    // namespace hpx::collectives::detail
 
-#endif    // !HPX_COMPUTE_DEVICE_CODE

--- a/libs/full/collectives/include/hpx/collectives/exclusive_scan.hpp
+++ b/libs/full/collectives/include/hpx/collectives/exclusive_scan.hpp
@@ -274,7 +274,6 @@ namespace hpx { namespace collectives {
 
 #include <hpx/config.hpp>
 
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/assert.hpp>
 #include <hpx/modules/algorithms.hpp>
 #include <hpx/modules/async_base.hpp>
@@ -779,5 +778,4 @@ namespace hpx::collectives {
     }
 }    // namespace hpx::collectives
 
-#endif    // !HPX_COMPUTE_DEVICE_CODE
 #endif    // DOXYGEN

--- a/libs/full/collectives/include/hpx/collectives/gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/gather.hpp
@@ -398,7 +398,6 @@ namespace hpx { namespace collectives {
 
 #include <hpx/config.hpp>
 
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/assert.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/async_distributed.hpp>
@@ -904,5 +903,4 @@ namespace hpx::collectives {
 ///////////////////////////////////////////////////////////////////////////////
 #define HPX_REGISTER_GATHER(...)             /**/
 
-#endif    // !HPX_COMPUTE_DEVICE_CODE
 #endif    // DOXYGEN

--- a/libs/full/collectives/include/hpx/collectives/inclusive_scan.hpp
+++ b/libs/full/collectives/include/hpx/collectives/inclusive_scan.hpp
@@ -217,7 +217,6 @@ namespace hpx { namespace collectives {
 
 #include <hpx/config.hpp>
 
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/assert.hpp>
 #include <hpx/modules/algorithms.hpp>
 #include <hpx/modules/async_base.hpp>
@@ -472,5 +471,4 @@ namespace hpx::collectives {
     }
 }    // namespace hpx::collectives
 
-#endif    // !HPX_COMPUTE_DEVICE_CODE
 #endif    // DOXYGEN

--- a/libs/full/collectives/include/hpx/collectives/reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/reduce.hpp
@@ -392,7 +392,6 @@ namespace hpx { namespace collectives {
 
 #include <hpx/config.hpp>
 
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/assert.hpp>
 #include <hpx/modules/algorithms.hpp>
 #include <hpx/modules/async_base.hpp>
@@ -933,5 +932,4 @@ namespace hpx::collectives {
     }
 }    // namespace hpx::collectives
 
-#endif    // !HPX_COMPUTE_DEVICE_CODE
 #endif    // DOXYGEN

--- a/libs/full/collectives/include/hpx/collectives/scatter.hpp
+++ b/libs/full/collectives/include/hpx/collectives/scatter.hpp
@@ -383,7 +383,6 @@ namespace hpx { namespace collectives {
 
 #include <hpx/config.hpp>
 
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/assert.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/async_distributed.hpp>
@@ -1080,5 +1079,4 @@ namespace hpx::collectives {
 ///////////////////////////////////////////////////////////////////////////////
 #define HPX_REGISTER_SCATTER(...)             /**/
 
-#endif    // !HPX_COMPUTE_DEVICE_CODE
 #endif    // DOXYGEN

--- a/libs/full/collectives/include/hpx/collectives/spmd_block.hpp
+++ b/libs/full/collectives/include/hpx/collectives/spmd_block.hpp
@@ -376,4 +376,3 @@ namespace hpx::lcos {
             HPX_FORWARD(Args, args)...);
     }
 }    // namespace hpx::lcos
-

--- a/libs/full/collectives/include/hpx/collectives/spmd_block.hpp
+++ b/libs/full/collectives/include/hpx/collectives/spmd_block.hpp
@@ -12,7 +12,6 @@
 
 #include <hpx/config.hpp>
 
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/components_base.hpp>
@@ -378,4 +377,3 @@ namespace hpx::lcos {
     }
 }    // namespace hpx::lcos
 
-#endif

--- a/libs/full/collectives/tests/regressions/CMakeLists.txt
+++ b/libs/full/collectives/tests/regressions/CMakeLists.txt
@@ -47,3 +47,27 @@ if(HPX_WITH_NETWORKING)
   endforeach()
 
 endif()
+
+if(HPX_WITH_COMPILE_ONLY_TESTS)
+  set(compile_tests)
+  if(HPX_WITH_CUDA OR HPX_WITH_HIP)
+    list(APPEND compile_tests device_headers_6740)
+    set(device_headers_6740_CUDA ON)
+  endif()
+
+  foreach(compile_test ${compile_tests})
+    if(${${compile_test}_CUDA})
+      set(sources ${compile_test}.cu)
+    else()
+      set(sources ${compile_test}.cpp)
+    endif()
+
+    source_group("Source Files" FILES ${sources})
+
+    add_hpx_regression_compile_test(
+      "modules.collectives" ${compile_test}
+      SOURCES ${sources} ${${compile_test}_FLAGS}
+      FOLDER "Tests/Regressions/Modules/Full/Collectives/CompileOnly"
+    )
+  endforeach()
+endif()

--- a/libs/full/collectives/tests/regressions/device_headers_6740.cu
+++ b/libs/full/collectives/tests/regressions/device_headers_6740.cu
@@ -5,17 +5,18 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 // Regression test for GitHub issue #6740: a CUDA translation unit must be able
-// to name HPX types and functions from the collectives, colocated and
-// component-factory APIs in host member functions of a class that also owns a
-// __global__ kernel. Compile-only smoke test; a successful build is the pass.
+// to name HPX types and functions from the collectives, component-factory and
+// coalescing-registration APIs in host member functions of a class that also
+// owns a __global__ kernel. Compile-only smoke test; a successful build is the
+// pass.
 
-#include <hpx/async_colocated/post_colocated.hpp>
 #include <hpx/collectives.hpp>
+#include <hpx/parcelset/coalescing_message_handler_registration.hpp>
 #include <hpx/runtime_configuration/component_factory_base.hpp>
 
 __global__ void k() {}
 
-// 1. Collectives shape — spans the headers whose whole-file guards were
+// 1. Collectives shape - spans the headers whose whole-file guards were
 //    removed: create_communicator, barrier, broadcast, all_reduce, all_gather,
 //    scatter.
 struct collectives_shape
@@ -37,22 +38,7 @@ struct collectives_shape
     }
 };
 
-// 2. post_colocated shape — the whole-file guard in post_colocated.hpp used
-//    to hide the definitions of hpx::detail::post_colocated. Compile-only,
-//    since a real call would only surface as a link-time reference here.
-struct post_colocated_shape
-{
-    void host_side()
-    {
-        using hpx::detail::post_colocated;
-    }
-    void launch()
-    {
-        k<<<1, 1>>>();
-    }
-};
-
-// 3. component_factory_base shape — small guard used to hide the forward
+// 2. component_factory_base shape - small guard used to hide the forward
 //    declaration of the struct on the device pass.
 struct component_factory_base_shape
 {
@@ -66,6 +52,25 @@ struct component_factory_base_shape
         k<<<1, 1>>>();
     }
 };
+
+// 3. coalescing_message_handler_registration shape - the compound guard on
+//    the header dropped its HPX_COMPUTE_DEVICE_CODE clause. The names below
+//    only exist when parcel coalescing and networking are on, so wrap the
+//    reference in the same conditions the header uses.
+#if defined(HPX_HAVE_PARCEL_COALESCING) && defined(HPX_HAVE_NETWORKING)
+struct coalescing_registration_shape
+{
+    void host_side()
+    {
+        hpx::parcelset::register_coalescing_for_action<int>* p = nullptr;
+        (void) p;
+    }
+    void launch()
+    {
+        k<<<1, 1>>>();
+    }
+};
+#endif
 
 int main()
 {

--- a/libs/full/collectives/tests/regressions/device_headers_6740.cu
+++ b/libs/full/collectives/tests/regressions/device_headers_6740.cu
@@ -1,0 +1,73 @@
+//  Copyright (c) 2026 Vansh Dobhal
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Regression test for GitHub issue #6740: a CUDA translation unit must be able
+// to name HPX types and functions from the collectives, colocated and
+// component-factory APIs in host member functions of a class that also owns a
+// __global__ kernel. Compile-only smoke test; a successful build is the pass.
+
+#include <hpx/async_colocated/post_colocated.hpp>
+#include <hpx/collectives.hpp>
+#include <hpx/runtime_configuration/component_factory_base.hpp>
+
+__global__ void k() {}
+
+// 1. Collectives shape — spans the headers whose whole-file guards were
+//    removed: create_communicator, barrier, broadcast, all_reduce, all_gather,
+//    scatter.
+struct collectives_shape
+{
+    void host_side()
+    {
+        hpx::collectives::communicator c;
+        (void) c;
+
+        using hpx::collectives::all_gather;
+        using hpx::collectives::all_reduce;
+        using hpx::collectives::barrier;
+        using hpx::collectives::broadcast_to;
+        using hpx::collectives::scatter_to;
+    }
+    void launch()
+    {
+        k<<<1, 1>>>();
+    }
+};
+
+// 2. post_colocated shape — the whole-file guard in post_colocated.hpp used
+//    to hide the definitions of hpx::detail::post_colocated. Compile-only,
+//    since a real call would only surface as a link-time reference here.
+struct post_colocated_shape
+{
+    void host_side()
+    {
+        using hpx::detail::post_colocated;
+    }
+    void launch()
+    {
+        k<<<1, 1>>>();
+    }
+};
+
+// 3. component_factory_base shape — small guard used to hide the forward
+//    declaration of the struct on the device pass.
+struct component_factory_base_shape
+{
+    void host_side()
+    {
+        hpx::components::component_factory_base* p = nullptr;
+        (void) p;
+    }
+    void launch()
+    {
+        k<<<1, 1>>>();
+    }
+};
+
+int main()
+{
+    return 0;
+}

--- a/libs/full/collectives/tests/regressions/device_headers_6740.cu
+++ b/libs/full/collectives/tests/regressions/device_headers_6740.cu
@@ -11,8 +11,8 @@
 // pass.
 
 #include <hpx/collectives.hpp>
-#include <hpx/parcelset/coalescing_message_handler_registration.hpp>
-#include <hpx/runtime_configuration/component_factory_base.hpp>
+#include <hpx/modules/parcelset.hpp>
+#include <hpx/modules/runtime_configuration.hpp>
 
 __global__ void k() {}
 

--- a/libs/full/parcelset/include/hpx/parcelset/coalescing_message_handler_registration.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/coalescing_message_handler_registration.hpp
@@ -10,8 +10,7 @@
 
 // the module itself should not register any actions which coalesce parcels
 #if defined(HPX_HAVE_PARCEL_COALESCING) && defined(HPX_HAVE_NETWORKING) &&     \
-    !defined(HPX_PARCEL_COALESCING_MODULE_EXPORTS) &&                          \
-    !defined(HPX_COMPUTE_DEVICE_CODE)
+    !defined(HPX_PARCEL_COALESCING_MODULE_EXPORTS)
 
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/preprocessor.hpp>


### PR DESCRIPTION
Refs #6740 — first of two PRs.

## Proposed Changes

  - Remove the whole-file `#if !defined(HPX_COMPUTE_DEVICE_CODE)` wraps from 19 collectives headers, `post_colocated.hpp` and `component_factory_base.hpp`, and drop the `HPX_COMPUTE_DEVICE_CODE` part of the compound guard in `coalescing_message_handler_registration.hpp`.
  - Add a compile-only regression test under `tests/regressions/`.

## Any background context you want to provide?

A class definition has to parse on both nvcc passes. These guards deleted the whole file on the device pass, so naming `hpx::collectives::communicator` in a host member function failed with "namespace has no member", even though nothing in the class runs on the GPU. The implicit `__host__` already stops device code calling these, so hiding the declarations wasn't needed.

Fails before, passes after:

```cpp
#include <hpx/collectives.hpp>
__global__ void k() {}
struct S {
    void host_side() { hpx::collectives::communicator c; (void) c; }
    void launch() { k<<<1, 1>>>(); }
};
```

`libs/full/collectives/include/hpx/collectives/macros.hpp` keeps its guard — it has a real `#else` branch, and removing it breaks the file.

Host builds don't change. `HPX_COMPUTE_DEVICE_CODE` is only defined on nvcc's device pass, so the guarded bodies always compiled and still do.

## What's left

This covers 18 of the 33 headers in the issue. Of the rest, 8 already work, 2 have guards that don't hide anything, 1 defines the macro itself, and 1 is gone.

Three still fail — `trigger_lco.hpp`, `primary_namespace.hpp`, `base_lco_with_value.hpp` — because `HPX_DEFINE_COMPONENT_ACTION` expands to nothing on device, so the `_action` typedefs disappear. That's the actions point from the thread and needs a decision on what those macros should emit on device. I'll post reproducers on the issue and do that separately.

Tested with nvcc 13.2 and gcc 15.2.1 as host compiler. 

## Checklist

Not all points below apply to all pull requests.
- [ ] I have added a new feature and have added tests to go along with it.
- [x] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.