### PR TITLE
Bound Slurm waits in LSU CI

### DIFF
--- a/.jenkins/common/slurm.sh
+++ b/.jenkins/common/slurm.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+# Copyright (c) 2026 Anshuman Agrawal
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# GNU timeout bounds controller RPCs as well as time spent in the queue.
+hpx_slurm_cancel_previous()
+{
+    local job_name="$1"
+    local deadline=$((SECONDS + ${2:-120}))
+    local jobs remaining
+    local user_id
+    user_id=$(id -u) || return "$?"
+
+    remaining=$((deadline - SECONDS))
+    (( remaining > 0 )) || return 124
+    timeout --foreground --kill-after=5s "${remaining}s" \
+        scancel --user="${user_id}" --name="${job_name}" || return "$?"
+    while (( SECONDS < deadline )); do
+        remaining=$((deadline - SECONDS))
+        (( remaining > 0 )) || break
+        jobs=$(timeout --foreground --kill-after=5s "${remaining}s" \
+            squeue --user="${user_id}" --name="${job_name}" --noheader) || return "$?"
+        [[ -n "${jobs}" ]] || return 0
+        sleep 1
+    done
+    echo "Timed out waiting for previous Slurm jobs: ${job_name}" >&2
+    return 124
+}
+
+# Called while the locals of hpx_slurm_run are still in scope. Never cancel
+# by name here: a newer Jenkins build may already have submitted the same lane.
+hpx_slurm_cleanup()
+{
+    local result="$1"
+    local job_id="" cluster="" extra=""
+    local grace=$((SECONDS + 5))
+
+    # A second abort must not interrupt cancellation of the owned job.
+    trap '' HUP INT TERM
+    if (( result != 0 )); then
+        # Allow an in-flight submission to return its ID before stopping sbatch.
+        while [[ ! -s "${submission_file}" ]] && \
+            kill -0 "${submission_pid}" 2>/dev/null && \
+            (( SECONDS < grace )); do
+            sleep 1
+        done
+        # timeout forwards TERM to sbatch and enforces its five-second kill grace.
+        kill -TERM "${submission_pid}" 2>/dev/null || true
+        wait "${submission_pid}" 2>/dev/null || true
+    fi
+
+    IFS=';' read -r job_id cluster extra < "${submission_file}" || true
+    if [[ "${job_id}" =~ ^[1-9][0-9]*$ && -z "${extra}" &&
+        "${cluster}" =~ ^[a-zA-Z0-9_-]*$ ]]; then
+        echo "Slurm job: ${job_id}${cluster:+;${cluster}}" >&2
+        if (( result != 0 )); then
+            if ! timeout --foreground --kill-after=5s 30s scancel \
+                ${cluster:+"--clusters=${cluster}"} "${job_id}"; then
+                echo "Failed to cancel Slurm job ${job_id}; check it manually" >&2
+            fi
+        fi
+    elif (( result == 0 )); then
+        echo "sbatch returned no valid job ID" >&2
+        result=1
+    else
+        echo "No Slurm job ID received; submission may need reconciliation" >&2
+    fi
+    rm -f "${submission_file}"
+    return "${result}"
+}
+
+# The limit includes submission, queueing and execution, unlike sbatch --time.
+# Leave one hour beyond the lane's runtime limit for queueing. Cleanup can add
+# at most five seconds for submission plus two five-second kill graces and one
+# thirty-second cancellation RPC. SIGKILL/host loss or a lost submission reply
+# still require administrator reconciliation; no name-based fallback is safe.
+hpx_slurm_run()
+{
+    local limit="$1"
+    shift
+    if [[ ! "${limit}" =~ ^[1-9][0-9]*[smhd]$ ]]; then
+        echo "Slurm timeout must be a positive integer followed by s/m/h/d" >&2
+        return 2
+    fi
+    local submission_file submission_pid result abort_status=0
+    # Defer signals until the child PID and EXIT cleanup are installed.
+    trap 'abort_status=129' HUP
+    trap 'abort_status=130' INT
+    trap 'abort_status=143' TERM
+    if ! submission_file=$(mktemp); then
+        trap - HUP INT TERM
+        return 1
+    fi
+    # Install EXIT after starting the child so cleanup always has a valid PID.
+    timeout --foreground --kill-after=5s "${limit}" sbatch --parsable --wait "$@" \
+        > "${submission_file}" &
+    submission_pid=$!
+    trap 'hpx_slurm_cleanup "$?"' EXIT
+    trap 'exit 129' HUP
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
+    (( abort_status == 0 )) || exit "${abort_status}"
+    if wait "${submission_pid}"; then
+        result=0
+    else
+        result=$?
+    fi
+    if hpx_slurm_cleanup "${result}"; then
+        result=0
+    else
+        result=$?
+    fi
+    trap - EXIT HUP INT TERM
+    return "${result}"
+}

