### PR TITLE
Add feature build check for std::filesystem::display_string

### DIFF
--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -620,3 +620,12 @@ function(hpx_check_for_stable_inplace_merge)
     FILE ${ARGN}
   )
 endfunction()
+
+# ##############################################################################
+function(hpx_check_for_cxx26_filesystem_display_string)
+  add_hpx_config_test(
+    HPX_WITH_CXX26_FILESYSTEM_DISPLAY_STRING
+    SOURCE cmake/tests/cxx26_filesystem_display_string.cpp
+    FILE ${ARGN}
+  )
+endfunction()

--- a/cmake/HPX_PerformCxxFeatureTests.cmake
+++ b/cmake/HPX_PerformCxxFeatureTests.cmake
@@ -146,4 +146,8 @@ function(hpx_perform_cxx_feature_tests)
     DEFINITIONS HPX_HAVE_BUILTIN_FRAME_ADDRESS
   )
 
+  hpx_check_for_cxx26_filesystem_display_string(
+    DEFINITIONS HPX_HAVE_CXX26_FILESYSTEM_DISPLAY_STRING
+  )
+
 endfunction()

--- a/cmake/tests/cxx26_filesystem_display_string.cpp
+++ b/cmake/tests/cxx26_filesystem_display_string.cpp
@@ -1,0 +1,16 @@
+//  Copyright (c) 2026 Nick Derise
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// test for availability of std::filesystem::path::display_string()
+
+#include <filesystem>
+
+int main()
+{
+    std::filesystem::path p;
+    (void) p.display_string();
+    return 0;
+}

--- a/libs/core/filesystem/include/hpx/filesystem/api.hpp
+++ b/libs/core/filesystem/include/hpx/filesystem/api.hpp
@@ -39,7 +39,7 @@ namespace hpx::filesystem {
     HPX_CXX_CORE_EXPORT [[nodiscard]] inline std::string to_string(
         path const& p)
     {
-#if defined(__GLIBCXX__) && __cplusplus >= 202400L
+#if defined(HPX_HAVE_CXX26_FILESYSTEM_DISPLAY_STRING)
         return p.display_string();
 #else
         return p.string();


### PR DESCRIPTION
Fixes #
Error in build using gcc 16.2, caused by incorrect flag check for display_string

## Proposed Changes
  - Add std::filesystem::display_string check and replace existing flag check

## Any background context you want to provide?
It seems that in 16.2 gcc has moved or removed `std::filesystem::display_string()`, and filesystem/api.hpp is only checking for cpp version definition, causing build failure when display_string() is called. This PR adds a dedicated test, perhaps later to be replaced by the test macro `__cpp_lib_format_path`, which is also breaking the build in 16.2.

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
