### PR TITLE
Keep the caching allocator's thread_local lookup out of line

### DIFF
--- a/.jenkins/lsu/env-common.sh
+++ b/.jenkins/lsu/env-common.sh
@@ -7,6 +7,10 @@
 
 configure_extra_options+=" -DCMAKE_BUILD_TYPE=${build_type}"
 configure_extra_options+=" -DHPX_WITH_CHECK_MODULE_DEPENDENCIES=ON"
+
+# The stale allocator cache reference of #6540 only showed up in release
+# builds, so verify the cache owner in every configuration here.
+configure_extra_options+=" -DHPX_ALLOCATOR_SUPPORT_WITH_CACHE_OWNER_VERIFICATION=ON"
 if [ "${build_type}" = "Debug" ]; then
     configure_extra_options+=" -DHPX_WITH_PARCELPORT_COUNTERS=ON"
     configure_extra_options+=" -DLCI_DEBUG=ON"

--- a/libs/core/allocator_support/CMakeLists.txt
+++ b/libs/core/allocator_support/CMakeLists.txt
@@ -18,14 +18,13 @@ if(HPX_ALLOCATOR_SUPPORT_WITH_CACHING)
   )
 endif()
 
-# Allow to verify that a per-thread allocator cache is only ever used by the OS
-# thread that created it. This is implicitly enabled for debug builds, the
-# option turns it on for release builds as well.
+# Diagnose access to a per-thread allocator cache from the wrong OS thread with
+# an assertion. This option is independent of the compiler protections in
+# cache(), which are always enabled. Debug builds enable the diagnostic
+# implicitly; this option enables it for release builds as well.
 hpx_option(
-  HPX_ALLOCATOR_SUPPORT_WITH_CACHE_OWNER_VERIFICATION
-  BOOL
-  "Verify that the caching allocator's per-thread cache is only used by its owning thread. (default: OFF, implicitly enabled in debug builds)"
-  OFF
+  HPX_ALLOCATOR_SUPPORT_WITH_CACHE_OWNER_VERIFICATION BOOL
+  "Diagnose invalid cache ownership. (default: OFF, implicit in Debug)" OFF
   ADVANCED
   CATEGORY "Modules"
   MODULE ALLOCATOR_SUPPORT

--- a/libs/core/allocator_support/CMakeLists.txt
+++ b/libs/core/allocator_support/CMakeLists.txt
@@ -18,6 +18,26 @@ if(HPX_ALLOCATOR_SUPPORT_WITH_CACHING)
   )
 endif()
 
