### PR TITLE
Tracing: add per-subsystem gates for event classes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1190,6 +1190,42 @@ if(HPX_WITH_TRACY)
     HPX_WITH_TRACY_TAG STRING "Tracy repository tag or branch" "v0.13.1"
     CATEGORY "Profiling"
   )
+
+  # Per-subsystem tracing gates. Each event class is compiled out when its
+  # option is OFF so that users profiling one subsystem do not pay the cost of
+  # the others. Defaults preserve current behaviour: all three classes on.
+  hpx_option(
+    HPX_WITH_TRACING_LIFECYCLE_EVENTS
+    BOOL
+    "Emit per-task lifecycle events (staged, created, executing, yielded, suspended, resumed, completed, deleted). Default: ON."
+    ON
+    CATEGORY "Profiling"
+  )
+  if(HPX_WITH_TRACING_LIFECYCLE_EVENTS)
+    hpx_add_config_define(HPX_HAVE_TRACING_LIFECYCLE_EVENTS)
+  endif()
+
+  hpx_option(
+    HPX_WITH_TRACING_CAUSAL_EVENTS
+    BOOL
+    "Emit causal chain events (future_fulfilled, future_exception_set, continuation_run, continuation_finished, handle_on_completed_fired). Default: ON."
+    ON
+    CATEGORY "Profiling"
+  )
+  if(HPX_WITH_TRACING_CAUSAL_EVENTS)
+    hpx_add_config_define(HPX_HAVE_TRACING_CAUSAL_EVENTS)
+  endif()
+
+  hpx_option(
+    HPX_WITH_TRACING_WORK_STEALING_EVENTS
+    BOOL
+    "Emit work-stealing events when a worker steals a task from another. Default: ON."
+    ON
+    CATEGORY "Profiling"
+  )
+  if(HPX_WITH_TRACING_WORK_STEALING_EVENTS)
+    hpx_add_config_define(HPX_HAVE_TRACING_WORK_STEALING_EVENTS)
+  endif()
 endif()
 
 hpx_option(

--- a/docs/sphinx/manual/building_hpx.rst
+++ b/docs/sphinx/manual/building_hpx.rst
@@ -117,6 +117,28 @@ used CMake options.
    start time, parcel id) that are carried on the wire and surfaced to whichever tracing backend is
    enabled. Defaults to ``ON`` when :option:`HPX_WITH_APEX` is on, ``OFF`` otherwise.
 
+.. option:: HPX_WITH_TRACING_LIFECYCLE_EVENTS
+
+   Emit per-task lifecycle events (staged, created, executing, yielded, suspended, resumed, completed,
+   deleted). Defaults to ``ON``. Turn ``OFF`` to compile out the per-task hooks and their runtime
+   connection check when profiling a workload where only causal or work-stealing events matter. The
+   saving applies on Tracy builds; the other backends already treat these hooks as no-ops.
+
+.. option:: HPX_WITH_TRACING_CAUSAL_EVENTS
+
+   Emit causal-chain events (``future_fulfilled``, ``future_exception_set``, ``continuation_run``,
+   ``continuation_finished``, ``handle_on_completed_fired``). Defaults to ``ON``. Turning this ``OFF``
+   also elides the active-continuations counter update in ``continuation_run`` /
+   ``continuation_finished``. The saving applies on Tracy builds; the other backends already treat
+   these hooks as no-ops.
+
+.. option:: HPX_WITH_TRACING_WORK_STEALING_EVENTS
+
+   Emit the work-stealing signal when a worker steals a task from another worker. Defaults to ``ON``.
+   Turn ``OFF`` when profiling a workload with heavy work stealing where the signal itself is not
+   being consumed. The saving applies on Tracy builds; the other backends already treat this hook as
+   a no-op.
+
 .. option:: HPX_WITH_GENERIC_CONTEXT_COROUTINES
 
    Enable Boost. Context for task context switching. It must be enabled for non-x86 architectures such as ARM and Power.

--- a/docs/sphinx/manual/optimizing_hpx_applications.rst
+++ b/docs/sphinx/manual/optimizing_hpx_applications.rst
@@ -3631,6 +3631,17 @@ To profile a distributed run, additionally enable
 carried on the wire and the ``send_parcel`` / ``recv_parcel`` /
 ``parcel_scheduled`` events can be correlated across localities by parcel id.
 