--- a/.jenkins/lsu-perftests/entry.sh
+++ b/.jenkins/lsu-perftests/entry.sh
@@ -10,6 +10,8 @@
 # Make undefined variables errors, print each command
 set -eux
 
+source .jenkins/common/slurm.sh
+
 source .jenkins/lsu-perftests/slurm-constraint-${configuration_name}.sh
 
 if [[ -z "${ghprbPullId:-}" ]]; then
@@ -21,13 +23,7 @@ else
 
     # Cancel currently running builds on the same branch, but only for pull
     # requests
-    scancel  --verbose --verbose --verbose --verbose --jobname="${job_name}"
-
-    # Wait for the job to be cancelled before launching a new job with the
-    # same name
-    while squeue --name="${job_name}" --noheader | grep -q .; do
-        sleep 1                  # adjust the interval as needed
-    done
+    hpx_slurm_cancel_previous "${job_name}"
 fi
 
 # delay things for a random amount of time
@@ -35,7 +31,7 @@ sleep $[(RANDOM % 10) + 1].$[(RANDOM % 10)]s
 
 # Start the actual build
 set +e
-sbatch \
+hpx_slurm_run "${HPX_SLURM_TIMEOUT:-4h}" \
     --verbose --verbose --verbose --verbose \
     --exclusive \
     --job-name="${job_name}" \
@@ -45,7 +41,8 @@ sbatch \
     --time="03:00:00" \
     --output="jenkins-hpx-${configuration_name}.out" \
     --error="jenkins-hpx-${configuration_name}.err" \
-    --wait .jenkins/lsu-perftests/batch.sh
+    .jenkins/lsu-perftests/batch.sh
+slurm_status=$?
 
 # Print slurm logs
 echo "= stdout =================================================="
@@ -64,4 +61,7 @@ fi
 
 
 set -e
+if [[ "${slurm_status}" -ne 0 ]]; then
+    exit "${slurm_status}"
+fi
 exit $(cat ${status_file})

--- a/.jenkins/lsu-test-coverage/entry.sh
+++ b/.jenkins/lsu-test-coverage/entry.sh
@@ -11,6 +11,8 @@
 # Make undefined variables errors, print each command
 set -eux
 
+source .jenkins/common/slurm.sh
+
 source .jenkins/lsu-test-coverage/slurm-constraint-${configuration_name}.sh
 
 if [[ -z "${CHANGE_ID:-}" ]]; then
@@ -22,7 +24,7 @@ else
 
     # Cancel currently running builds on the same branch, but only for pull
     # requests
-    scancel  --verbose --verbose --verbose --verbose --jobname="${job_name}"
+    hpx_slurm_cancel_previous "${job_name}"
 fi
 
 # delay things for a random amount of time
@@ -41,7 +43,7 @@ fi
 
 # Start the actual build
 set +e
-sbatch \
+hpx_slurm_run "${HPX_SLURM_TIMEOUT:-6h}" \
     --verbose --verbose --verbose --verbose \
     --exclusive \
     --job-name="${job_name}" \
@@ -50,7 +52,8 @@ sbatch \
     --time="05:00:00" \
     --output="jenkins-hpx-${configuration_name}.out" \
     --error="jenkins-hpx-${configuration_name}.err" \
-    --wait .jenkins/lsu-test-coverage/batch.sh
+    .jenkins/lsu-test-coverage/batch.sh
+slurm_status=$?
 
 
 # Print slurm logs
@@ -64,4 +67,7 @@ cat jenkins-hpx-${configuration_name}.err
 status_file="jenkins-hpx-${configuration_name}-ctest-status.txt"
 
 set -e
+if [[ "${slurm_status}" -ne 0 ]]; then
+    exit "${slurm_status}"
+fi
 exit $(cat ${status_file})