+# Allow to verify that a per-thread allocator cache is only ever used by the OS
+# thread that created it. This is implicitly enabled for debug builds, the
+# option turns it on for release builds as well.
+hpx_option(
+  HPX_ALLOCATOR_SUPPORT_WITH_CACHE_OWNER_VERIFICATION
+  BOOL
+  "Verify that the caching allocator's per-thread cache is only used by its owning thread. (default: OFF, implicitly enabled in debug builds)"
+  OFF
+  ADVANCED
+  CATEGORY "Modules"
+  MODULE ALLOCATOR_SUPPORT
+)
+
+if(HPX_ALLOCATOR_SUPPORT_WITH_CACHE_OWNER_VERIFICATION)
+  hpx_add_config_define_namespace(
+    DEFINE HPX_ALLOCATOR_SUPPORT_HAVE_CACHE_OWNER_VERIFICATION
+    NAMESPACE ALLOCATOR_SUPPORT
+  )
+endif()
+
 set(allocator_support_headers
     hpx/allocator_support/aligned_allocator.hpp
     hpx/allocator_support/allocator_deleter.hpp
@@ -54,6 +74,7 @@ add_hpx_module(
   COMPAT_HEADERS ${allocator_support_compat_headers}
   ADD_TO_GLOBAL_HEADER "hpx/allocator_support/detail/new.hpp"
   DEPENDENCIES hpx_dependencies_allocator
-  MODULE_DEPENDENCIES hpx_concepts hpx_config hpx_preprocessor hpx_type_support
+  MODULE_DEPENDENCIES hpx_assertion hpx_concepts hpx_config hpx_preprocessor
+                      hpx_type_support
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/allocator_support/include/hpx/allocator_support/thread_local_caching_allocator.hpp
+++ b/libs/core/allocator_support/include/hpx/allocator_support/thread_local_caching_allocator.hpp
@@ -18,6 +18,10 @@
 #include <utility>
 #include <vector>
 
+#if defined(HPX_ALLOCATOR_SUPPORT_HAVE_CACHING) &&                             \
+    !((defined(HPX_HAVE_CUDA) && defined(__CUDACC__)) ||                       \
+        defined(HPX_HAVE_HIP))
+
 // The cache owner verification is enabled either by its own configuration
 // option or implicitly in debug builds. The option exists so that CI can turn
 // the check on for release builds as well, which is where a stale cache
@@ -28,6 +32,7 @@
 #include <hpx/assert.hpp>
 
 #include <thread>
+#endif
 #endif
 
 namespace hpx::util {

--- a/libs/core/allocator_support/include/hpx/allocator_support/thread_local_caching_allocator.hpp
+++ b/libs/core/allocator_support/include/hpx/allocator_support/thread_local_caching_allocator.hpp
@@ -18,6 +18,18 @@
 #include <utility>
 #include <vector>
 
+// The cache owner verification is enabled either by its own configuration
+// option or implicitly in debug builds. The option exists so that CI can turn
+// the check on for release builds as well, which is where a stale cache
+// reference has been observed (see #6540).
+#if defined(HPX_ALLOCATOR_SUPPORT_HAVE_CACHE_OWNER_VERIFICATION) ||            \
+    defined(HPX_DEBUG)
+#define HPX_ALLOCATOR_SUPPORT_VERIFY_CACHE_OWNER
+#include <hpx/assert.hpp>
+
+#include <thread>
+#endif
+
 namespace hpx::util {
 
 #if defined(HPX_ALLOCATOR_SUPPORT_HAVE_CACHING) &&                             \
@@ -81,6 +93,8 @@ namespace hpx::util {
 
             pointer allocate(size_type n)
             {
+                verify_owner();
+
                 // Search for an entry with matching size. We try popping until
                 // we find matching size or data empty. Popped non-matching
                 // entries are temporarily stored and then pushed back to
@@ -133,6 +147,8 @@ namespace hpx::util {
 
             void deallocate(pointer p, size_type n)
             {
+                verify_owner();
+
                 if (cached.load(std::memory_order_relaxed) < capacity)
                 {
                     try
@@ -153,6 +169,24 @@ namespace hpx::util {
             }
 
         private:
+            // A cache belongs to the OS thread that created it. Reaching it
+            // from any other thread means a caller held on to the reference
+            // returned by cache() across a point where its HPX thread
+            // suspended and was resumed on a different worker.
+            //
+            // This is kept out of line for the same reason cache() is: some
+            // standard libraries declare the underlying thread id lookup as
+            // const, which would allow the compiler to reuse a value read
+            // before the suspension and hide the very mismatch we look for.
+            HPX_NOINLINE void verify_owner() const noexcept
+            {
+#if defined(HPX_ALLOCATOR_SUPPORT_VERIFY_CACHE_OWNER)
+                HPX_ASSERT_(owner == std::this_thread::get_id(),
+                    "the thread_local allocator cache is being used by a "
+                    "thread other than the one that created it, see #6540");
+#endif
+            }
+
             void clear_cache() noexcept
             {
                 cached_entry p;
@@ -175,6 +209,9 @@ namespace hpx::util {
             Stack<cached_entry, Allocator> data;
             std::atomic<std::size_t> cached;
             std::size_t const capacity = DefaultCapacity;
+#if defined(HPX_ALLOCATOR_SUPPORT_VERIFY_CACHE_OWNER)
+            std::thread::id const owner = std::this_thread::get_id();
+#endif
         };
 
         // Keep this lookup out of line. Once it is inlined, the compiler may

--- a/libs/core/allocator_support/include/hpx/allocator_support/thread_local_caching_allocator.hpp
+++ b/libs/core/allocator_support/include/hpx/allocator_support/thread_local_caching_allocator.hpp
@@ -177,14 +177,14 @@ namespace hpx::util {
             std::size_t const capacity = DefaultCapacity;
         };
 
-        // Keep this lookup out of line. HPX threads migrate between OS
-        // threads. If the compiler inlines the thread_local access into a
-        // caller that suspends the HPX thread, it reuses the thread pointer
-        // from before the suspension, and after the HPX thread resumes on
-        // another worker the caller pushes into that worker's cache instead
-        // of its own. That is harmless while the other worker lives, because
-        // the stack is lock-free, and corrupts the node list once the other
-        // worker has exited and its destructor is walking it.
+        // Keep this lookup out of line. Once it is inlined, the compiler may
+        // cache the address of allocated_data in the caller and reuse it
+        // across a point where the HPX thread suspends (see #6540). If the
+        // HPX thread resumes on another worker OS thread, that cached
+        // reference still names the previous worker's cache, so the caller
+        // pushes into it. The lock-free stack tolerates that while the
+        // previous worker lives. Once that worker has exited and its cache
+        // destructor is walking the node list, the list is corrupted.
         HPX_NOINLINE allocated_cache& cache()
         {
             thread_local allocated_cache allocated_data(alloc, DefaultCapacity);

--- a/libs/core/allocator_support/include/hpx/allocator_support/thread_local_caching_allocator.hpp
+++ b/libs/core/allocator_support/include/hpx/allocator_support/thread_local_caching_allocator.hpp
@@ -177,7 +177,15 @@ namespace hpx::util {
             std::size_t const capacity = DefaultCapacity;
         };
 
-        allocated_cache& cache()
+        // Keep this lookup out of line. HPX threads migrate between OS
+        // threads. If the compiler inlines the thread_local access into a
+        // caller that suspends the HPX thread, it reuses the thread pointer
+        // from before the suspension, and after the HPX thread resumes on
+        // another worker the caller pushes into that worker's cache instead
+        // of its own. That is harmless while the other worker lives, because
+        // the stack is lock-free, and corrupts the node list once the other
+        // worker has exited and its destructor is walking it.
+        HPX_NOINLINE allocated_cache& cache()
         {
             thread_local allocated_cache allocated_data(alloc, DefaultCapacity);
             return allocated_data;

--- a/libs/core/allocator_support/include/hpx/allocator_support/thread_local_caching_allocator.hpp
+++ b/libs/core/allocator_support/include/hpx/allocator_support/thread_local_caching_allocator.hpp
@@ -22,10 +22,11 @@
     !((defined(HPX_HAVE_CUDA) && defined(__CUDACC__)) ||                       \
         defined(HPX_HAVE_HIP))
 
-// The cache owner verification is enabled either by its own configuration
-// option or implicitly in debug builds. The option exists so that CI can turn
-// the check on for release builds as well, which is where a stale cache
-// reference has been observed (see #6540).
+// This diagnostic asserts that the cache is used by its owning OS thread.
+// It is independent of the compiler protections in cache(), which are
+// always enabled. Verification is enabled by its own configuration option
+// or implicitly in debug builds. The option lets CI enable it in release
+// builds, where stale cache references have been observed (see #6540).
 #if defined(HPX_ALLOCATOR_SUPPORT_HAVE_CACHE_OWNER_VERIFICATION) ||            \
     defined(HPX_DEBUG)
 #define HPX_ALLOCATOR_SUPPORT_VERIFY_CACHE_OWNER
@@ -188,8 +189,11 @@ namespace hpx::util {
             // standard libraries declare the underlying thread id lookup as
             // const, which would allow the compiler to reuse a value read
             // before the suspension and hide the very mismatch we look for.
+            // The compiler fence prevents interprocedural optimizations,
+            // including LTO, from eliminating repeated calls to this check.
             HPX_NOINLINE void verify_owner() const noexcept
             {
+                HPX_COMPILER_FENCE;
                 HPX_ASSERT_(owner == std::this_thread::get_id(),
                     "the thread_local allocator cache is being used by a "
                     "thread other than the one that created it, see #6540");
@@ -231,8 +235,12 @@ namespace hpx::util {
         // pushes into it. The lock-free stack tolerates that while the
         // previous worker lives. Once that worker has exited and its cache
         // destructor is walking the node list, the list is corrupted.
+        // The compiler fence also prevents interprocedural optimizations,
+        // including LTO, from treating this lookup as side-effect-free and
+        // reusing an earlier call's result.
         HPX_NOINLINE allocated_cache& cache()
         {
+            HPX_COMPILER_FENCE;
             thread_local allocated_cache allocated_data(alloc, DefaultCapacity);
             return allocated_data;
         }

--- a/libs/core/allocator_support/include/hpx/allocator_support/thread_local_caching_allocator.hpp
+++ b/libs/core/allocator_support/include/hpx/allocator_support/thread_local_caching_allocator.hpp
@@ -93,7 +93,9 @@ namespace hpx::util {
 
             pointer allocate(size_type n)
             {
+#if defined(HPX_ALLOCATOR_SUPPORT_VERIFY_CACHE_OWNER)
                 verify_owner();
+#endif
 
                 // Search for an entry with matching size. We try popping until
                 // we find matching size or data empty. Popped non-matching
@@ -147,7 +149,9 @@ namespace hpx::util {
 
             void deallocate(pointer p, size_type n)
             {
+#if defined(HPX_ALLOCATOR_SUPPORT_VERIFY_CACHE_OWNER)
                 verify_owner();
+#endif
 
                 if (cached.load(std::memory_order_relaxed) < capacity)
                 {
@@ -169,6 +173,7 @@ namespace hpx::util {
             }
 
         private:
+#if defined(HPX_ALLOCATOR_SUPPORT_VERIFY_CACHE_OWNER)
             // A cache belongs to the OS thread that created it. Reaching it
             // from any other thread means a caller held on to the reference
             // returned by cache() across a point where its HPX thread
@@ -180,12 +185,11 @@ namespace hpx::util {
             // before the suspension and hide the very mismatch we look for.
             HPX_NOINLINE void verify_owner() const noexcept
             {
-#if defined(HPX_ALLOCATOR_SUPPORT_VERIFY_CACHE_OWNER)
                 HPX_ASSERT_(owner == std::this_thread::get_id(),
                     "the thread_local allocator cache is being used by a "
                     "thread other than the one that created it, see #6540");
-#endif
             }
+#endif
 
             void clear_cache() noexcept
             {


### PR DESCRIPTION
`thread_local_caching_allocator::cache()` returns a function-local thread_local and gets inlined into every caller. A caller that suspends the HPX thread keeps the thread pointer from before the suspension, so after the HPX thread resumes on another worker it pushes into that worker's per-thread cache. The stack is lock-free, so nothing shows while the other worker lives. Once it has exited and its destructor is walking the node list, the list is corrupt. That is the `free(): invalid pointer` and `malloc_consolidate(): invalid chunk size` at `__call_tls_dtors` behind the sort, stable_sort, move and move_range failures on the gcc-13 and gcc-12-cuda release lanes, in CDash since at least 16 July.

Mark `cache()` `HPX_NOINLINE` so every lookup reads the current OS thread.

Measured on rostam, buran, gcc 13.3.1, master at bec10f3950, Release, `LD_PRELOAD=libc_malloc_debug.so.0 MALLOC_CHECK_=3`, `--hpx:threads=4`, 20 runs per test. master: 30 of 80 fail (move 5, move_range 7, stable_sort 10, sort 8). Same binaries with `--hpx:threads=1`: 80 of 80 pass. The cache made a pass-through: 80 of 80. This change: 80 of 80. valgrind on master shows the destructor freeing one 24 byte stack node twice.

No new test. The failure needs a worker to exit while a migrated HPX thread still holds the stale thread pointer; the existing algorithm tests hit that about a third of the time on the gcc-13 lane and nothing hits it deterministically.

`HPX_ALLOCATOR_SUPPORT_WITH_CACHING=OFF` no longer builds, `dataflow.hpp:110` uses the allocator unconditionally. Separate change.