+Event classes can be compiled out individually to reduce the tracing cost
+when only a subset of the timeline is being investigated:
+:option:`HPX_WITH_TRACING_LIFECYCLE_EVENTS`,
+:option:`HPX_WITH_TRACING_CAUSAL_EVENTS`, and
+:option:`HPX_WITH_TRACING_WORK_STEALING_EVENTS`. All three default to ``ON``; turning
+one off compiles the wrapper for that class to a no-op, so the runtime
+connection check and the event body do not run (argument evaluation at each
+call site is unchanged). These gates affect the Tracy backend, which is the
+only backend that emits these classes today; the APEX, ITT-Notify and empty
+backends already treat all three as no-ops.
+
 Start ``tracy-profiler`` (or ``tracy-capture`` for headless capture) before
 or during the run. Tracy discovers instrumented processes via UDP broadcast
 on the local network; no port configuration is required for the common case.

--- a/libs/core/tracing/include/hpx/tracing/backends/tracy.hpp
+++ b/libs/core/tracing/include/hpx/tracing/backends/tracy.hpp
@@ -283,9 +283,12 @@ namespace hpx::tracing {
             void const* task_id) noexcept;
     }    // namespace detail
 
-    // Inline gate wrappers. When the profiler is not connected, the whole
-    // per-task snprintf/message/log-string chain is short-circuited at the
-    // call site; only a single atomic load runs.
+    // Inline gate wrappers. When the profiler is not connected, each wrapper
+    // short-circuits on a single atomic load. HPX_HAVE_TRACING_LIFECYCLE_EVENTS
+    // compiles the wrapper body to a constexpr no-op, so the runtime check and
+    // the _impl call are elided; argument evaluation at each call site is
+    // unchanged.
+#if defined(HPX_HAVE_TRACING_LIFECYCLE_EVENTS)
 
     /// \brief Task-lifecycle signal: task description registered before the
     ///        thread object exists.
@@ -372,6 +375,42 @@ namespace hpx::tracing {
         detail::task_deleted_impl(task_id);
     }
 
+#else
+
+    // Gated-off versions mirror the empty-backend shape (unnamed parameters,
+    // constexpr no-op) so the wrapper inlines away at every existing site.
+    HPX_CXX_CORE_EXPORT constexpr void task_staged(
+        char const*, void const* = nullptr) noexcept
+    {
+    }
+    HPX_CXX_CORE_EXPORT constexpr void task_created(
+        char const*, void const*, void const* = nullptr) noexcept
+    {
+    }
+    HPX_CXX_CORE_EXPORT constexpr void task_executing(
+        void const*, char const*, std::size_t) noexcept
+    {
+    }
+    HPX_CXX_CORE_EXPORT constexpr void task_yielded(
+        void const*, char const*) noexcept
+    {
+    }
+    HPX_CXX_CORE_EXPORT constexpr void task_suspended(
+        void const*, char const*, char const* = nullptr) noexcept
+    {
+    }
+    HPX_CXX_CORE_EXPORT constexpr void task_resumed(
+        void const*, char const*, char const* = nullptr) noexcept
+    {
+    }
+    HPX_CXX_CORE_EXPORT constexpr void task_completed(
+        void const*, char const*) noexcept
+    {
+    }
+    HPX_CXX_CORE_EXPORT constexpr void task_deleted(void const*) noexcept {}
+
+#endif    // HPX_HAVE_TRACING_LIFECYCLE_EVENTS
+
     ////////////////////////////////////////////////////////////////////////////
     // Causal tracing: future fulfillment signals.
     //