--- a/.jenkins/lsu/entry.sh
+++ b/.jenkins/lsu/entry.sh
@@ -15,6 +15,7 @@ rm -f ./jenkins-hpx* ./*-Testing
 export configuration_name_with_build_type="${configuration_name}-${build_type,,}"
 
 source .jenkins/lsu/slurm-configuration-${configuration_name}.sh
+source .jenkins/common/slurm.sh
 
 if [[ -z "${ghprbPullId:-}" ]]; then
     # Set name of branch if not building a pull request
@@ -31,13 +32,7 @@ else
 
     # Cancel currently running builds on the same branch, but only for pull
     # requests
-    scancel --verbose --verbose --verbose --verbose --jobname="${job_name}"
-
-    # Wait for the job to be cancelled before launching a new job with the
-    # same name
-    while squeue --name="${job_name}" --noheader | grep -q .; do
-        sleep 1                  # adjust the interval as needed
-    done
+    hpx_slurm_cancel_previous "${job_name}"
 
     export install_hpx=0
 fi
@@ -47,7 +42,7 @@ sleep $[(RANDOM % 20) + 1].$[(RANDOM % 20)]s
 
 # Start the actual build
 set +e
-sbatch \
+hpx_slurm_run "${HPX_SLURM_TIMEOUT:-7h}" \
     --verbose --verbose --verbose --verbose \
     --exclusive \
     --job-name="${job_name}" \
@@ -57,7 +52,8 @@ sbatch \
     --time="06:00:00" \
     --output="jenkins-hpx-${configuration_name_with_build_type}.out" \
     --error="jenkins-hpx-${configuration_name_with_build_type}.err" \
-    --wait .jenkins/lsu/batch.sh
+    .jenkins/lsu/batch.sh
+slurm_status=$?
 
 # Print slurm logs
 echo "= stdout =================================================="
@@ -72,7 +68,8 @@ cat jenkins-hpx-${configuration_name_with_build_type}-cdash-submission.txt
 
 # Get build status
 status_file="jenkins-hpx-${configuration_name_with_build_type}-ctest-status.txt"
-if [[ -f "${status_file}" && "$(cat ${status_file})" -eq "0" ]]; then
+if [[ "${slurm_status}" -eq 0 && -f "${status_file}" &&
+    "$(cat ${status_file})" -eq "0" ]]; then
     github_commit_status="success"
 else
     github_commit_status="failure"
@@ -106,4 +103,7 @@ else
 fi
 
 set -e
+if [[ "${slurm_status}" -ne 0 ]]; then
+    exit "${slurm_status}"
+fi
 exit $(cat ${status_file})

--- a/.jenkins/tests/test_slurm_lifecycle.py
+++ b/.jenkins/tests/test_slurm_lifecycle.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Anshuman Agrawal
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+"""Run with Python 3; all Slurm commands are private executable stubs.
+
+GNU timeout and Bash 4+ must be on PATH. Set HPX_TEST_BASH to select Bash.
+"""
+
+import json
+import os
+from pathlib import Path
+import shlex
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+BASH = os.environ.get("HPX_TEST_BASH", "bash")
+STUB = r'''
+import json
+import os
+from pathlib import Path
+import signal
+import sys
+import time
+
+name = Path(sys.argv[0]).name
+with open(os.environ["CALL_LOG"], "a") as log:
+    log.write(json.dumps([name] + sys.argv[1:]) + "\n")
+if name == "sbatch":
+    if os.environ.get("ARTIFACT_PREFIX"):
+        prefix = os.environ["ARTIFACT_PREFIX"]
+        for suffix in (".out", ".err", "-cdash-submission.txt",
+                       "-cdash-build-id.txt", "-ctest-status.txt"):
+            Path(prefix + suffix).write_text("0\n")
+    if os.environ.get("IGNORE_TERM"):
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    time.sleep(float(os.environ.get("SUBMIT_DELAY", "0")))
+    if os.environ.get("JOB_ID", "12345"):
+        print(os.environ.get("JOB_ID", "12345"), flush=True)
+    Path(os.environ["READY"]).touch()
+    time.sleep(float(os.environ.get("JOB_DELAY", "0")))
+    sys.exit(int(os.environ.get("JOB_EXIT", "0")))
+if name == "scancel":
+    time.sleep(float(os.environ.get("CANCEL_DELAY", "0")))
+    sys.exit(int(os.environ.get("CANCEL_EXIT", "0")))
+if name == "squeue":
+    time.sleep(float(os.environ.get("QUEUE_DELAY", "0")))
+    if os.environ.get("QUEUE_JOBS"):
+        print("12345")
+    sys.exit(int(os.environ.get("QUEUE_EXIT", "0")))
+'''
+
+
+class SlurmLifecycle(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.path = Path(self.temp.name)
+        for command in ("sbatch", "scancel", "squeue"):
+            stub = self.path / command
+            stub.write_text("#!" + sys.executable + "\n" + STUB)
+            stub.chmod(0o755)
+        self.log = self.path / "calls.jsonl"
+        self.ready = self.path / "ready"
+        self.env = dict(os.environ, PATH=str(self.path) + ":" + os.environ["PATH"],
+                        CALL_LOG=str(self.log), READY=str(self.ready),
+                        TMPDIR=str(self.path))
+
+    def start(self, command='hpx_slurm_run 10s --job-name=lane batch.sh', **env):
+        self.env.update(env)
+        script = ('set -eu\nsource ' +
+                  shlex.quote(str(ROOT / ".jenkins/common/slurm.sh")) +
+                  '\n' + command)
+        process = subprocess.Popen([BASH, "-c", script], env=self.env,
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                start_new_session=True, cwd=self.path)
+        self.addCleanup(self.stop, process)
+        return process
+
+    @staticmethod
+    def stop(process):
+        # This test owns the session, including timeout and any stub children.
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        process.communicate(timeout=3)
+
+    def finish(self, process, timeout=12):
+        try:
+            out, err = process.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            os.killpg(process.pid, signal.SIGKILL)
+            process.communicate()
+            self.fail("Slurm helper did not finish within its test bound")
+        self.assertFalse(list(self.path.glob("tmp.*")), "temporary ID file leaked")
+        return process.returncode, out.decode(), err.decode()
+
+    def calls(self, name):
+        lines = self.log.read_text().splitlines() if self.log.exists() else []
+        return [row[1:] for row in map(json.loads, lines) if row[0] == name]
+
+    def wait_ready(self):
+        deadline = time.monotonic() + 3
+        while not self.ready.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        self.assertTrue(self.ready.exists(), "stub submission never completed")
+
+    def start_entry(self, lane, **env):
+        jenkins = self.path / ".jenkins"
+        target = jenkins / lane
+        target.mkdir(parents=True, exist_ok=True)
+        (jenkins / "common").mkdir(exist_ok=True)
+        for relative in (lane + "/entry.sh", "common/slurm.sh"):
+            shutil.copyfile(ROOT / ".jenkins" / relative, jenkins / relative)
+        config = ("slurm-configuration-test.sh" if lane == "lsu" else
+                  "slurm-constraint-test.sh")
+        (target / config).write_text(
+            'configuration_slurm_num_nodes=1\n'
+            'configuration_slurm_partition=test\n'
+            'configuration_slurm_nodelist=test\n')
+        status_script = jenkins / "common/set_github_status.sh"
+        status_script.write_text("#!/bin/sh\nexit 0\n")
+        status_script.chmod(0o755)
+        comment_script = target / "comment_github.sh"
+        comment_script.write_text("#!/bin/sh\nexit 0\n")
+        comment_script.chmod(0o755)
+        # No downloads, unpacking, or randomized entry delays in this fixture.
+        for command in ("wget", "sha256sum", "tar", "sleep"):
+            stub = self.path / command
+            stub.write_text("#!/bin/sh\nexit 0\n")
+            stub.chmod(0o755)
+        (self.path / "grcov").touch()
+        (self.path / "grcov.tar.bz2").touch()
+        prefix = "jenkins-hpx-test" + ("-debug" if lane == "lsu" else "")
+        self.env.update(configuration_name="test", build_type="Debug",
+                        GIT_BRANCH="origin/master", GIT_COMMIT="fixture",
+                        GITHUB_TOKEN="fixture-unused", ARTIFACT_PREFIX=prefix)
+        self.env.update(env)
+        process = subprocess.Popen([BASH, str(target / "entry.sh")], env=self.env,
+                                cwd=self.path, stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE, start_new_session=True)
+        self.addCleanup(self.stop, process)
+        return process
+
+    def test_entries_preserve_success(self):
+        for lane in ("lsu", "lsu-perftests", "lsu-test-coverage"):
+            with self.subTest(lane=lane):
+                code, _, err = self.finish(self.start_entry(lane))
+                self.assertEqual(code, 0, err)
+
+    def test_entries_reject_success_sentinel_after_slurm_failure(self):
+        for lane in ("lsu", "lsu-perftests", "lsu-test-coverage"):
+            with self.subTest(lane=lane):
+                code, _, err = self.finish(self.start_entry(lane, JOB_EXIT="42"))
+                self.assertEqual(code, 42, err)
+
+    def test_entries_timeout_cancels_owned_job(self):
+        for lane in ("lsu", "lsu-perftests", "lsu-test-coverage"):
+            with self.subTest(lane=lane):
+                code, _, err = self.finish(self.start_entry(
+                    lane, JOB_DELAY="30", HPX_SLURM_TIMEOUT="1s"))
+                self.assertEqual(code, 124, err)
+        self.assertEqual(self.calls("scancel"), [["12345"]] * 3)
+
+    def test_entries_abort_cancels_owned_job(self):
+        for lane in ("lsu", "lsu-perftests", "lsu-test-coverage"):
+            with self.subTest(lane=lane):
+                self.ready.unlink(missing_ok=True)
+                process = self.start_entry(lane, JOB_DELAY="30")
+                self.wait_ready()
+                process.send_signal(signal.SIGTERM)
+                code, _, err = self.finish(process)
+                self.assertEqual(code, 143, err)
+        self.assertEqual(self.calls("scancel"), [["12345"]] * 3)
+
+    def test_invalid_timeout_cannot_disable_bound(self):
+        for limit in ("0", "0s", "-1h", "invalid"):
+            with self.subTest(limit=limit):
+                code, _, _ = self.finish(self.start(
+                    "hpx_slurm_run " + limit + " batch.sh"))
+                self.assertEqual(code, 2)
+        self.assertEqual(self.calls("sbatch"), [])
+
+    def test_success(self):
+        code, _, _ = self.finish(self.start())
+        self.assertEqual(code, 0)
+        self.assertEqual(self.calls("scancel"), [])
+        self.assertEqual(self.calls("sbatch")[0][:2], ["--parsable", "--wait"])
+
+    def test_job_failure_preserved(self):
+        code, _, _ = self.finish(self.start(JOB_EXIT="42"))
+        self.assertEqual(code, 42)
+        self.assertEqual(self.calls("scancel"), [["12345"]])
+
+    def test_submission_failure_has_no_name_fallback(self):
+        code, _, err = self.finish(self.start(JOB_ID="", JOB_EXIT="9"))
+        self.assertEqual(code, 9)
+        self.assertIn("No Slurm job ID", err)
+        self.assertEqual(self.calls("scancel"), [])
+
+    def test_missing_or_invalid_id_is_not_success(self):
+        for job_id in ("", "0", "bad;id", "123;cluster;extra"):
+            with self.subTest(job_id=job_id):
+                code, _, _ = self.finish(self.start(JOB_ID=job_id))
+                self.assertEqual(code, 1)
+        self.assertEqual(self.calls("scancel"), [])
+
+    def test_queue_and_runtime_timeout(self):
+        code, _, _ = self.finish(self.start(
+            'hpx_slurm_run 1s batch.sh', JOB_DELAY="30"))
+        self.assertEqual(code, 124)
+        self.assertEqual(self.calls("scancel"), [["12345"]])
+
+    def test_timeout_kills_unresponsive_sbatch(self):
+        code, _, _ = self.finish(self.start(
+            'hpx_slurm_run 1s batch.sh', JOB_DELAY="30", IGNORE_TERM="1"))
+        self.assertEqual(code, 137)
+        self.assertEqual(self.calls("scancel"), [["12345"]])
+
+    def test_hung_cleanup_rpc_is_bounded(self):
+        code, _, err = self.finish(self.start(
+            JOB_EXIT="42", CANCEL_DELAY="60"), timeout=40)
+        self.assertEqual(code, 42)
+        self.assertIn("Failed to cancel Slurm job 12345", err)
+
+    def test_hung_previous_cancellation_rpc_is_bounded(self):
+        code, _, _ = self.finish(self.start(
+            'hpx_slurm_cancel_previous lane 1', CANCEL_DELAY="30"))
+        self.assertEqual(code, 124)
+        self.assertEqual(self.calls("squeue"), [])
+
+    def test_hung_queue_rpc_is_bounded(self):
+        code, _, _ = self.finish(self.start(
+            'hpx_slurm_cancel_previous lane 2', QUEUE_DELAY="30"))
+        self.assertEqual(code, 124)
+
+    def test_cluster_job_id(self):
+        code, _, _ = self.finish(self.start(JOB_ID="12345;rostam", JOB_EXIT="7"))
+        self.assertEqual(code, 7)
+        self.assertEqual(self.calls("scancel"), [["--clusters=rostam", "12345"]])
+
+    def test_failed_cancellation_keeps_failure(self):
+        code, _, err = self.finish(self.start(JOB_EXIT="42", CANCEL_EXIT="8"))
+        self.assertEqual(code, 42)
+        self.assertIn("Failed to cancel Slurm job 12345", err)
+
+    def test_abort_signals_cancel_owned_id(self):
+        for sig in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+            with self.subTest(sig=sig):
+                self.ready.unlink(missing_ok=True)
+                process = self.start(JOB_DELAY="30")
+                self.wait_ready()
+                process.send_signal(sig)
+                code, _, _ = self.finish(process)
+                self.assertEqual(code, 128 + sig)
+        self.assertEqual(self.calls("scancel"), [["12345"]] * 3)
+
+    def test_process_group_abort(self):
+        process = self.start(JOB_DELAY="30")
+        self.wait_ready()
+        os.killpg(process.pid, signal.SIGTERM)
+        code, _, _ = self.finish(process)
+        self.assertEqual(code, 143)
+        self.assertEqual(self.calls("scancel"), [["12345"]])
+
+    def test_abort_during_submission_captures_late_id(self):
+        process = self.start(SUBMIT_DELAY="0.3", JOB_DELAY="30")
+        deadline = time.monotonic() + 3
+        while not self.log.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        self.assertTrue(self.log.exists())
+        process.send_signal(signal.SIGTERM)
+        code, _, _ = self.finish(process)
+        self.assertEqual(code, 143)
+        self.assertEqual(self.calls("scancel"), [["12345"]])
+
+    def test_previous_cancellation_success(self):
+        code, _, _ = self.finish(self.start('hpx_slurm_cancel_previous lane 3'))
+        self.assertEqual(code, 0)
+        self.assertEqual(self.calls("scancel"),
+                         [["--user=" + str(os.getuid()), "--name=lane"]])
+        self.assertEqual(self.calls("squeue"),
+                         [["--user=" + str(os.getuid()), "--name=lane",
+                           "--noheader"]])
+        self.assertEqual(self.calls("sbatch"), [])
+
+    def test_previous_cancellation_is_bounded(self):
+        code, _, _ = self.finish(self.start(
+            'hpx_slurm_cancel_previous lane 1', QUEUE_JOBS="1"))
+        self.assertEqual(code, 124)
+        self.assertEqual(self.calls("sbatch"), [])
+
+    def test_queue_error_is_failure(self):
+        code, _, _ = self.finish(self.start(
+            'hpx_slurm_cancel_previous lane 3', QUEUE_EXIT="6"))
+        self.assertEqual(code, 6)
+
+    def test_previous_cancel_error_is_failure(self):
+        code, _, _ = self.finish(self.start(
+            'hpx_slurm_cancel_previous lane 3', CANCEL_EXIT="8"))
+        self.assertEqual(code, 8)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Proposed Changes

`sbatch --wait` can hold a Jenkins executor indefinitely while a job stays pending. Add a timeout covering submission, queueing, and execution, with defaults of seven hours for HPX, four for performance tests, and six for coverage. The limit is configurable with `HPX_SLURM_TIMEOUT`.

Track the submitted job ID and cancel it on timeout or abort. Bound cancellation of older PR jobs and restrict those lookups to the current user. Preserve Slurm failures even when a successful CTest status file exists.

## Any background context you want to provide?

All 23 regression tests pass with stubbed Slurm commands, including signals, delayed submission replies, and hung cancellation calls. Live cluster validation is pending; host loss or SIGKILL can still require manual cleanup.

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [x] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
