### PR TITLE
Tracy: bump to v0.14.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1187,7 +1187,7 @@ hpx_option(
 
 if(HPX_WITH_TRACY)
   hpx_option(
-    HPX_WITH_TRACY_TAG STRING "Tracy repository tag or branch" "v0.14.0"
+    HPX_WITH_TRACY_TAG STRING "Tracy repository tag or branch" "v0.14.1"
     CATEGORY "Profiling"
   )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1187,7 +1187,7 @@ hpx_option(
 
 if(HPX_WITH_TRACY)
   hpx_option(
-    HPX_WITH_TRACY_TAG STRING "Tracy repository tag or branch" "v0.13.1"
+    HPX_WITH_TRACY_TAG STRING "Tracy repository tag or branch" "v0.14.0"
     CATEGORY "Profiling"
   )
 endif()

--- a/docs/sphinx/manual/optimizing_hpx_applications.rst
+++ b/docs/sphinx/manual/optimizing_hpx_applications.rst
@@ -3622,9 +3622,12 @@ per-thread zone tracking, message logs, and fiber support. Enable it with
 Tracy can be supplied via a system install (point ``Tracy_ROOT`` at the install
 tree) or fetched by CMake at configure time by adding
 ``HPX_WITH_FETCH_TRACY=ON``. The version fetched is pinned by
-``HPX_WITH_TRACY_TAG``, which defaults to ``v0.13.1``. When Tracy is
-fetched, |hpx| forces ``TRACY_ON_DEMAND`` and ``TRACY_FIBERS`` on the built
-client. A system-supplied Tracy must have been built with both.
+``HPX_WITH_TRACY_TAG``, which defaults to ``v0.14.0``. When Tracy is
+fetched, |hpx| forces ``TRACY_ENABLE``, ``TRACY_ON_DEMAND`` and
+``TRACY_FIBERS`` on the built client. A system-supplied Tracy must have
+been built with the same three options; Tracy 0.14 mangles its exported
+profiler symbol based on the active define set, so a mismatch fails at
+link time rather than producing a silent inconsistency at runtime.
 
 To profile a distributed run, additionally enable
 :option:`HPX_WITH_PARCEL_PROFILING`\ ``=ON`` so per-parcel identifiers are

--- a/docs/sphinx/manual/optimizing_hpx_applications.rst
+++ b/docs/sphinx/manual/optimizing_hpx_applications.rst
@@ -3622,7 +3622,7 @@ per-thread zone tracking, message logs, and fiber support. Enable it with
 Tracy can be supplied via a system install (point ``Tracy_ROOT`` at the install
 tree) or fetched by CMake at configure time by adding
 ``HPX_WITH_FETCH_TRACY=ON``. The version fetched is pinned by
-``HPX_WITH_TRACY_TAG``, which defaults to ``v0.14.0``. When Tracy is
+``HPX_WITH_TRACY_TAG``, which defaults to ``v0.14.1``. When Tracy is
 fetched, |hpx| forces ``TRACY_ENABLE``, ``TRACY_ON_DEMAND`` and
 ``TRACY_FIBERS`` on the built client. A system-supplied Tracy must have
 been built with the same three options; Tracy 0.14 mangles its exported

--- a/libs/core/tracy/CMakeLists.txt
+++ b/libs/core/tracy/CMakeLists.txt
@@ -27,7 +27,7 @@ add_hpx_module(
   GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${tracy_sources}
   HEADERS ${tracy_headers}
-  MODULE_DEPENDENCIES hpx_config
+  MODULE_DEPENDENCIES hpx_config hpx_type_support
   DEPENDENCIES tracy::tracy
   CMAKE_SUBDIRS tests
 )

--- a/libs/core/tracy/CMakeLists.txt
+++ b/libs/core/tracy/CMakeLists.txt
@@ -27,7 +27,7 @@ add_hpx_module(
   GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${tracy_sources}
   HEADERS ${tracy_headers}
-  MODULE_DEPENDENCIES hpx_config hpx_type_support
+  MODULE_DEPENDENCIES hpx_config
   DEPENDENCIES tracy::tracy
   CMAKE_SUBDIRS tests
 )

--- a/libs/core/tracy/cmake/HPX_SetupTracy.cmake
+++ b/libs/core/tracy/cmake/HPX_SetupTracy.cmake
@@ -15,10 +15,6 @@ if(TRACY_ROOT AND NOT Tracy_ROOT)
   unset(TRACY_ROOT CACHE)
 endif()
 
-if(NOT HPX_WITH_TRACY_TAG)
-  set(HPX_WITH_TRACY_TAG "v0.13.1")
-endif()
-
 if(NOT HPX_WITH_FETCH_TRACY)
   find_package(Tracy)
   if(NOT Tracy_FOUND)
@@ -48,7 +44,13 @@ elseif(NOT TARGET tracy::tracy)
     GIT_SHALLOW TRUE
   )
 
-  # Set the correct build options for Tracy and make it available
+  # Set the correct build options for Tracy and make it available. 0.14 defaults
+  # TRACY_ENABLE OFF; without forcing it on, a HPX build with HPX_WITH_TRACY=ON
+  # compiles, links, and records nothing.
+  set(TRACY_ENABLE
+      ON
+      CACHE BOOL "" FORCE
+  )
   set(TRACY_FIBERS
       ON
       CACHE BOOL "" FORCE

--- a/libs/core/tracy/include/hpx/tracy/tracy_tls.hpp
+++ b/libs/core/tracy/include/hpx/tracy/tracy_tls.hpp
@@ -11,17 +11,21 @@
 
 #if defined(HPX_HAVE_TRACY)
 
-#include <hpx/modules/type_support.hpp>
-
 #include <cstddef>
 #include <cstdint>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx::tracy {
 
-    // Holds a TracyCZoneCtx without pulling in Tracy's headers. 16 bytes is
-    // Tracy 0.14 with TRACY_ON_DEMAND; tracy_tls.cpp asserts it still matches.
-    using zone_ctx_storage = hpx::aligned_storage_t<16, 8>;
+    // Mirror of TracyCZoneCtx under TRACY_ON_DEMAND (which HPX forces on).
+    // Keeping our own struct lets tracy_tls.hpp stay free of Tracy's headers.
+    // tracy_tls.cpp asserts the Tracy version and that the layouts still match.
+    struct zone_ctx_storage
+    {
+        std::uint32_t id = 0;
+        std::int32_t active = 0;
+        std::uint64_t connectionId = 0;
+    };
 
     HPX_CXX_CORE_EXPORT struct region_data
     {

--- a/libs/core/tracy/include/hpx/tracy/tracy_tls.hpp
+++ b/libs/core/tracy/include/hpx/tracy/tracy_tls.hpp
@@ -11,16 +11,22 @@
 
 #if defined(HPX_HAVE_TRACY)
 
+#include <hpx/type_support/aligned_storage.hpp>
+
 #include <cstddef>
 #include <cstdint>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx::tracy {
 
+    // Holds a TracyCZoneCtx without pulling in Tracy's headers. 16 bytes is
+    // Tracy 0.14 with TRACY_ON_DEMAND; tracy_tls.cpp asserts it still matches.
+    using zone_ctx_storage = hpx::aligned_storage_t<16, 8>;
+
     HPX_CXX_CORE_EXPORT struct region_data
     {
         char const* name = nullptr;
-        std::uint64_t data = 0;
+        zone_ctx_storage data{};
         std::uint32_t color = 0;
         std::uint32_t phase = 0;
     };
@@ -34,8 +40,8 @@ namespace hpx::tracy {
         HPX_CORE_EXPORT void add_worker_thread_text(
             region_data const& r, std::size_t num_thread) noexcept;
         HPX_CORE_EXPORT char const* rename_region(char const*) noexcept;
-        HPX_CORE_EXPORT std::uint64_t push_zone(char const*) noexcept;
-        HPX_CORE_EXPORT void pop_zone(std::uint64_t) noexcept;
+        HPX_CORE_EXPORT zone_ctx_storage push_zone(char const*) noexcept;
+        HPX_CORE_EXPORT void pop_zone(zone_ctx_storage const&) noexcept;
         HPX_CORE_EXPORT region_data stop_region(
             region_data const& prev_region) noexcept;
         // Set/clear the per-OS-thread "inside fiber" flag used to guard
@@ -183,7 +189,7 @@ namespace hpx::tracy {
         // the paired pop_zone in the dtor.
         explicit mark_event(char const* name, bool active) noexcept
           : active_(active)
-          , ctx_value(active_ ? detail::push_zone(name) : 0)
+          , ctx_value(active_ ? detail::push_zone(name) : zone_ctx_storage{})
         {
         }
 
@@ -208,7 +214,7 @@ namespace hpx::tracy {
 
     private:
         bool active_;
-        std::uint64_t ctx_value;
+        zone_ctx_storage ctx_value;
     };
 
     // RAII guard that closes the running fiber zone before self_.yield() and

--- a/libs/core/tracy/include/hpx/tracy/tracy_tls.hpp
+++ b/libs/core/tracy/include/hpx/tracy/tracy_tls.hpp
@@ -11,7 +11,7 @@
 
 #if defined(HPX_HAVE_TRACY)
 
-#include <hpx/type_support/aligned_storage.hpp>
+#include <hpx/modules/type_support.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/libs/core/tracy/src/tracy_tls.cpp
+++ b/libs/core/tracy/src/tracy_tls.cpp
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <type_traits>
 
 #include <tracy/TracyC.h>
 
@@ -50,14 +51,26 @@ namespace hpx::tracy {
             return flag;
         }
 
-        // This union is used to hide the Tracy context type from the user.
+        // Aliases TracyCZoneCtx with a byte buffer of matching size and
+        // alignment so callers can hold the ctx opaquely. The static_asserts
+        // are the guardrail against a Tracy version bump that grows the ctx.
         union tracy_context
         {
-            static_assert(sizeof(TracyCZoneCtx) == sizeof(std::uint64_t));
+            static_assert(sizeof(TracyCZoneCtx) == sizeof(zone_ctx_storage));
+            static_assert(alignof(TracyCZoneCtx) == alignof(zone_ctx_storage));
+            static_assert(std::is_trivially_copyable_v<zone_ctx_storage>);
 
             TracyCZoneCtx context;
-            std::uint64_t value;
+            zone_ctx_storage value;
         };
+
+        // Compare against a zero-initialised storage. Used as the
+        // "unset" sentinel by callers that stash a ctx into TLS.
+        bool ctx_is_empty(zone_ctx_storage const& s) noexcept
+        {
+            zone_ctx_storage const zero{};
+            return std::memcmp(&s, &zero, sizeof(zone_ctx_storage)) == 0;
+        }
 
         // Store the zone ctx that was opened on the fiber's stack.
         // enter_fiber opens a zone (so the fiber track is visible in Tracy),
@@ -67,7 +80,7 @@ namespace hpx::tracy {
         // task resumes from self_.yield().
         struct fiber_zone_data
         {
-            std::uint64_t ctx_value = 0;
+            zone_ctx_storage ctx_value{};
             char const* zone_name = "fiber";
             std::uint32_t color = 0;
             bool active = false;
@@ -184,7 +197,7 @@ namespace hpx::tracy {
                 data.value = fz.ctx_value;
                 TracyCZoneEnd(data.context);
                 fz.active = false;
-                fz.ctx_value = 0;
+                fz.ctx_value = {};
             }
         }
 
@@ -262,7 +275,8 @@ namespace hpx::tracy {
             char const* txt, std::size_t size) noexcept
         {
             auto& fz = current_fiber_zone();
-            if (txt == nullptr || size == 0 || !fz.active || fz.ctx_value == 0)
+            if (txt == nullptr || size == 0 || !fz.active ||
+                ctx_is_empty(fz.ctx_value))
                 return;
 
             tracy_context data;
@@ -307,7 +321,7 @@ namespace hpx::tracy {
         HPX_CORE_EXPORT void add_worker_thread_text(
             region_data const& r, std::size_t const num_thread) noexcept
         {
-            if (r.data == 0)
+            if (ctx_is_empty(r.data))
                 return;
 
             auto const& cache = get_worker_labels();
@@ -362,7 +376,7 @@ namespace hpx::tracy {
             return nullptr;
         }
 
-        HPX_CORE_EXPORT std::uint64_t push_zone(char const* name) noexcept
+        HPX_CORE_EXPORT zone_ctx_storage push_zone(char const* name) noexcept
         {
             char const* safe_name = intern_zone_label(name, "event");
             TracyCZoneC(ctx, 0x0078D7, 1);
@@ -372,9 +386,10 @@ namespace hpx::tracy {
             return data.value;
         }
 
-        HPX_CORE_EXPORT void pop_zone(std::uint64_t ctx_value) noexcept
+        HPX_CORE_EXPORT void pop_zone(
+            zone_ctx_storage const& ctx_value) noexcept
         {
-            if (ctx_value)
+            if (!ctx_is_empty(ctx_value))
             {
                 tracy_context data;
                 data.value = ctx_value;

--- a/libs/core/tracy/src/tracy_tls.cpp
+++ b/libs/core/tracy/src/tracy_tls.cpp
@@ -14,14 +14,38 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
-#include <type_traits>
 
+#include <common/TracyVersion.hpp>
 #include <tracy/TracyC.h>
+
+// zone_ctx_storage mirrors ___tracy_c_zone_context under TRACY_ON_DEMAND. The
+// version check pins the range the layout was written for; the size and
+// alignment asserts catch a change within a patch release.
+static_assert(tracy::Version::Major == 0 && tracy::Version::Minor == 14,
+    "zone_ctx_storage layout was written for Tracy 0.14.x; re-check "
+    "___tracy_c_zone_context before widening the range.");
+static_assert(sizeof(TracyCZoneCtx) == sizeof(hpx::tracy::zone_ctx_storage));
+static_assert(alignof(TracyCZoneCtx) == alignof(hpx::tracy::zone_ctx_storage));
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx::tracy {
 
     namespace {
+
+        // Conversions to and from Tracy's C ctx type. Designated initialisers
+        // turn a future field reorder or rename into a compile error.
+        constexpr zone_ctx_storage to_storage(TracyCZoneCtx const& c) noexcept
+        {
+            return {
+                .id = c.id, .active = c.active, .connectionId = c.connectionId};
+        }
+
+        constexpr TracyCZoneCtx to_tracy(zone_ctx_storage const& s) noexcept
+        {
+            return {
+                .id = s.id, .active = s.active, .connectionId = s.connectionId};
+        }
+
         char const* intern_zone_label(
             char const* label, char const* fallback) noexcept
         {
@@ -51,25 +75,12 @@ namespace hpx::tracy {
             return flag;
         }
 
-        // Aliases TracyCZoneCtx with a byte buffer of matching size and
-        // alignment so callers can hold the ctx opaquely. The static_asserts
-        // are the guardrail against a Tracy version bump that grows the ctx.
-        union tracy_context
+        // "Unset" sentinel for a ctx stashed in TLS. A live ctx opened while
+        // disconnected is also all-zero, but TracyCZoneEnd is a no-op when
+        // active is 0, so treating that case as "unset" is safe.
+        constexpr bool ctx_is_empty(zone_ctx_storage const& s) noexcept
         {
-            static_assert(sizeof(TracyCZoneCtx) == sizeof(zone_ctx_storage));
-            static_assert(alignof(TracyCZoneCtx) == alignof(zone_ctx_storage));
-            static_assert(std::is_trivially_copyable_v<zone_ctx_storage>);
-
-            TracyCZoneCtx context;
-            zone_ctx_storage value;
-        };
-
-        // Compare against a zero-initialised storage. Used as the
-        // "unset" sentinel by callers that stash a ctx into TLS.
-        bool ctx_is_empty(zone_ctx_storage const& s) noexcept
-        {
-            zone_ctx_storage const zero{};
-            return std::memcmp(&s, &zero, sizeof(zone_ctx_storage)) == 0;
+            return s.id == 0 && s.active == 0 && s.connectionId == 0;
         }
 
         // Store the zone ctx that was opened on the fiber's stack.
@@ -99,10 +110,7 @@ namespace hpx::tracy {
             TracyCZoneC(ctx, color, 1);
             TracyCZoneName(ctx, zone_name, std::strlen(zone_name));
 
-            tracy_context data;
-            data.context = ctx;
-
-            fz.ctx_value = data.value;
+            fz.ctx_value = to_storage(ctx);
             fz.active = true;
         }
     }    // namespace
@@ -121,14 +129,11 @@ namespace hpx::tracy {
             TracyCZoneName(ctx, new_region, std::strlen(new_region));
             TracyCZoneValue(ctx, static_cast<std::uint32_t>(phase));
 
-            tracy_context data;
-            data.context = ctx;
-
             region_data& region = current_region();
             region_data const prev_region = region;
 
             region.name = new_region;
-            region.data = data.value;
+            region.data = to_storage(ctx);
             region.color = static_cast<std::uint32_t>(thread_num);
             region.phase = static_cast<std::uint32_t>(phase);
 
@@ -141,14 +146,11 @@ namespace hpx::tracy {
             TracyCZoneC(ctx, color, 1);
             TracyCZoneName(ctx, name, std::strlen(name));
 
-            tracy_context data;
-            data.context = ctx;
-
             region_data& region = current_region();
             region_data const prev_region = region;
 
             region.name = name;
-            region.data = data.value;
+            region.data = to_storage(ctx);
             region.color = color;
             region.phase = 0;
 
@@ -163,9 +165,7 @@ namespace hpx::tracy {
             current_region() = prev_region;
             if (curr_region.name != nullptr)
             {
-                tracy_context data;
-                data.value = curr_region.data;
-                TracyCZoneEnd(data.context);
+                TracyCZoneEnd(to_tracy(curr_region.data));
             }
 
             return curr_region;
@@ -193,9 +193,7 @@ namespace hpx::tracy {
             auto& fz = current_fiber_zone();
             if (fz.active)
             {
-                tracy_context data;
-                data.value = fz.ctx_value;
-                TracyCZoneEnd(data.context);
+                TracyCZoneEnd(to_tracy(fz.ctx_value));
                 fz.active = false;
                 fz.ctx_value = {};
             }
@@ -215,11 +213,7 @@ namespace hpx::tracy {
                 return;
 
             // Close the running zone.
-            {
-                tracy_context data;
-                data.value = fz.ctx_value;
-                TracyCZoneEnd(data.context);
-            }
+            TracyCZoneEnd(to_tracy(fz.ctx_value));
             fz.active = false;
 
             // Open a grey "suspended" zone on the fiber stack.
@@ -252,11 +246,7 @@ namespace hpx::tracy {
                 return;
 
             // Close the suspended (grey) zone.
-            {
-                tracy_context data;
-                data.value = fz.ctx_value;
-                TracyCZoneEnd(data.context);
-            }
+            TracyCZoneEnd(to_tracy(fz.ctx_value));
             fz.active = false;
 
             // Reopen the running zone with cached or supplied name/color.
@@ -279,10 +269,8 @@ namespace hpx::tracy {
                 ctx_is_empty(fz.ctx_value))
                 return;
 
-            tracy_context data;
-            data.value = fz.ctx_value;
             // TracyCZoneText sends the text via the zone validation protocol.
-            TracyCZoneText(data.context, txt, size);
+            TracyCZoneText(to_tracy(fz.ctx_value), txt, size);
         }
 
         namespace {
@@ -345,9 +333,7 @@ namespace hpx::tracy {
 
             if (len > 0)
             {
-                tracy_context data;
-                data.value = r.data;
-                TracyCZoneText(data.context, text, len);
+                TracyCZoneText(to_tracy(r.data), text, len);
             }
         }
 
@@ -367,10 +353,8 @@ namespace hpx::tracy {
                 char const* previous_name = name;
                 name = new_region;
 
-                tracy_context data;
-                data.value = value;
                 TracyCZoneName(
-                    data.context, new_region, std::strlen(new_region));
+                    to_tracy(value), new_region, std::strlen(new_region));
                 return previous_name;
             }
             return nullptr;
@@ -381,9 +365,7 @@ namespace hpx::tracy {
             char const* safe_name = intern_zone_label(name, "event");
             TracyCZoneC(ctx, 0x0078D7, 1);
             TracyCZoneName(ctx, safe_name, std::strlen(safe_name));
-            tracy_context data;
-            data.context = ctx;
-            return data.value;
+            return to_storage(ctx);
         }
 
         HPX_CORE_EXPORT void pop_zone(
@@ -391,9 +373,7 @@ namespace hpx::tracy {
         {
             if (!ctx_is_empty(ctx_value))
             {
-                tracy_context data;
-                data.value = ctx_value;
-                TracyCZoneEnd(data.context);
+                TracyCZoneEnd(to_tracy(ctx_value));
             }
         }
     }    // namespace detail


### PR DESCRIPTION
## Proposed Changes

  - Bump `HPX_WITH_TRACY_TAG` to `v0.14.0` and force `TRACY_ENABLE` on, since 0.14 defaults it off.
  - Store the zone context in `hpx::aligned_storage_t` instead of a `std::uint64_t` — 0.14 grew `TracyCZoneCtx` from 8 to 16 bytes.
  - Update the Tracy section of the manual.

## Any background context you want to provide?

**TRACY_ENABLE.** 0.14 changed the default to off in Tracy's own CMake. Without forcing it, a build with `HPX_WITH_TRACY=ON` compiles and links fine but records nothing — no error, no warning, just an empty capture. `HPX_SetupTracy.cmake` now forces it alongside the existing `TRACY_ON_DEMAND` and `TRACY_FIBERS`.

**The context.** 0.14 added a `connectionId` field to `TracyCZoneCtx` under `TRACY_ON_DEMAND`, taking it from 8 to 16 bytes. `tracy_tls.cpp` held that context in a union with a `std::uint64_t` and asserted the sizes matched, so the assert now fails. It's stored in `hpx::aligned_storage_t<16, 8>` now.

The asserts moved into the `.cpp`, where `TracyC.h` is already included, so the header no longer needs Tracy's C API. I compiled the new file against 0.13.1's headers to check they still fire — GCC reports `(8 == 16)` and `(4 == 8)`. So if Tracy grows the context again the build fails instead of silently truncating.

The old code used `if (ctx_value)` to check whether a context was set, which doesn't work on a 16-byte struct. Three of those places now use `ctx_is_empty`, and two reset with `= {}`.

**One side effect.** `region_data` grows from 24 to 32 bytes, which carries into the tracing wrapper types. Anything built against Tracy-enabled HPX needs rebuilding.

I diffed the Tracy C API symbols we call between the two versions and didn't find other changes, but I've only tested on Linux with GCC.

**CI.** `linux_debug_tracy.yml` and `windows_debug_vs2022_tracy.yml` don't pin the tag, so they pick up the new default. No Jenkins job builds Tracy.

## Checklist

Not all points below apply to all pull requests.
- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.

