### PR TITLE
Factor the disconnected-locality dispatch guard into a shared helper

### DIFF
--- a/libs/full/async_distributed/CMakeLists.txt
+++ b/libs/full/async_distributed/CMakeLists.txt
@@ -32,6 +32,7 @@ set(async_headers
     hpx/async_distributed/detail/async_implementations.hpp
     hpx/async_distributed/detail/async_unwrap_result_implementations_fwd.hpp
     hpx/async_distributed/detail/async_unwrap_result_implementations.hpp
+    hpx/async_distributed/detail/locality_disconnected.hpp
     hpx/async_distributed/detail/post_callback.hpp
     hpx/async_distributed/detail/post_continue_callback.hpp
     hpx/async_distributed/detail/post_continue_fwd.hpp
@@ -114,6 +115,7 @@ set(async_sources
     base_lco_with_value_2.cpp
     base_lco_with_value_3.cpp
     continuation.cpp
+    locality_disconnected.cpp
     packaged_action.cpp
     promise.cpp
     trigger_lco.cpp

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/async_implementations.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/async_implementations.hpp
@@ -26,6 +26,7 @@
 #include <hpx/modules/parcelset_base.hpp>
 
 #include <hpx/async_distributed/detail/async_implementations_fwd.hpp>
+#include <hpx/async_distributed/detail/locality_disconnected.hpp>
 #include <hpx/async_distributed/packaged_action.hpp>
 
 #include <cstddef>
@@ -471,19 +472,12 @@ namespace hpx::detail {
         using action_type = hpx::traits::extract_action_t<Action>;
         using component_type = action_type::component_type;
 
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-        using result_type = action_type::local_result_type;
-
-        if (parcelset::locality_was_disconnected(
-                naming::get_locality_id_from_id(id)))
+        if (locality_is_disconnected(id))
         {
-            return hpx::make_exceptional_future<result_type>(
-                HPX_GET_EXCEPTION(hpx::error::locality_was_disconnected,
-                    "hpx::detail::async_impl",
-                    hpx::util::format(
-                        "the requested locality {} was disconnected", id)));
+            return hpx::make_exceptional_future<
+                typename action_type::local_result_type>(
+                get_locality_disconnected_exception(id));
         }
-#endif
 
         [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
         naming::address addr;
@@ -546,17 +540,11 @@ namespace hpx::detail {
         using result_type = action_type::local_result_type;
         using component_type = action_type::component_type;
 
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-        if (parcelset::locality_was_disconnected(
-                naming::get_locality_id_from_id(id)))
+        if (locality_is_disconnected(id))
         {
             return hpx::make_exceptional_future<result_type>(
-                HPX_GET_EXCEPTION(hpx::error::locality_was_disconnected,
-                    "hpx::detail::async_cb_impl",
-                    hpx::util::format(
-                        "the requested locality {} was disconnected", id)));
+                get_locality_disconnected_exception(id));
         }
-#endif
 
         [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
         naming::address addr;
@@ -674,17 +662,11 @@ namespace hpx::detail {
         using result_type = action_type::local_result_type;
         using component_type = action_type::component_type;
 
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-        if (parcelset::locality_was_disconnected(
-                naming::get_locality_id_from_id(id)))
+        if (locality_is_disconnected(id))
         {
             return hpx::make_exceptional_future<result_type>(
-                HPX_GET_EXCEPTION(hpx::error::locality_was_disconnected,
-                    "hpx::detail::async_impl",
-                    hpx::util::format(
-                        "the requested locality {} was disconnected", id)));
+                get_locality_disconnected_exception(id));
         }
-#endif
 
         [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
         naming::address addr;
@@ -765,17 +747,11 @@ namespace hpx::detail {
         using result_type = action_type::local_result_type;
         using component_type = action_type::component_type;
 
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-        if (parcelset::locality_was_disconnected(
-                naming::get_locality_id_from_id(id)))
+        if (locality_is_disconnected(id))
         {
             return hpx::make_exceptional_future<result_type>(
-                HPX_GET_EXCEPTION(hpx::error::locality_was_disconnected,
-                    "hpx::detail::async_impl",
-                    hpx::util::format(
-                        "the requested locality {} was disconnected", id)));
+                get_locality_disconnected_exception(id));
         }
-#endif
 
         [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
         naming::address addr;
@@ -862,17 +838,11 @@ namespace hpx::detail {
         using action_type = hpx::traits::extract_action_t<Action>;
         using result_type = action_type::local_result_type;
 
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-        if (parcelset::locality_was_disconnected(
-                naming::get_locality_id_from_id(id)))
+        if (locality_is_disconnected(id))
         {
             return hpx::make_exceptional_future<result_type>(
-                HPX_GET_EXCEPTION(hpx::error::locality_was_disconnected,
-                    "hpx::detail::async_impl",
-                    hpx::util::format(
-                        "the requested locality {} was disconnected", id)));
+                get_locality_disconnected_exception(id));
         }
-#endif
 
         naming::address addr;
         [[maybe_unused]] bool result = agas::is_local_address_cached(id, addr);

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/async_unwrap_result_implementations.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/async_unwrap_result_implementations.hpp
@@ -18,6 +18,7 @@
 
 #include <hpx/async_distributed/detail/async_implementations.hpp>
 #include <hpx/async_distributed/detail/async_unwrap_result_implementations_fwd.hpp>
+#include <hpx/async_distributed/detail/locality_disconnected.hpp>
 #include <hpx/async_distributed/detail/sync_implementations.hpp>
 
 #include <utility>
@@ -66,15 +67,10 @@ namespace hpx::detail {
         using action_type = hpx::traits::extract_action_t<Action>;
         using component_type = typename action_type::component_type;
 
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-        if (parcelset::locality_was_disconnected(
-                naming::get_locality_id_from_id(id)))
+        if (locality_is_disconnected(id))
         {
-            HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
-                "hpx::detail::async_unwrap_result_impl",
-                "the requested locality {} was disconnected", id);
+            throw_locality_disconnected(id);
         }
-#endif
 
         [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
         naming::address addr;

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/locality_disconnected.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/locality_disconnected.hpp
@@ -1,0 +1,70 @@
+//  Copyright (c) 2026 Abhishek Kumar
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file locality_disconnected.hpp
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/modules/naming_base.hpp>
+#include <hpx/modules/parcelset_base.hpp>
+
+#include <cstdint>
+#include <exception>
+#include <source_location>
+
+namespace hpx::detail {
+    /// \cond NOINTERNAL
+
+    ///////////////////////////////////////////////////////////////////////////
+    // The dispatch guard below is duplicated across all of the async/post/sync
+    // implementations. Centralizing it here keeps the (single) preprocessor
+    // gate in one place and makes sure all call sites report the same
+    // diagnostics.
+    //
+    // Note that hpx::parcelset::locality_was_disconnected is declared only if
+    // networking is enabled, while HPX_HAVE_FORCE_DISCONNECT does not imply
+    // HPX_HAVE_NETWORKING. Both conditions are therefore tested here.
+
+    /// Returns whether the given locality has been forcefully disconnected.
+    /// Folds into a constant \a false if the corresponding functionality has
+    /// not been enabled.
+    HPX_FORCEINLINE bool locality_is_disconnected(
+        [[maybe_unused]] std::uint32_t const locality_id)
+    {
+#if defined(HPX_HAVE_FORCE_DISCONNECT) && defined(HPX_HAVE_NETWORKING)
+        return parcelset::locality_was_disconnected(locality_id);
+#else
+        return false;
+#endif
+    }
+
+    /// \copydoc locality_is_disconnected(std::uint32_t)
+    HPX_FORCEINLINE bool locality_is_disconnected(hpx::id_type const& id)
+    {
+        return locality_is_disconnected(naming::get_locality_id_from_id(id));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // The two helpers below report the location of their caller, just like
+    // HPX_THROW_EXCEPTION and HPX_GET_EXCEPTION do for their expansion site.
+    // The reported function defaults to the caller's own name; pass \a func
+    // explicitly to override it.
+
+    /// Throw hpx::error::locality_was_disconnected on behalf of the caller.
+    HPX_CXX_EXPORT [[noreturn]] HPX_EXPORT void throw_locality_disconnected(
+        hpx::id_type const& id, char const* func = nullptr,
+        std::source_location const& location = std::source_location::current());
+
+    /// Return an exception_ptr referring to
+    /// hpx::error::locality_was_disconnected on behalf of the caller.
+    HPX_CXX_EXPORT [[nodiscard]] HPX_EXPORT std::exception_ptr
+    get_locality_disconnected_exception(hpx::id_type const& id,
+        char const* func = nullptr,
+        std::source_location const& location = std::source_location::current());
+
+    /// \endcond
+}    // namespace hpx::detail

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/post_implementations.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/post_implementations.hpp
@@ -15,6 +15,7 @@
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/modules/parcelset_base.hpp>
 
+#include <hpx/async_distributed/detail/locality_disconnected.hpp>
 #include <hpx/async_distributed/detail/post_implementations_fwd.hpp>
 
 #include <type_traits>
@@ -39,15 +40,10 @@ namespace hpx::detail {
                 hpx::actions::detail::get_action_name<action_type>());
         }
 
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-        if (parcelset::locality_was_disconnected(
-                naming::get_locality_id_from_id(id)))
+        if (locality_is_disconnected(id))
         {
-            HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
-                "hpx::detail::post_impl",
-                "the requested locality {} was disconnected", id);
+            throw_locality_disconnected(id);
         }
-#endif
 
         [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
         naming::address addr;
@@ -119,15 +115,10 @@ namespace hpx::detail {
                 hpx::actions::detail::get_action_name<action_type>());
         }
 
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-        if (parcelset::locality_was_disconnected(
-                naming::get_locality_id_from_id(id)))
+        if (locality_is_disconnected(id))
         {
-            HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
-                "hpx::detail::post_impl",
-                "the requested locality {} was disconnected", id);
+            throw_locality_disconnected(id);
         }
-#endif
 
         if (naming::get_locality_id_from_gid(addr.locality_) ==
             agas::get_locality_id())
@@ -172,15 +163,10 @@ namespace hpx::detail {
                 hpx::actions::detail::get_action_name<action_type>());
         }
 
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-        if (parcelset::locality_was_disconnected(
-                naming::get_locality_id_from_id(id)))
+        if (locality_is_disconnected(id))
         {
-            HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
-                "hpx::detail::post_impl",
-                "the requested locality {} was disconnected", id);
+            throw_locality_disconnected(id);
         }
-#endif
 
         [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
         naming::address addr;
@@ -247,15 +233,10 @@ namespace hpx::detail {
                 hpx::actions::detail::get_action_name<action_type>());
         }
 
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-        if (parcelset::locality_was_disconnected(
-                naming::get_locality_id_from_id(id)))
+        if (locality_is_disconnected(id))
         {
-            HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
-                "hpx::detail::post_impl",
-                "the requested locality {} was disconnected", id);
+            throw_locality_disconnected(id);
         }
-#endif
 
         if (naming::get_locality_id_from_gid(addr.locality_) ==
             agas::get_locality_id())
@@ -301,15 +282,12 @@ namespace hpx::detail {
             return false;
         }
 
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-        if (parcelset::locality_was_disconnected(
-                naming::get_locality_id_from_id(id)))
+        if (locality_is_disconnected(id))
         {
             invoke_callback(HPX_FORWARD(Callback, cb),
                 make_system_error_code(hpx::error::locality_was_disconnected));
             return false;
         }
-#endif
 
         [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
         naming::address addr;
@@ -379,15 +357,12 @@ namespace hpx::detail {
             return false;
         }
 
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-        if (parcelset::locality_was_disconnected(
-                naming::get_locality_id_from_id(id)))
+        if (locality_is_disconnected(id))
         {
             invoke_callback(HPX_FORWARD(Callback, cb),
                 make_system_error_code(hpx::error::locality_was_disconnected));
             return false;
         }
-#endif
 
         [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
         naming::address addr;

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/sync_implementations.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/sync_implementations.hpp
@@ -17,6 +17,7 @@
 #include <hpx/modules/parcelset_base.hpp>
 
 #include <hpx/async_distributed/detail/async_implementations.hpp>
+#include <hpx/async_distributed/detail/locality_disconnected.hpp>
 #include <hpx/async_distributed/detail/sync_implementations_fwd.hpp>
 
 #include <utility>
@@ -62,15 +63,10 @@ namespace hpx::detail {
         using result_type = action_type::local_result_type;
         using component_type = action_type::component_type;
 
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-        if (parcelset::locality_was_disconnected(
-                naming::get_locality_id_from_id(id)))
+        if (locality_is_disconnected(id))
         {
-            HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
-                "hpx::detail::sync_impl",
-                "the requested locality {} was disconnected", id);
+            throw_locality_disconnected(id);
         }
-#endif
 
         [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
         naming::address addr;

--- a/libs/full/async_distributed/include/hpx/async_distributed/packaged_action.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/packaged_action.hpp
@@ -17,6 +17,7 @@
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/parcelset_base.hpp>
 
+#include <hpx/async_distributed/detail/locality_disconnected.hpp>
 #include <hpx/async_distributed/detail/post.hpp>
 #include <hpx/async_distributed/detail/post_callback.hpp>
 #include <hpx/async_distributed/detail/post_implementations_fwd.hpp>
@@ -49,7 +50,7 @@ namespace hpx::lcos {
                 if (ec)
                 {
                     if ((hpx::tolerate_node_faults() && is_asio_error(ec)) ||
-                        parcelset::locality_was_disconnected(
+                        hpx::detail::locality_is_disconnected(
                             p.destination_locality_id()))
                     {
                         std::exception_ptr exception = HPX_GET_EXCEPTION(
@@ -85,7 +86,7 @@ namespace hpx::lcos {
                 if (ec)
                 {
                     if ((hpx::tolerate_node_faults() && is_asio_error(ec)) ||
-                        parcelset::locality_was_disconnected(
+                        hpx::detail::locality_is_disconnected(
                             p.destination_locality_id()))
                     {
                         std::exception_ptr exception = HPX_GET_EXCEPTION(
@@ -454,15 +455,10 @@ namespace hpx::lcos {
             using action_type = hpx::traits::extract_action_t<Action>;
             using component_type = action_type::component_type;
 
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-            if (parcelset::locality_was_disconnected(
-                    naming::get_locality_id_from_id(id)))
+            if (hpx::detail::locality_is_disconnected(id))
             {
-                HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
-                    "hpx::detail::post",
-                    "the requested locality {} was disconnected", id);
+                hpx::detail::throw_locality_disconnected(id);
             }
-#endif
 
             [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
             naming::address addr;
@@ -523,15 +519,10 @@ namespace hpx::lcos {
             using action_type = hpx::traits::extract_action_t<Action>;
             using component_type = action_type::component_type;
 
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-            if (parcelset::locality_was_disconnected(
-                    naming::get_locality_id_from_id(id)))
+            if (hpx::detail::locality_is_disconnected(id))
             {
-                HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
-                    "hpx::detail::post",
-                    "the requested locality {} was disconnected", id);
+                hpx::detail::throw_locality_disconnected(id);
             }
-#endif
 
             if (addr &&
                 naming::get_locality_id_from_gid(addr.locality_) ==
@@ -573,15 +564,10 @@ namespace hpx::lcos {
             using action_type = hpx::traits::extract_action_t<Action>;
             using component_type = action_type::component_type;
 
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-            if (parcelset::locality_was_disconnected(
-                    naming::get_locality_id_from_id(id)))
+            if (hpx::detail::locality_is_disconnected(id))
             {
-                HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
-                    "hpx::detail::post_cb",
-                    "the requested locality {} was disconnected", id);
+                hpx::detail::throw_locality_disconnected(id);
             }
-#endif
 
             [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
             naming::address addr;
@@ -642,15 +628,10 @@ namespace hpx::lcos {
         void post_cb(naming::address&& addr, hpx::id_type const& id,
             Callback&& cb, Ts&&... vs)
         {
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-            if (parcelset::locality_was_disconnected(
-                    naming::get_locality_id_from_id(id)))
+            if (hpx::detail::locality_is_disconnected(id))
             {
-                HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
-                    "hpx::detail::post_cb",
-                    "the requested locality {} was disconnected", id);
+                hpx::detail::throw_locality_disconnected(id);
             }
-#endif
 
             if (addr &&
                 naming::get_locality_id_from_gid(addr.locality_) ==

--- a/libs/full/async_distributed/include/hpx/async_distributed/trigger.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/trigger.hpp
@@ -14,6 +14,7 @@
 #include <hpx/modules/type_support.hpp>
 
 #include <hpx/async_distributed/continuation_fwd.hpp>
+#include <hpx/async_distributed/detail/locality_disconnected.hpp>
 
 #include <cstdlib>
 #include <exception>
@@ -33,14 +34,11 @@ namespace hpx::actions {
                     cont.trigger_error(ex);
                 },
                 [&](std::exception_ptr const&) {
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-                    if (parcelset::locality_was_disconnected(
-                            naming::get_locality_id_from_id(cont.get_id())))
+                    if (hpx::detail::locality_is_disconnected(cont.get_id()))
                     {
                         // ignore any errors as locality is now unreachable
                         return;
                     }
-#endif
                     std::abort();    // nothing we can do here
                 });
         }

--- a/libs/full/async_distributed/src/locality_disconnected.cpp
+++ b/libs/full/async_distributed/src/locality_disconnected.cpp
@@ -1,0 +1,53 @@
+//  Copyright (c) 2026 Abhishek Kumar
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/modules/errors.hpp>
+#include <hpx/modules/format.hpp>
+#include <hpx/modules/naming_base.hpp>
+
+#include <hpx/async_distributed/detail/locality_disconnected.hpp>
+
+#include <exception>
+#include <source_location>
+#include <string>
+
+namespace hpx::detail {
+
+    namespace {
+
+        std::string locality_disconnected_message(hpx::id_type const& id)
+        {
+            return hpx::util::format(
+                "the requested locality {} was disconnected", id);
+        }
+
+        char const* locality_disconnected_function(
+            char const* func, std::source_location const& location) noexcept
+        {
+            return func != nullptr ? func : location.function_name();
+        }
+    }    // namespace
+
+    [[noreturn]] void throw_locality_disconnected(hpx::id_type const& id,
+        char const* func, std::source_location const& location)
+    {
+        hpx::detail::throw_exception(hpx::error::locality_was_disconnected,
+            locality_disconnected_message(id),
+            locality_disconnected_function(func, location),
+            location.file_name(), static_cast<long>(location.line()));
+    }
+
+    std::exception_ptr get_locality_disconnected_exception(
+        hpx::id_type const& id, char const* func,
+        std::source_location const& location)
+    {
+        return hpx::detail::get_exception(hpx::error::locality_was_disconnected,
+            locality_disconnected_message(id), hpx::throwmode::plain,
+            locality_disconnected_function(func, location),
+            location.file_name(), static_cast<long>(location.line()));
+    }
+}    // namespace hpx::detail


### PR DESCRIPTION
Fixes #7469

## Proposed Changes

  - Add `hpx/async_distributed/detail/locality_disconnected.hpp` with a `locality_is_disconnected()` predicate (overloaded for `hpx::id_type` and for a raw locality id) plus `throw_locality_disconnected()` / `get_locality_disconnected_exception()`. Following your suggestion on the issue, the two diagnostics helpers take a defaulted `std::source_location`, so the reported file/line still points at the call site rather than at the helper header.
  - Convert all 20 uses of the guard in `async_distributed` to the shared helpers: 5 in `detail/async_implementations.hpp`, 6 in `detail/post_implementations.hpp`, 6 in `packaged_action.hpp`, 1 each in `detail/sync_implementations.hpp`, `detail/async_unwrap_result_implementations.hpp` and `trigger.hpp`. Twenty `#if defined(HPX_HAVE_FORCE_DISCONNECT)` blocks become one, inside the new header.
  - Include the three call sites I had originally proposed to leave alone, per your review. The two `parcel_write_handler`s had no `HPX_HAVE_FORCE_DISCONNECT` gate at all, so they took the `parcelhandler` mutex on every failed parcel write even in builds without the functionality; they now fold away with the rest. `trigger_error` keeps its inverted polarity (swallow rather than `std::abort()`), it just shares the predicate.
  - Fix the function names the guards report. Three of the four `async_cb_impl` overloads said `"hpx::detail::async_impl"`, and the four `packaged_action` guards said `"hpx::detail::post"` / `"hpx::detail::post_cb"` although they are members of `hpx::lcos::packaged_action`.

## Any background context you want to provide?

The predicate tests `HPX_HAVE_NETWORKING` alongside `HPX_HAVE_FORCE_DISCONNECT`. `hpx::parcelset::locality_was_disconnected` is declared only inside `#if defined(HPX_HAVE_NETWORKING)` in `parcelset_base/locality_interface.hpp`, but `HPX_WITH_FORCE_DISCONNECT` has no dependency on `HPX_WITH_NETWORKING` and CMake only rejects the reverse combination. `-DHPX_WITH_DISTRIBUTED_RUNTIME=ON -DHPX_WITH_NETWORKING=OFF -DHPX_WITH_FORCE_DISCONNECT=ON` therefore did not build before this change. The rest of `post_implementations.hpp` already gates its remote paths on `HPX_HAVE_NETWORKING`, so this also makes the guards consistent with their own file. Happy to split that part out into its own commit or PR if you would rather keep it separate from the refactoring.

One small knock-on in `async_impl`: the `using result_type` alias lived inside the guard and was unused elsewhere in that function, so hoisting it would have tripped `-Wunused-local-typedef` in builds without the functionality. The type is spelled out at the point of use instead.

I could not build the full tree locally (no CMake/Boost/hwloc on this machine), so the following is what I did verify:

- `tools/check_module_cmakelists.sh` reports no missing files and no missing dependencies; removing the new entry from `libs/full/async_distributed/CMakeLists.txt` makes it fail, so the check is exercising the new header.
- `clang-format` 20.1.8, the version used by the formatting workflow, leaves every touched file unchanged.
- The header body compiles standalone against stand-ins that mirror the real declarations (including the `HPX_HAVE_NETWORKING` gate on `locality_was_disconnected`) in all four combinations of the two config macros, and the exceptions carry the caller's file/line. The same stand-ins reproduce the `NETWORKING=OFF` build failure with the old guard.

`libs/full/init_runtime/tests/unit/force_disconnect.cpp` is the behavioural check here and is unchanged; `build-and-test.yml` builds with `HPX_WITH_SUPERVISION=On`, so the converted paths are compiled in CI. I have not added a changelog entry, let me know if you want one for this.

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