@@ -388,20 +427,22 @@ namespace hpx::tracing {
     // producer message precedes the consumer wake-up in wall-clock order).
 
     namespace detail {
+#if defined(HPX_HAVE_TRACING_CAUSAL_EVENTS)
         HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void future_fulfilled_impl(
             void const* future_id, char const* desc = nullptr) noexcept;
 
         HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void future_exception_set_impl(
             void const* future_id, char const* desc = nullptr) noexcept;
 
-        // Active-continuations counter. Updated unconditionally by the
-        // continuation_run / continuation_finished inline wrappers below,
-        // even when no profiler is attached, so the tally stays consistent
-        // across connect/disconnect transitions. Only the Tracy emission
-        // (message + sample_value + fiber text) is gated. If both sides
-        // were gated instead, a run that started disconnected and finished
-        // connected would decrement without a matching increment (and the
-        // reverse would leak a permanent positive drift).
+        // Active-continuations counter. Two gates apply at different levels.
+        // Runtime (profiler connected or not): continuation_run/finished bump
+        // this on every call regardless of connection state, so a run that
+        // spans a disconnect/connect transition leaves no drift. Only the
+        // Tracy emission (message + sample_value + fiber text) is gated on
+        // is_profiler_connected(). Compile (HPX_HAVE_TRACING_CAUSAL_EVENTS):
+        // the counter and its updates are compiled out together with the
+        // rest of the causal machinery; nothing outside these _emit bodies
+        // reads it.
         //
         // The plot value is loaded inside each _emit body rather than
         // snapshotted at the fetch_add/fetch_sub call site, so that Tracy
@@ -418,6 +459,7 @@ namespace hpx::tracing {
 
         HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void handle_on_completed_fired_impl(
             void const* task_id = nullptr) noexcept;
+#endif    // HPX_HAVE_TRACING_CAUSAL_EVENTS
 
         HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void work_stolen_impl(
             std::size_t thief_id, std::size_t victim_id, void const* task_id,
@@ -442,6 +484,13 @@ namespace hpx::tracing {
             std::uint64_t source_locality_id,
             std::uint64_t source_thread_id) noexcept;
     }    // namespace detail
+
+    // HPX_HAVE_TRACING_CAUSAL_EVENTS gates the producer wrappers and the
+    // consumer wrappers together, including the g_active_continuations
+    // fetch_add/fetch_sub inside continuation_run/finished. Nothing outside
+    // these wrappers reads that counter, so gating it off leaves nothing
+    // stale.
+#if defined(HPX_HAVE_TRACING_CAUSAL_EVENTS)
 
     /// \brief Producer-side signal: a future shared state was set to a value.
     ///
@@ -505,6 +554,36 @@ namespace hpx::tracing {
         detail::handle_on_completed_fired_impl(task_id);
     }
 
+#else
+
+    HPX_CXX_CORE_EXPORT constexpr void future_fulfilled(
+        void const*, char const* = nullptr) noexcept
+    {
+    }
+    HPX_CXX_CORE_EXPORT constexpr void future_exception_set(
+        void const*, char const* = nullptr) noexcept
+    {
+    }
+    HPX_CXX_CORE_EXPORT constexpr void continuation_run(
+        void const* = nullptr) noexcept
+    {
+    }
+    HPX_CXX_CORE_EXPORT constexpr void continuation_finished(
+        void const* = nullptr) noexcept
+    {
+    }
+    HPX_CXX_CORE_EXPORT constexpr void handle_on_completed_fired(
+        void const* = nullptr) noexcept
+    {
+    }
+
+#endif    // HPX_HAVE_TRACING_CAUSAL_EVENTS
+
+    // HPX_HAVE_TRACING_WORK_STEALING_EVENTS gates the work-steal signal. The signal
+    // is emitted from the scheduler's steal loop after a successful steal;
+    // gating it off elides the runtime check and the _impl body.
+#if defined(HPX_HAVE_TRACING_WORK_STEALING_EVENTS)
+
     /// \brief Signal emitted when a worker thread steals a task from
     ///        another worker.
     HPX_CXX_CORE_EXPORT inline void work_stolen(std::size_t thief_id,
@@ -515,6 +594,15 @@ namespace hpx::tracing {
             return;
         detail::work_stolen_impl(thief_id, victim_id, task_id, desc);
     }
+
+#else
+
+    HPX_CXX_CORE_EXPORT constexpr void work_stolen(
+        std::size_t, std::size_t, void const*, char const* = nullptr) noexcept
+    {
+    }
+
+#endif    // HPX_HAVE_TRACING_WORK_STEALING_EVENTS
 
     /// \brief Emit a frame/stage boundary marker in Tracy timeline.
     ///

--- a/libs/core/tracing/include/hpx/tracing/backends/tracy.hpp
+++ b/libs/core/tracing/include/hpx/tracing/backends/tracy.hpp
@@ -253,6 +253,7 @@ namespace hpx::tracing {
     };
 
     namespace detail {
+#if defined(HPX_HAVE_TRACING_LIFECYCLE_EVENTS)
         HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void task_staged_impl(
             char const* description,
             void const* parent_task_id = nullptr) noexcept;
@@ -281,6 +282,7 @@ namespace hpx::tracing {
 
         HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void task_deleted_impl(
             void const* task_id) noexcept;
+#endif    // HPX_HAVE_TRACING_LIFECYCLE_EVENTS
     }    // namespace detail
 
     // Inline gate wrappers. When the profiler is not connected, each wrapper
@@ -461,9 +463,11 @@ namespace hpx::tracing {
             void const* task_id = nullptr) noexcept;
 #endif    // HPX_HAVE_TRACING_CAUSAL_EVENTS
 
+#if defined(HPX_HAVE_TRACING_WORK_STEALING_EVENTS)
         HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void work_stolen_impl(
             std::size_t thief_id, std::size_t victim_id, void const* task_id,
             char const* desc = nullptr) noexcept;
+#endif    // HPX_HAVE_TRACING_WORK_STEALING_EVENTS
 
         HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void frame_mark_impl(
             char const* name = nullptr) noexcept;

--- a/libs/core/tracing/src/backends/tracy.cpp
+++ b/libs/core/tracing/src/backends/tracy.cpp
@@ -182,6 +182,7 @@ namespace hpx::tracing {
         }
 
         ////////////////////////////////////////////////////////////////////////
+#if defined(HPX_HAVE_TRACING_LIFECYCLE_EVENTS)
         enum class color : std::uint32_t
         {
             staged = 0x808080,
@@ -198,10 +199,12 @@ namespace hpx::tracing {
         {
             return str ? str : "<unknown>";
         }
+#endif    // HPX_HAVE_TRACING_LIFECYCLE_EVENTS
     }    // namespace detail
 
     namespace detail {
 
+#if defined(HPX_HAVE_TRACING_LIFECYCLE_EVENTS)
         void task_staged_impl(
             char const* description, void const* parent_task_id) noexcept
         {
@@ -319,10 +322,12 @@ namespace hpx::tracing {
             hpx::tracy::message(buffer, std::strlen(buffer),
                 static_cast<std::uint32_t>(color::deleted));
         }
+#endif    // HPX_HAVE_TRACING_LIFECYCLE_EVENTS
 
         ////////////////////////////////////////////////////////////////////////////
         // Causal tracing: future fulfillment signals
 
+#if defined(HPX_HAVE_TRACING_CAUSAL_EVENTS)
         void future_fulfilled_impl(
             void const* future_id, char const* desc) noexcept
         {
@@ -426,7 +431,9 @@ namespace hpx::tracing {
             // Embed directly into active fiber visual zone text
             hpx::tracy::detail::add_zone_text_to_fiber(buffer, len);
         }
+#endif    // HPX_HAVE_TRACING_CAUSAL_EVENTS
 
+#if defined(HPX_HAVE_TRACING_WORK_STEALING_EVENTS)
         void work_stolen_impl(std::size_t thief_id, std::size_t victim_id,
             void const* task_id, char const* desc) noexcept
         {
@@ -446,6 +453,7 @@ namespace hpx::tracing {
             // Amber/Gold color: 0xFFC107
             hpx::tracy::message(buffer, std::strlen(buffer), 0xFFC107u);
         }
+#endif    // HPX_HAVE_TRACING_WORK_STEALING_EVENTS
 
         void frame_mark_impl(char const* name) noexcept
         {


### PR DESCRIPTION
## Proposed Changes

  - Add `HPX_WITH_TRACING_LIFECYCLE_EVENTS`, `HPX_WITH_TRACING_CAUSAL_EVENTS` and `HPX_WITH_TRACING_WORK_STEALING`, all defaulting to `ON`.
  - Gate the corresponding hooks in the Tracy backend so turning one off compiles the wrapper to a no-op.
  - Document the three options.

## Any background context you want to provide?

Someone profiling scheduler behaviour pays for causal tracing they aren't looking at. These let a build drop whole classes of events.

Gated inside the backend wrappers rather than at the call sites, so nothing at the ~30 emit sites changes. When a gate is off the wrapper becomes a `constexpr` no-op — the runtime connection check and the event body both go. Argument evaluation at the call site is unchanged, so `get_safe_description` in `create_thread.cpp` still runs either way.

The `CAUSAL` gate also removes `g_active_continuations` and its `fetch_add`/`fetch_sub`, since nothing outside the causal wrappers reads it.

Only the Tracy backend is gated — APEX, ITT-Notify and the empty backend already treat all 14 hooks as no-ops, so there's nothing to compile out there. I'll add the same guards to ITT when I implement the hooks there.

**Measurements.** Timing deltas between separately-linked binaries turned out to be dominated by code-layout noise, so I counted events instead and multiplied by the per-emit cost. On `benchmark_stealing` at 4 threads under a live profiler, tracing overhead is 1.22s of a 1.32s run across 1.33M events, so about 917ns per emit.

| | events | share of wall time |
|---|---|---|
| lifecycle | 815k | 57% |
| causal | 325k | 22% |
| work stealing | 190k | 13% |

`async_overheads` gives a similar picture, except work stealing drops to 2% since that workload barely steals.

The lifecycle projection reproduces on `future_overhead_test`: lifecycle-off is 53% faster than all-on at 4 threads under capture. The causal projection agrees with a direct timing run at 14-18%, which is inside the noise floor for cross-binary timing — that's why counting is the primary method here.

Verified with `nm -u` on the compiled objects under `libs/core/{threading_base,futures,schedulers,thread_pools}` that each gate removes only its own class's `_impl` references.

I also looked at gating sleep events, but `os_thread_sleep` fires 4 times per run on every benchmark I tried, so there was nothing to gate.

## Checklist

Not all points below apply to all pull requests.
- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.

