### PR TITLE
Avoid communicator reuse between collectives test phases

### DIFF
--- a/libs/full/collectives/tests/unit/all_gather.cpp
+++ b/libs/full/collectives/tests/unit/all_gather.cpp
@@ -20,7 +20,15 @@
 
 using namespace hpx::collectives;
 
+// Keep independently created communicators from aliasing in AGAS while
+// localities transition between test phases.
 constexpr char const* all_gather_direct_basename = "/test/all_gather_direct/";
+constexpr char const* all_gather_direct_multiple_use_basename =
+    "/test/all_gather_direct/multiple_use/";
+constexpr char const* all_gather_direct_explicit_generation_basename =
+    "/test/all_gather_direct/explicit_generation/";
+constexpr char const* all_gather_direct_local_basename =
+    "/test/all_gather_direct/local/";
 #if defined(HPX_DEBUG)
 constexpr int ITERATIONS = 100;
 #else
@@ -60,7 +68,7 @@ void test_multiple_use()
 
     // test functionality based on immediate local result value
     auto const all_gather_direct_client =
-        create_communicator(all_gather_direct_basename,
+        create_communicator(all_gather_direct_multiple_use_basename,
             num_sites_arg(num_localities), this_site_arg(here));
 
     for (int i = 0; i != ITERATIONS; ++i)
@@ -87,7 +95,7 @@ void test_multiple_use_with_generation()
 
     // test functionality based on immediate local result value
     auto const all_gather_direct_client =
-        create_communicator(all_gather_direct_basename,
+        create_communicator(all_gather_direct_explicit_generation_basename,
             num_sites_arg(num_localities), this_site_arg(here));
 
     hpx::chrono::high_resolution_timer const t;
@@ -123,7 +131,7 @@ void test_local_use(std::uint32_t num_sites)
     {
         sites.push_back(hpx::async([=]() {
             auto const all_gather_direct_client =
-                create_local_communicator(all_gather_direct_basename,
+                create_local_communicator(all_gather_direct_local_basename,
                     num_sites_arg(num_sites), this_site_arg(site));
 
             hpx::chrono::high_resolution_timer const t;

--- a/libs/full/collectives/tests/unit/all_gather_hierarchical.cpp
+++ b/libs/full/collectives/tests/unit/all_gather_hierarchical.cpp
@@ -21,8 +21,12 @@
 
 using namespace hpx::collectives;
 
+// Keep independently created communicators from aliasing in AGAS while
+// localities transition between test phases.
 constexpr char const* all_gather_direct_basename =
     "/test/all_gather_hierarchical/";
+constexpr char const* all_gather_direct_local_basename =
+    "/test/all_gather_hierarchical/local/";
 #if defined(HPX_DEBUG)
 constexpr int ITERATIONS = 50;
 #else
@@ -76,7 +80,7 @@ void test_local_use(std::uint32_t num_sites, int arity = 2)
     {
         sites.push_back(hpx::async([=]() {
             auto const all_gather_clients = create_hierarchical_communicator(
-                all_gather_direct_basename, num_sites_arg(num_sites),
+                all_gather_direct_local_basename, num_sites_arg(num_sites),
                 this_site_arg(site), arity_arg(arity), generation_arg(),
                 root_site_arg(), flat_fallback_threshold_arg(0));
 

--- a/libs/full/collectives/tests/unit/all_gather_sync.cpp
+++ b/libs/full/collectives/tests/unit/all_gather_sync.cpp
@@ -20,7 +20,15 @@
 
 using namespace hpx::collectives;
 
+// Keep independently created communicators from aliasing in AGAS while
+// localities transition between test phases.
 constexpr char const* all_gather_direct_basename = "/test/all_gather_direct/";
+constexpr char const* all_gather_direct_multiple_use_basename =
+    "/test/all_gather_direct/multiple_use/";
+constexpr char const* all_gather_direct_explicit_generation_basename =
+    "/test/all_gather_direct/explicit_generation/";
+constexpr char const* all_gather_direct_local_basename =
+    "/test/all_gather_direct/local/";
 #if defined(HPX_DEBUG)
 constexpr int ITERATIONS = 100;
 #else
@@ -59,7 +67,7 @@ void test_multiple_use()
 
     // test functionality based on immediate local result value
     auto const all_gather_direct_client =
-        create_communicator(all_gather_direct_basename,
+        create_communicator(all_gather_direct_multiple_use_basename,
             num_sites_arg(num_localities), this_site_arg(here));
 
     for (int i = 0; i != ITERATIONS; ++i)
@@ -85,7 +93,7 @@ void test_multiple_use_with_generation()
 
     // test functionality based on immediate local result value
     auto const all_gather_direct_client =
-        create_communicator(all_gather_direct_basename,
+        create_communicator(all_gather_direct_explicit_generation_basename,
             num_sites_arg(num_localities), this_site_arg(here));
 
     hpx::chrono::high_resolution_timer const t;
@@ -122,7 +130,7 @@ void test_local_use()
     {
         sites.push_back(hpx::async([=]() {
             auto const all_gather_direct_client =
-                create_local_communicator(all_gather_direct_basename,
+                create_local_communicator(all_gather_direct_local_basename,
                     num_sites_arg(num_sites), this_site_arg(site));
 
             hpx::chrono::high_resolution_timer const t;

--- a/libs/full/collectives/tests/unit/all_reduce.cpp
+++ b/libs/full/collectives/tests/unit/all_reduce.cpp
@@ -20,7 +20,15 @@
 
 using namespace hpx::collectives;
 
+// Keep independently created communicators from aliasing in AGAS while
+// localities transition between test phases.
 constexpr char const* all_reduce_direct_basename = "/test/all_reduce_direct/";
+constexpr char const* all_reduce_direct_multiple_use_basename =
+    "/test/all_reduce_direct/multiple_use/";
+constexpr char const* all_reduce_direct_explicit_generation_basename =
+    "/test/all_reduce_direct/explicit_generation/";
+constexpr char const* all_reduce_direct_local_basename =
+    "/test/all_reduce_direct/local/";
 #if defined(HPX_DEBUG)
 constexpr int ITERATIONS = 100;
 #else
@@ -74,7 +82,7 @@ void test_multiple_use()
     HPX_TEST_LTE(static_cast<std::uint32_t>(2), num_localities);
 
     auto const all_reduce_direct_client =
-        create_communicator(all_reduce_direct_basename,
+        create_communicator(all_reduce_direct_multiple_use_basename,
             num_sites_arg(num_localities), this_site_arg(here));
 
     // test functionality based on immediate local result value
@@ -100,7 +108,7 @@ void test_multiple_use_with_generation()
     HPX_TEST_LTE(static_cast<std::uint32_t>(2), num_localities);
 
     auto const all_reduce_direct_client =
-        create_communicator(all_reduce_direct_basename,
+        create_communicator(all_reduce_direct_explicit_generation_basename,
             num_sites_arg(num_localities), this_site_arg(here));
 
     hpx::chrono::high_resolution_timer const t;
@@ -136,7 +144,7 @@ void test_local_use(std::uint32_t num_sites)
     {
         sites.push_back(hpx::async([=]() {
             auto const all_reduce_direct_client =
-                create_local_communicator(all_reduce_direct_basename,
+                create_local_communicator(all_reduce_direct_local_basename,
                     num_sites_arg(num_sites), this_site_arg(site));
 
             hpx::chrono::high_resolution_timer const t;

--- a/libs/full/collectives/tests/unit/all_reduce_hierarchical.cpp
+++ b/libs/full/collectives/tests/unit/all_reduce_hierarchical.cpp
@@ -21,8 +21,12 @@
 
 using namespace hpx::collectives;
 
+// Keep independently created communicators from aliasing in AGAS while
+// localities transition between test phases.
 constexpr char const* all_reduce_direct_basename =
     "/test/all_reduce_hierarchical/";
+constexpr char const* all_reduce_direct_local_basename =
+    "/test/all_reduce_hierarchical/local/";
 #if defined(HPX_DEBUG)
 constexpr int ITERATIONS = 50;
 #else
@@ -76,7 +80,7 @@ void test_local_use(std::uint32_t num_sites, int arity = 2)
     {
         sites.push_back(hpx::async([=]() {
             auto const all_reduce_clients = create_hierarchical_communicator(
-                all_reduce_direct_basename, num_sites_arg(num_sites),
+                all_reduce_direct_local_basename, num_sites_arg(num_sites),
                 this_site_arg(site), arity_arg(arity), generation_arg(),
                 root_site_arg(), flat_fallback_threshold_arg(0));
 

--- a/libs/full/collectives/tests/unit/all_reduce_sync.cpp
+++ b/libs/full/collectives/tests/unit/all_reduce_sync.cpp
@@ -20,7 +20,15 @@
 
 using namespace hpx::collectives;
 
+// Keep independently created communicators from aliasing in AGAS while
+// localities transition between test phases.
 constexpr char const* all_reduce_direct_basename = "/test/all_reduce_direct/";
+constexpr char const* all_reduce_direct_multiple_use_basename =
+    "/test/all_reduce_direct/multiple_use/";
+constexpr char const* all_reduce_direct_explicit_generation_basename =
+    "/test/all_reduce_direct/explicit_generation/";
+constexpr char const* all_reduce_direct_local_basename =
+    "/test/all_reduce_direct/local/";
 #if defined(HPX_DEBUG)
 constexpr int ITERATIONS = 100;
 #else
@@ -59,7 +67,7 @@ void test_multiple_use()
     HPX_TEST_LTE(static_cast<std::uint32_t>(2), num_localities);
 
     auto const all_reduce_direct_client =
-        create_communicator(all_reduce_direct_basename,
+        create_communicator(all_reduce_direct_multiple_use_basename,
             num_sites_arg(num_localities), this_site_arg(here));
 
     // test functionality based on immediate local result value
@@ -85,7 +93,7 @@ void test_multiple_use_with_generation()
     HPX_TEST_LTE(static_cast<std::uint32_t>(2), num_localities);
 
     auto const all_reduce_direct_client =
-        create_communicator(all_reduce_direct_basename,
+        create_communicator(all_reduce_direct_explicit_generation_basename,
             num_sites_arg(num_localities), this_site_arg(here));
 
     hpx::chrono::high_resolution_timer const t;
@@ -123,7 +131,7 @@ void test_local_use()
     {
         sites.push_back(hpx::async([=]() {
             auto const all_reduce_direct_client =
-                create_local_communicator(all_reduce_direct_basename,
+                create_local_communicator(all_reduce_direct_local_basename,
                     num_sites_arg(num_sites), this_site_arg(site));
 
             hpx::chrono::high_resolution_timer const t;

--- a/libs/full/collectives/tests/unit/all_to_all_sync.cpp
+++ b/libs/full/collectives/tests/unit/all_to_all_sync.cpp
@@ -20,7 +20,15 @@
 
 using namespace hpx::collectives;
 
+// Keep independently created communicators from aliasing in AGAS while
+// localities transition between test phases.
 constexpr char const* all_to_all_direct_basename = "/test/all_to_all_direct/";
+constexpr char const* all_to_all_direct_multiple_use_basename =
+    "/test/all_to_all_direct/multiple_use/";
+constexpr char const* all_to_all_direct_explicit_generation_basename =
+    "/test/all_to_all_direct/explicit_generation/";
+constexpr char const* all_to_all_direct_local_basename =
+    "/test/all_to_all_direct/local/";
 #if defined(HPX_DEBUG)
 constexpr int ITERATIONS = 100;
 #else
@@ -62,7 +70,7 @@ void test_multiple_use()
     HPX_TEST_LTE(static_cast<std::uint32_t>(2), num_localities);
 
     auto const all_to_all_direct_client =
-        create_communicator(all_to_all_direct_basename,
+        create_communicator(all_to_all_direct_multiple_use_basename,
             num_sites_arg(num_localities), this_site_arg(this_locality));
 
     // test functionality based on immediate local result value
@@ -91,7 +99,7 @@ void test_multiple_use_with_generation()
     HPX_TEST_LTE(static_cast<std::uint32_t>(2), num_localities);
 
     auto const all_to_all_direct_client =
-        create_communicator(all_to_all_direct_basename,
+        create_communicator(all_to_all_direct_explicit_generation_basename,
             num_sites_arg(num_localities), this_site_arg(this_locality));
 
     hpx::chrono::high_resolution_timer const t;
@@ -131,7 +139,7 @@ void test_local_use()
     {
         sites.push_back(hpx::async([=]() {
             auto const all_to_all_direct_client =
-                create_local_communicator(all_to_all_direct_basename,
+                create_local_communicator(all_to_all_direct_local_basename,
                     num_sites_arg(num_sites), this_site_arg(site));
 
             hpx::chrono::high_resolution_timer const t;

--- a/libs/full/collectives/tests/unit/barrier_hierarchical.cpp
+++ b/libs/full/collectives/tests/unit/barrier_hierarchical.cpp
@@ -22,7 +22,11 @@
 
 using namespace hpx::collectives;
 
+// Keep independently created communicators from aliasing in AGAS while
+// localities transition between test phases.
 constexpr char const* barrier_direct_basename = "/test/barrier_hierarchical/";
+constexpr char const* barrier_direct_local_basename =
+    "/test/barrier_hierarchical/local/";
 #if defined(HPX_DEBUG)
 constexpr int ITERATIONS = 50;
 #else
@@ -79,7 +83,7 @@ void test_local_use(std::uint32_t num_sites, int arity)
     {
         sites.push_back(hpx::async([=]() {
             auto const barrier_clients = create_hierarchical_communicator(
-                barrier_direct_basename, num_sites_arg(num_sites),
+                barrier_direct_local_basename, num_sites_arg(num_sites),
                 this_site_arg(site), arity_arg(arity), generation_arg(),
                 root_site_arg(), flat_fallback_threshold_arg(0));
 

--- a/libs/full/collectives/tests/unit/broadcast.cpp
+++ b/libs/full/collectives/tests/unit/broadcast.cpp
@@ -20,7 +20,15 @@
 
 using namespace hpx::collectives;
 
+// Keep independently created communicators from aliasing in AGAS while
+// localities transition between test phases.
 constexpr char const* broadcast_direct_basename = "/test/broadcast_direct/";
+constexpr char const* broadcast_direct_multiple_use_basename =
+    "/test/broadcast_direct/multiple_use/";
+constexpr char const* broadcast_direct_explicit_generation_basename =
+    "/test/broadcast_direct/explicit_generation/";
+constexpr char const* broadcast_direct_local_basename =
+    "/test/broadcast_direct/local/";
 #if defined(HPX_DEBUG)
 constexpr int ITERATIONS = 100;
 #else
@@ -65,7 +73,7 @@ void test_multiple_use()
     HPX_TEST_LTE(static_cast<std::uint32_t>(2), num_localities);
 
     auto const broadcast_direct_client =
-        create_communicator(broadcast_direct_basename,
+        create_communicator(broadcast_direct_multiple_use_basename,
             num_sites_arg(num_localities), this_site_arg(here));
 
     // test functionality based on immediate local result value
@@ -97,7 +105,7 @@ void test_multiple_use_with_generation()
     HPX_TEST_LTE(static_cast<std::uint32_t>(2), num_localities);
 
     auto const broadcast_direct_client =
-        create_communicator(broadcast_direct_basename,
+        create_communicator(broadcast_direct_explicit_generation_basename,
             num_sites_arg(num_localities), this_site_arg(here));
 
     hpx::chrono::high_resolution_timer const t;
@@ -138,7 +146,7 @@ void test_local_use(std::uint32_t num_sites)
     {
         sites.push_back(hpx::async([=]() {
             auto const broadcast_direct_client =
-                create_communicator(broadcast_direct_basename,
+                create_communicator(broadcast_direct_local_basename,
                     num_sites_arg(num_sites), this_site_arg(site));
 
             hpx::chrono::high_resolution_timer const t;

--- a/libs/full/collectives/tests/unit/broadcast_hierarchical.cpp
+++ b/libs/full/collectives/tests/unit/broadcast_hierarchical.cpp
@@ -21,8 +21,14 @@
 
 using namespace hpx::collectives;
 
+// Keep independently created communicators from aliasing in AGAS while
+// localities transition between test phases.
 constexpr char const* broadcast_direct_basename =
     "/test/broadcast_hierarchical/";
+constexpr char const* broadcast_direct_explicit_generation_basename =
+    "/test/broadcast_hierarchical/explicit_generation/";
+constexpr char const* broadcast_direct_local_basename =
+    "/test/broadcast_hierarchical/local/";
 #if defined(HPX_DEBUG)
 constexpr int ITERATIONS = 50;
 #else
@@ -79,9 +85,9 @@ void test_multiple_use_with_generation(int arity = 2)
     HPX_TEST_LTE(static_cast<std::uint32_t>(2), num_localities);
 
     auto const broadcast_clients = create_hierarchical_communicator(
-        broadcast_direct_basename, num_sites_arg(num_localities),
-        this_site_arg(here), arity_arg(arity), generation_arg(),
-        root_site_arg(), flat_fallback_threshold_arg(0));
+        broadcast_direct_explicit_generation_basename,
+        num_sites_arg(num_localities), this_site_arg(here), arity_arg(arity),
+        generation_arg(), root_site_arg(), flat_fallback_threshold_arg(0));
 
     hpx::chrono::high_resolution_timer const t;
 
@@ -123,7 +129,7 @@ void test_local_use(std::uint32_t num_sites, int arity)
     {
         sites.push_back(hpx::async([=]() {
             auto const broadcast_clients = create_hierarchical_communicator(
-                broadcast_direct_basename, num_sites_arg(num_sites),
+                broadcast_direct_local_basename, num_sites_arg(num_sites),
                 this_site_arg(site), arity_arg(arity), generation_arg(),
                 root_site_arg(), flat_fallback_threshold_arg(0));
 

--- a/libs/full/collectives/tests/unit/broadcast_sync.cpp
+++ b/libs/full/collectives/tests/unit/broadcast_sync.cpp
@@ -20,7 +20,19 @@
 
 using namespace hpx::collectives;
 
+// Keep independently created communicators from aliasing in AGAS while
+// localities transition between test phases.
 constexpr char const* broadcast_direct_basename = "/test/broadcast_direct/";
+constexpr char const* broadcast_direct_multiple_use_basename =
+    "/test/broadcast_direct/multiple_use/";
+constexpr char const* broadcast_direct_explicit_generation_basename =
+    "/test/broadcast_direct/explicit_generation/";
+constexpr char const* broadcast_direct_explicit_generation_sync_basename =
+    "/test/broadcast_direct/explicit_generation_sync/";
+constexpr char const* broadcast_direct_local_basename =
+    "/test/broadcast_direct/local/";
+constexpr char const* broadcast_direct_local_sync_basename =
+    "/test/broadcast_direct/local_sync/";
 #if defined(HPX_DEBUG)
 constexpr int ITERATIONS = 100;
 #else
@@ -65,7 +77,7 @@ void test_multiple_use()
     HPX_TEST_LTE(static_cast<std::uint32_t>(2), num_localities);
 
     auto const broadcast_direct_client =
-        create_communicator(broadcast_direct_basename,
+        create_communicator(broadcast_direct_multiple_use_basename,
             num_sites_arg(num_localities), this_site_arg(here));
 
     // test functionality based on immediate local result value
@@ -96,7 +108,7 @@ void test_multiple_use_with_generation()
     HPX_TEST_LTE(static_cast<std::uint32_t>(2), num_localities);
 
     auto const broadcast_direct_client =
-        create_communicator(broadcast_direct_basename,
+        create_communicator(broadcast_direct_explicit_generation_basename,
             num_sites_arg(num_localities), this_site_arg(here));
 
     hpx::chrono::high_resolution_timer const t;
@@ -135,7 +147,7 @@ void test_multiple_use_with_generation_sync()
     HPX_TEST_LTE(static_cast<std::uint32_t>(2), num_localities);
 
     auto const broadcast_direct_client =
-        create_communicator(broadcast_direct_basename,
+        create_communicator(broadcast_direct_explicit_generation_sync_basename,
             num_sites_arg(num_localities), this_site_arg(here));
 
     hpx::chrono::high_resolution_timer const t;
@@ -179,7 +191,7 @@ void test_local_use()
     {
         sites.push_back(hpx::async([=]() {
             auto const broadcast_direct_client =
-                create_communicator(broadcast_direct_basename,
+                create_communicator(broadcast_direct_local_basename,
                     num_sites_arg(num_sites), this_site_arg(site));
 
             hpx::chrono::high_resolution_timer const t;
@@ -229,7 +241,7 @@ void test_local_use_sync()
     {
         sites.push_back(hpx::async([=]() {
             auto const broadcast_direct_client =
-                create_communicator(broadcast_direct_basename,
+                create_communicator(broadcast_direct_local_sync_basename,
                     num_sites_arg(num_sites), this_site_arg(site));
 
             hpx::chrono::high_resolution_timer const t;

--- a/libs/full/collectives/tests/unit/gather.cpp
+++ b/libs/full/collectives/tests/unit/gather.cpp
@@ -20,7 +20,15 @@
 
 using namespace hpx::collectives;
 
+// Keep independently created communicators from aliasing in AGAS while
+// localities transition between test phases.
 constexpr char const* gather_direct_basename = "/test/gather_direct/";
+constexpr char const* gather_direct_multiple_use_basename =
+    "/test/gather_direct/multiple_use/";
+constexpr char const* gather_direct_explicit_generation_basename =
+    "/test/gather_direct/explicit_generation/";
+constexpr char const* gather_direct_local_basename =
+    "/test/gather_direct/local/";
 #if defined(HPX_DEBUG)
 constexpr int ITERATIONS = 100;
 #else
@@ -70,7 +78,7 @@ void test_multiple_use()
 
     // test functionality based on immediate local result value
     auto const gather_direct_client =
-        create_communicator(gather_direct_basename,
+        create_communicator(gather_direct_multiple_use_basename,
             num_sites_arg(num_localities), this_site_arg(this_locality));
 
     for (std::uint32_t i = 0; i != ITERATIONS; ++i)
@@ -104,7 +112,7 @@ void test_multiple_use_with_generation()
 
     // test functionality based on immediate local result value
     auto const gather_direct_client =
-        create_communicator(gather_direct_basename,
+        create_communicator(gather_direct_explicit_generation_basename,
             num_sites_arg(num_localities), this_site_arg(this_locality));
 
     hpx::chrono::high_resolution_timer const t;
@@ -149,7 +157,7 @@ void test_local_use(std::uint32_t num_sites)
     {
         sites.push_back(hpx::async([=]() {
             auto const gather_direct_client =
-                create_communicator(gather_direct_basename,
+                create_communicator(gather_direct_local_basename,
                     num_sites_arg(num_sites), this_site_arg(site));
 
             hpx::chrono::high_resolution_timer const t;

--- a/libs/full/collectives/tests/unit/gather_hierarchical.cpp
+++ b/libs/full/collectives/tests/unit/gather_hierarchical.cpp
@@ -21,7 +21,13 @@
 
 using namespace hpx::collectives;
 
+// Keep independently created communicators from aliasing in AGAS while
+// localities transition between test phases.
 constexpr char const* gather_direct_basename = "/test/gather_hierarchical/";
+constexpr char const* gather_direct_explicit_generation_basename =
+    "/test/gather_hierarchical/explicit_generation/";
+constexpr char const* gather_direct_local_basename =
+    "/test/gather_hierarchical/local/";
 #if defined(HPX_DEBUG)
 constexpr int ITERATIONS = 50;
 #else
@@ -81,9 +87,10 @@ void test_multiple_use_with_generation(int arity = 2)
 
     // test functionality based on immediate local result value
     auto const gather_clients = create_hierarchical_communicator(
-        gather_direct_basename, num_sites_arg(num_localities),
-        this_site_arg(this_locality), arity_arg(arity), generation_arg(),
-        root_site_arg(), flat_fallback_threshold_arg(0));
+        gather_direct_explicit_generation_basename,
+        num_sites_arg(num_localities), this_site_arg(this_locality),
+        arity_arg(arity), generation_arg(), root_site_arg(),
+        flat_fallback_threshold_arg(0));
 
     hpx::chrono::high_resolution_timer const t;
 
@@ -128,7 +135,7 @@ void test_local_use(std::uint32_t num_sites, int arity = 2)
     {
         sites.push_back(hpx::async([=]() {
             auto const gather_clients = create_hierarchical_communicator(
-                gather_direct_basename, num_sites_arg(num_sites),
+                gather_direct_local_basename, num_sites_arg(num_sites),
                 this_site_arg(site), arity_arg(arity), generation_arg(),
                 root_site_arg(), flat_fallback_threshold_arg(0));
 

--- a/libs/full/collectives/tests/unit/gather_sync.cpp
+++ b/libs/full/collectives/tests/unit/gather_sync.cpp
@@ -20,7 +20,15 @@
 
 using namespace hpx::collectives;
 
+// Keep independently created communicators from aliasing in AGAS while
+// localities transition between test phases.
 constexpr char const* gather_direct_basename = "/test/gather_direct/";
+constexpr char const* gather_direct_multiple_use_basename =
+    "/test/gather_direct/multiple_use/";
+constexpr char const* gather_direct_explicit_generation_basename =
+    "/test/gather_direct/explicit_generation/";
+constexpr char const* gather_direct_local_basename =
+    "/test/gather_direct/local/";
 #if defined(HPX_DEBUG)
 constexpr int ITERATIONS = 100;
 #else
@@ -67,7 +75,7 @@ void test_multiple_use()
 
     // test functionality based on immediate local result value
     auto const gather_direct_client =
-        create_communicator(gather_direct_basename,
+        create_communicator(gather_direct_multiple_use_basename,
             num_sites_arg(num_localities), this_site_arg(this_locality));
 
     for (std::uint32_t i = 0; i != ITERATIONS; ++i)
@@ -99,7 +107,7 @@ void test_multiple_use_with_generation()
 
     // test functionality based on immediate local result value
     auto const gather_direct_client =
-        create_communicator(gather_direct_basename,
+        create_communicator(gather_direct_explicit_generation_basename,
             num_sites_arg(num_localities), this_site_arg(this_locality));
 
     hpx::chrono::high_resolution_timer const t;
@@ -142,7 +150,7 @@ void test_local_use()
     {
         sites.push_back(hpx::async([=]() {
             auto const gather_direct_client =
-                create_communicator(gather_direct_basename,
+                create_communicator(gather_direct_local_basename,
                     num_sites_arg(num_sites), this_site_arg(site));
 
             hpx::chrono::high_resolution_timer const t;

--- a/libs/full/collectives/tests/unit/reduce.cpp
+++ b/libs/full/collectives/tests/unit/reduce.cpp
@@ -20,7 +20,15 @@
 
 using namespace hpx::collectives;
 
+// Keep independently created communicators from aliasing in AGAS while
+// localities transition between test phases.
 constexpr char const* reduce_direct_basename = "/test/reduce_direct/";
+constexpr char const* reduce_direct_multiple_use_basename =
+    "/test/reduce_direct/multiple_use/";
+constexpr char const* reduce_direct_explicit_generation_basename =
+    "/test/reduce_direct/explicit_generation/";
+constexpr char const* reduce_direct_local_basename =
+    "/test/reduce_direct/local/";
 #if defined(HPX_DEBUG)
 constexpr int ITERATIONS = 100;
 #else
@@ -85,7 +93,7 @@ void test_multiple_use()
     HPX_TEST_LTE(static_cast<std::uint32_t>(2), num_localities);
 
     auto const reduce_direct_client =
-        create_communicator(reduce_direct_basename,
+        create_communicator(reduce_direct_multiple_use_basename,
             num_sites_arg(num_localities), this_site_arg(this_locality));
 
     // test functionality based on immediate local result value
@@ -122,7 +130,7 @@ void test_multiple_use_with_generation()
     HPX_TEST_LTE(static_cast<std::uint32_t>(2), num_localities);
 
     auto const reduce_direct_client =
-        create_communicator(reduce_direct_basename,
+        create_communicator(reduce_direct_explicit_generation_basename,
             num_sites_arg(num_localities), this_site_arg(this_locality));
 
     hpx::chrono::high_resolution_timer const t;
@@ -168,7 +176,7 @@ void test_local_use(std::uint32_t num_sites)
     {
         sites.push_back(hpx::async([=]() {
             auto const reduce_direct_client =
-                create_communicator(reduce_direct_basename,
+                create_communicator(reduce_direct_local_basename,
                     num_sites_arg(num_sites), this_site_arg(site));
 
             hpx::chrono::high_resolution_timer const t;

--- a/libs/full/collectives/tests/unit/reduce_hierarchical.cpp
+++ b/libs/full/collectives/tests/unit/reduce_hierarchical.cpp
@@ -21,7 +21,13 @@
 
 using namespace hpx::collectives;
 
+// Keep independently created communicators from aliasing in AGAS while
+// localities transition between test phases.
 constexpr char const* reduce_direct_basename = "/test/reduce_hierarchical/";
+constexpr char const* reduce_direct_explicit_generation_basename =
+    "/test/reduce_hierarchical/explicit_generation/";
+constexpr char const* reduce_direct_local_basename =
+    "/test/reduce_hierarchical/local/";
 #if defined(HPX_DEBUG)
 constexpr int ITERATIONS = 50;
 #else
@@ -82,9 +88,10 @@ void test_multiple_use_with_generation(int arity = 2)
     HPX_TEST_LTE(static_cast<std::uint32_t>(2), num_localities);
 
     auto const reduce_clients = create_hierarchical_communicator(
-        reduce_direct_basename, num_sites_arg(num_localities),
-        this_site_arg(this_locality), arity_arg(arity), generation_arg(),
-        root_site_arg(), flat_fallback_threshold_arg(0));
+        reduce_direct_explicit_generation_basename,
+        num_sites_arg(num_localities), this_site_arg(this_locality),
+        arity_arg(arity), generation_arg(), root_site_arg(),
+        flat_fallback_threshold_arg(0));
 
     hpx::chrono::high_resolution_timer const t;
 
@@ -132,7 +139,7 @@ void test_local_use(std::uint32_t num_sites, int arity = 2)
     {
         sites.push_back(hpx::async([=]() {
             auto const reduce_clients = create_hierarchical_communicator(
-                reduce_direct_basename, num_sites_arg(num_sites),
+                reduce_direct_local_basename, num_sites_arg(num_sites),
                 this_site_arg(site), arity_arg(arity), generation_arg(),
                 root_site_arg(), flat_fallback_threshold_arg(0));
 

--- a/libs/full/collectives/tests/unit/reduce_sync.cpp
+++ b/libs/full/collectives/tests/unit/reduce_sync.cpp
@@ -20,7 +20,19 @@
 
 using namespace hpx::collectives;
 
+// Keep independently created communicators from aliasing in AGAS while
+// localities transition between test phases.
 constexpr char const* reduce_direct_basename = "/test/reduce_direct/";
+constexpr char const* reduce_direct_multiple_use_basename =
+    "/test/reduce_direct/multiple_use/";
+constexpr char const* reduce_direct_explicit_generation_basename =
+    "/test/reduce_direct/explicit_generation/";
+constexpr char const* reduce_direct_explicit_generation_sync_basename =
+    "/test/reduce_direct/explicit_generation_sync/";
+constexpr char const* reduce_direct_local_basename =
+    "/test/reduce_direct/local/";
+constexpr char const* reduce_direct_local_sync_basename =
+    "/test/reduce_direct/local_sync/";
 #if defined(HPX_DEBUG)
 constexpr int ITERATIONS = 100;
 #else
@@ -69,7 +81,7 @@ void test_multiple_use()
     HPX_TEST_LTE(static_cast<std::uint32_t>(2), num_localities);
 
     auto const reduce_direct_client =
-        create_communicator(reduce_direct_basename,
+        create_communicator(reduce_direct_multiple_use_basename,
             num_sites_arg(num_localities), this_site_arg(this_locality));
 
     // test functionality based on immediate local result value
@@ -105,7 +117,7 @@ void test_multiple_use_with_generation()
     HPX_TEST_LTE(static_cast<std::uint32_t>(2), num_localities);
 
     auto const reduce_direct_client =
-        create_communicator(reduce_direct_basename,
+        create_communicator(reduce_direct_explicit_generation_basename,
             num_sites_arg(num_localities), this_site_arg(this_locality));
 
     hpx::chrono::high_resolution_timer const t;
@@ -148,7 +160,7 @@ void test_multiple_use_with_generation_sync()
     HPX_TEST_LTE(static_cast<std::uint32_t>(2), num_localities);
 
     auto const reduce_direct_client =
-        create_communicator(reduce_direct_basename,
+        create_communicator(reduce_direct_explicit_generation_sync_basename,
             num_sites_arg(num_localities), this_site_arg(this_locality));
 
     hpx::chrono::high_resolution_timer const t;
@@ -195,7 +207,7 @@ void test_local_use()
     {
         sites.push_back(hpx::async([=]() {
             auto const reduce_direct_client =
-                create_communicator(reduce_direct_basename,
+                create_communicator(reduce_direct_local_basename,
                     num_sites_arg(num_sites), this_site_arg(site));
 
             hpx::chrono::high_resolution_timer const t;
@@ -250,7 +262,7 @@ void test_local_use_sync()
     {
         sites.push_back(hpx::async([=]() {
             auto const reduce_direct_client =
-                create_communicator(reduce_direct_basename,
+                create_communicator(reduce_direct_local_sync_basename,
                     num_sites_arg(num_sites), this_site_arg(site));
 
             hpx::chrono::high_resolution_timer const t;

--- a/libs/full/collectives/tests/unit/scatter_hierarchical.cpp
+++ b/libs/full/collectives/tests/unit/scatter_hierarchical.cpp
@@ -25,11 +25,11 @@ using namespace hpx::collectives;
 
 // Keep independently created communicators from aliasing in AGAS while
 // localities transition between test phases.
-constexpr char const* scatter_direct_basename = "/test/scatter_hierachical/";
+constexpr char const* scatter_direct_basename = "/test/scatter_hierarchical/";
 constexpr char const* scatter_direct_explicit_generation_basename =
-    "/test/scatter_hierachical/explicit_generation/";
+    "/test/scatter_hierarchical/explicit_generation/";
 constexpr char const* scatter_direct_local_basename =
-    "/test/scatter_hierachical/local/";
+    "/test/scatter_hierarchical/local/";
 #if defined(HPX_DEBUG)
 constexpr int ITERATIONS = 50;
 #else

--- a/libs/full/collectives/tests/unit/scatter_hierarchical.cpp
+++ b/libs/full/collectives/tests/unit/scatter_hierarchical.cpp
@@ -23,7 +23,13 @@
 
 using namespace hpx::collectives;
 
+// Keep independently created communicators from aliasing in AGAS while
+// localities transition between test phases.
 constexpr char const* scatter_direct_basename = "/test/scatter_hierachical/";
+constexpr char const* scatter_direct_explicit_generation_basename =
+    "/test/scatter_hierachical/explicit_generation/";
+constexpr char const* scatter_direct_local_basename =
+    "/test/scatter_hierachical/local/";
 #if defined(HPX_DEBUG)
 constexpr int ITERATIONS = 50;
 #else
@@ -84,9 +90,10 @@ void test_multiple_use_with_generation(int arity = 2)
     std::uint32_t const this_locality = hpx::get_locality_id();
 
     auto const scatter_clients = create_hierarchical_communicator(
-        scatter_direct_basename, num_sites_arg(num_localities),
-        this_site_arg(this_locality), arity_arg(arity), generation_arg(),
-        root_site_arg(), flat_fallback_threshold_arg(0));
+        scatter_direct_explicit_generation_basename,
+        num_sites_arg(num_localities), this_site_arg(this_locality),
+        arity_arg(arity), generation_arg(), root_site_arg(),
+        flat_fallback_threshold_arg(0));
 
     hpx::chrono::high_resolution_timer const t;
 
@@ -130,7 +137,7 @@ void test_local_use(std::uint32_t num_sites, int arity = 2)
     {
         sites.push_back(hpx::async([=]() {
             auto const scatter_clients = create_hierarchical_communicator(
-                scatter_direct_basename, num_sites_arg(num_sites),
+                scatter_direct_local_basename, num_sites_arg(num_sites),
                 this_site_arg(site), arity_arg(arity), generation_arg(),
                 root_site_arg(), flat_fallback_threshold_arg(0));
 

--- a/libs/full/collectives/tests/unit/scatter_sync.cpp
+++ b/libs/full/collectives/tests/unit/scatter_sync.cpp
@@ -22,7 +22,15 @@
 
 using namespace hpx::collectives;
 
+// Keep independently created communicators from aliasing in AGAS while
+// localities transition between test phases.
 constexpr char const* scatter_direct_basename = "/test/scatter_direct/";
+constexpr char const* scatter_direct_multiple_use_basename =
+    "/test/scatter_direct/multiple_use/";
+constexpr char const* scatter_direct_explicit_generation_basename =
+    "/test/scatter_direct/explicit_generation/";
+constexpr char const* scatter_direct_local_basename =
+    "/test/scatter_direct/local/";
 #if defined(HPX_DEBUG)
 constexpr int ITERATIONS = 100;
 #else
@@ -72,7 +80,7 @@ void test_multiple_use()
     std::uint32_t const this_locality = hpx::get_locality_id();
 
     auto const scatter_direct_client =
-        create_communicator(scatter_direct_basename,
+        create_communicator(scatter_direct_multiple_use_basename,
             num_sites_arg(num_localities), this_site_arg(this_locality));
 
     // test functionality based on immediate local result value
@@ -107,7 +115,7 @@ void test_multiple_use_with_generation()
     std::uint32_t const this_locality = hpx::get_locality_id();
 
     auto const scatter_direct_client =
-        create_communicator(scatter_direct_basename,
+        create_communicator(scatter_direct_explicit_generation_basename,
             num_sites_arg(num_localities), this_site_arg(this_locality));
 
     hpx::chrono::high_resolution_timer const t;
@@ -153,7 +161,7 @@ void test_local_use()
     {
         sites.push_back(hpx::async([=]() {
             auto const scatter_direct_client =
-                create_communicator(scatter_direct_basename,
+                create_communicator(scatter_direct_local_basename,
                     num_sites_arg(num_sites), this_site_arg(site));
 
             hpx::chrono::high_resolution_timer const t;


### PR DESCRIPTION
dbf793ed1e gave the four scan tests a basename per phase. The other collectives tests still run their auto-generation and explicit-generation phases on one basename, so a locality that runs ahead resolves the previous phase's communicator through AGAS and the generation guard in `communicator.hpp` throws. That is the `reduce_hierarchical` timeout on #7516 and the `all_reduce_sync` one on #7523.

Nineteen tests get a constant per phase, no logic changes. 19 of 19 pass over tcp locally.
