### PR TITLE
Fix data race in hostname_print_helper::get_hostname()"

### DIFF
--- a/libs/core/debugging/src/print.cpp
+++ b/libs/core/debugging/src/print.cpp
@@ -23,6 +23,7 @@
 #include <iomanip>
 #include <iostream>
 #include <iterator>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <type_traits>
@@ -267,13 +268,12 @@ namespace hpx::debug {
         // ------------------------------------------------------------------
         [[nodiscard]] char const* hostname_print_helper::get_hostname() const
         {
-            static bool initialized = false;
+            static std::once_flag hostname_once;
             static char hostname_[32] = {'\0'};
-            if (!initialized)
-            {
-                initialized = true;
+            std::call_once(hostname_once, [this]() {
 #if !defined(__FreeBSD__)
-                gethostname(hostname_, static_cast<std::size_t>(12));
+                gethostname(hostname_, sizeof(hostname_) - 1);
+                hostname_[sizeof(hostname_) - 1] = '\0';
 #endif
                 int const rank = guess_rank();
                 if (rank >= 0)
@@ -282,7 +282,7 @@ namespace hpx::debug {
                     std::snprintf(
                         hostname_ + len, sizeof(hostname_) - len, "(%d)", rank);
                 }
-            }
+            });
             return hostname_;
         }
 

--- a/libs/core/debugging/tests/regressions/CMakeLists.txt
+++ b/libs/core/debugging/tests/regressions/CMakeLists.txt
@@ -3,3 +3,27 @@
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests hostname_print_helper_7520)
+
+set(hostname_print_helper_7520_PARAMETERS THREADS_PER_LOCALITY 4)
+
+# Create test cases
+foreach(test ${tests})
+  set(sources ${test}.cpp)
+
+  source_group("Source Files" FILES ${sources})
+
+  # add example executable
+  add_hpx_executable(
+    ${test}_test INTERNAL_FLAGS
+    SOURCES ${sources} ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Regressions/Modules/Core/Debugging"
+  )
+
+  target_link_libraries(${test}_test PRIVATE ${${test}_LIBRARIES})
+  add_hpx_regression_test("modules.debugging" ${test} ${${test}_PARAMETERS})
+
+endforeach()

--- a/libs/core/debugging/tests/regressions/hostname_print_helper_7520.cpp
+++ b/libs/core/debugging/tests/regressions/hostname_print_helper_7520.cpp
@@ -15,14 +15,15 @@
 // worker threads and checks every task observed the same fully
 // initialized string once all tasks have finished.
 
+#include <hpx/barrier.hpp>
 #include <hpx/future.hpp>
 #include <hpx/init.hpp>
 #include <hpx/modules/debugging.hpp>
 #include <hpx/modules/testing.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
-
 constexpr int num_tasks = 64;
 constexpr int calls_per_task = 1000;
 

--- a/libs/core/debugging/tests/regressions/hostname_print_helper_7520.cpp
+++ b/libs/core/debugging/tests/regressions/hostname_print_helper_7520.cpp
@@ -1,0 +1,63 @@
+//  Copyright (c) 2026 Rohan on Keys
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Regression test for issue #7520.
+//
+// hostname_print_helper::get_hostname() lazily filled a static buffer
+// behind a plain bool flag. Two worker threads could both observe the
+// flag as false and race on writing the flag and the buffer, so the
+// flag could become true before the buffer was fully written.
+//
+// This calls get_hostname() many times from tasks spread across multiple
+// worker threads and checks every task observed the same fully
+// initialized string once all tasks have finished.
+
+#include <hpx/future.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/debugging.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <string>
+#include <vector>
+
+constexpr int num_tasks = 64;
+constexpr int calls_per_task = 1000;
+
+int hpx_main()
+{
+    std::vector<std::string> results(num_tasks);
+    std::vector<hpx::future<void>> futures;
+    futures.reserve(num_tasks);
+
+    for (int i = 0; i < num_tasks; ++i)
+    {
+        futures.push_back(hpx::async([&results, i]() {
+            hpx::debug::detail::hostname_print_helper helper;
+            char const* name = nullptr;
+            for (int j = 0; j < calls_per_task; ++j)
+            {
+                name = helper.get_hostname();
+                HPX_TEST(name != nullptr);
+            }
+            results[i] = name;
+        }));
+    }
+
+    hpx::wait_all(futures);
+
+    for (int i = 1; i < num_tasks; ++i)
+    {
+        HPX_TEST_EQ(results[i], results[0]);
+    }
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ(hpx::local::init(hpx_main, argc, argv), 0);
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
Fixes #7520

## Proposed Changes

  - Replace the plain `bool initialized` flag in `hostname_print_helper::get_hostname()` with `std::once_flag` and `std::call_once`, since both statics had trivial constant initializers and never got the compiler's magic-static guard, letting two worker threads race on the flag and the buffer during `on_start_thread`.
  - Read up to `sizeof(hostname_) - 1` bytes from `gethostname` instead of a hardcoded `12`, and null-terminate explicitly, since `gethostname` does not guarantee termination on truncation.
  - Add a regression test that calls `get_hostname()` concurrently from 64 tasks across 4 worker threads and checks every task observes the same fully initialized string once all tasks complete.

## Any background context you want to provide?

Found via ThreadSanitizer while reproducing #6502, unrelated to that issue, just hit on the way there. TSan flagged a read/write race on `get_hostname() const::initialized` during ordinary worker thread startup with more than one worker thread, nothing NUMA-specific. Repro and TSan output are in #7520.

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [x] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.