### PR TITLE
Refactor disconnected locality dispatch guard

### DIFF
--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/async_implementations.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/async_implementations.hpp
@@ -471,19 +471,16 @@ namespace hpx::detail {
         using action_type = hpx::traits::extract_action_t<Action>;
         using component_type = action_type::component_type;
 
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-        using result_type = action_type::local_result_type;
-
-        if (parcelset::locality_was_disconnected(
-                naming::get_locality_id_from_id(id)))
+        if (parcelset::check_locality_disconnected(id))
         {
+            using result_type = action_type::local_result_type;
+
             return hpx::make_exceptional_future<result_type>(
                 HPX_GET_EXCEPTION(hpx::error::locality_was_disconnected,
                     "hpx::detail::async_impl",
                     hpx::util::format(
                         "the requested locality {} was disconnected", id)));
         }
-#endif
 
         [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
         naming::address addr;
@@ -546,9 +543,7 @@ namespace hpx::detail {
         using result_type = action_type::local_result_type;
         using component_type = action_type::component_type;
 
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-        if (parcelset::locality_was_disconnected(
-                naming::get_locality_id_from_id(id)))
+        if (parcelset::check_locality_disconnected(id))
         {
             return hpx::make_exceptional_future<result_type>(
                 HPX_GET_EXCEPTION(hpx::error::locality_was_disconnected,
@@ -556,7 +551,6 @@ namespace hpx::detail {
                     hpx::util::format(
                         "the requested locality {} was disconnected", id)));
         }
-#endif
 
         [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
         naming::address addr;
@@ -674,9 +668,7 @@ namespace hpx::detail {
         using result_type = action_type::local_result_type;
         using component_type = action_type::component_type;
 
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-        if (parcelset::locality_was_disconnected(
-                naming::get_locality_id_from_id(id)))
+        if (parcelset::check_locality_disconnected(id))
         {
             return hpx::make_exceptional_future<result_type>(
                 HPX_GET_EXCEPTION(hpx::error::locality_was_disconnected,
@@ -684,7 +676,6 @@ namespace hpx::detail {
                     hpx::util::format(
                         "the requested locality {} was disconnected", id)));
         }
-#endif
 
         [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
         naming::address addr;
@@ -765,9 +756,7 @@ namespace hpx::detail {
         using result_type = action_type::local_result_type;
         using component_type = action_type::component_type;
 
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-        if (parcelset::locality_was_disconnected(
-                naming::get_locality_id_from_id(id)))
+        if (parcelset::check_locality_disconnected(id))
         {
             return hpx::make_exceptional_future<result_type>(
                 HPX_GET_EXCEPTION(hpx::error::locality_was_disconnected,
@@ -775,7 +764,6 @@ namespace hpx::detail {
                     hpx::util::format(
                         "the requested locality {} was disconnected", id)));
         }
-#endif
 
         [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
         naming::address addr;
@@ -862,9 +850,7 @@ namespace hpx::detail {
         using action_type = hpx::traits::extract_action_t<Action>;
         using result_type = action_type::local_result_type;
 
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-        if (parcelset::locality_was_disconnected(
-                naming::get_locality_id_from_id(id)))
+        if (parcelset::check_locality_disconnected(id))
         {
             return hpx::make_exceptional_future<result_type>(
                 HPX_GET_EXCEPTION(hpx::error::locality_was_disconnected,
@@ -872,7 +858,6 @@ namespace hpx::detail {
                     hpx::util::format(
                         "the requested locality {} was disconnected", id)));
         }
-#endif
 
         naming::address addr;
         [[maybe_unused]] bool result = agas::is_local_address_cached(id, addr);

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/async_unwrap_result_implementations.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/async_unwrap_result_implementations.hpp
@@ -66,15 +66,12 @@ namespace hpx::detail {
         using action_type = hpx::traits::extract_action_t<Action>;
         using component_type = typename action_type::component_type;
 
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-        if (parcelset::locality_was_disconnected(
-                naming::get_locality_id_from_id(id)))
+        if (parcelset::check_locality_disconnected(id))
         {
             HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
                 "hpx::detail::async_unwrap_result_impl",
                 "the requested locality {} was disconnected", id);
         }
-#endif
 
         [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
         naming::address addr;

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/post_implementations.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/post_implementations.hpp
@@ -39,15 +39,12 @@ namespace hpx::detail {
                 hpx::actions::detail::get_action_name<action_type>());
         }
 
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-        if (parcelset::locality_was_disconnected(
-                naming::get_locality_id_from_id(id)))
+        if (parcelset::check_locality_disconnected(id))
         {
             HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
                 "hpx::detail::post_impl",
                 "the requested locality {} was disconnected", id);
         }
-#endif
 
         [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
         naming::address addr;
@@ -119,15 +116,12 @@ namespace hpx::detail {
                 hpx::actions::detail::get_action_name<action_type>());
         }
 
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-        if (parcelset::locality_was_disconnected(
-                naming::get_locality_id_from_id(id)))
+        if (parcelset::check_locality_disconnected(id))
         {
             HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
                 "hpx::detail::post_impl",
                 "the requested locality {} was disconnected", id);
         }
-#endif
 
         if (naming::get_locality_id_from_gid(addr.locality_) ==
             agas::get_locality_id())
@@ -172,15 +166,12 @@ namespace hpx::detail {
                 hpx::actions::detail::get_action_name<action_type>());
         }
 
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-        if (parcelset::locality_was_disconnected(
-                naming::get_locality_id_from_id(id)))
+        if (parcelset::check_locality_disconnected(id))
         {
             HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
                 "hpx::detail::post_impl",
                 "the requested locality {} was disconnected", id);
         }
-#endif
 
         [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
         naming::address addr;
@@ -247,15 +238,12 @@ namespace hpx::detail {
                 hpx::actions::detail::get_action_name<action_type>());
         }
 
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-        if (parcelset::locality_was_disconnected(
-                naming::get_locality_id_from_id(id)))
+        if (parcelset::check_locality_disconnected(id))
         {
             HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
                 "hpx::detail::post_impl",
                 "the requested locality {} was disconnected", id);
         }
-#endif
 
         if (naming::get_locality_id_from_gid(addr.locality_) ==
             agas::get_locality_id())
@@ -301,15 +289,12 @@ namespace hpx::detail {
             return false;
         }
 
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-        if (parcelset::locality_was_disconnected(
-                naming::get_locality_id_from_id(id)))
+        if (parcelset::check_locality_disconnected(id))
         {
             invoke_callback(HPX_FORWARD(Callback, cb),
                 make_system_error_code(hpx::error::locality_was_disconnected));
             return false;
         }
-#endif
 
         [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
         naming::address addr;
@@ -379,15 +364,12 @@ namespace hpx::detail {
             return false;
         }
 
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-        if (parcelset::locality_was_disconnected(
-                naming::get_locality_id_from_id(id)))
+        if (parcelset::check_locality_disconnected(id))
         {
             invoke_callback(HPX_FORWARD(Callback, cb),
                 make_system_error_code(hpx::error::locality_was_disconnected));
             return false;
         }
-#endif
 
         [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
         naming::address addr;

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/sync_implementations.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/sync_implementations.hpp
@@ -62,15 +62,12 @@ namespace hpx::detail {
         using result_type = action_type::local_result_type;
         using component_type = action_type::component_type;
 
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-        if (parcelset::locality_was_disconnected(
-                naming::get_locality_id_from_id(id)))
+        if (parcelset::check_locality_disconnected(id))
         {
             HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
                 "hpx::detail::sync_impl",
                 "the requested locality {} was disconnected", id);
         }
-#endif
 
         [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
         naming::address addr;

--- a/libs/full/async_distributed/include/hpx/async_distributed/packaged_action.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/packaged_action.hpp
@@ -454,15 +454,12 @@ namespace hpx::lcos {
             using action_type = hpx::traits::extract_action_t<Action>;
             using component_type = action_type::component_type;
 
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-            if (parcelset::locality_was_disconnected(
-                    naming::get_locality_id_from_id(id)))
+            if (parcelset::check_locality_disconnected(id))
             {
                 HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
                     "hpx::detail::post",
                     "the requested locality {} was disconnected", id);
             }
-#endif
 
             [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
             naming::address addr;
@@ -523,15 +520,12 @@ namespace hpx::lcos {
             using action_type = hpx::traits::extract_action_t<Action>;
             using component_type = action_type::component_type;
 
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-            if (parcelset::locality_was_disconnected(
-                    naming::get_locality_id_from_id(id)))
+            if (parcelset::check_locality_disconnected(id))
             {
                 HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
                     "hpx::detail::post",
                     "the requested locality {} was disconnected", id);
             }
-#endif
 
             if (addr &&
                 naming::get_locality_id_from_gid(addr.locality_) ==
@@ -573,15 +567,12 @@ namespace hpx::lcos {
             using action_type = hpx::traits::extract_action_t<Action>;
             using component_type = action_type::component_type;
 
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-            if (parcelset::locality_was_disconnected(
-                    naming::get_locality_id_from_id(id)))
+            if (parcelset::check_locality_disconnected(id))
             {
                 HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
                     "hpx::detail::post_cb",
                     "the requested locality {} was disconnected", id);
             }
-#endif
 
             [[maybe_unused]] std::pair<bool, components::pinned_ptr> r;
             naming::address addr;
@@ -642,15 +633,12 @@ namespace hpx::lcos {
         void post_cb(naming::address&& addr, hpx::id_type const& id,
             Callback&& cb, Ts&&... vs)
         {
-#if defined(HPX_HAVE_FORCE_DISCONNECT)
-            if (parcelset::locality_was_disconnected(
-                    naming::get_locality_id_from_id(id)))
+            if (parcelset::check_locality_disconnected(id))
             {
                 HPX_THROW_EXCEPTION(hpx::error::locality_was_disconnected,
                     "hpx::detail::post_cb",
                     "the requested locality {} was disconnected", id);
             }
-#endif
 
             if (addr &&
                 naming::get_locality_id_from_gid(addr.locality_) ==

--- a/libs/full/parcelset_base/include/hpx/parcelset_base/locality_interface.hpp
+++ b/libs/full/parcelset_base/include/hpx/parcelset_base/locality_interface.hpp
@@ -10,6 +10,7 @@
 
 #if defined(HPX_HAVE_NETWORKING)
 #include <hpx/modules/errors.hpp>
+#include <hpx/modules/naming_base.hpp>
 
 #include <hpx/parcelset_base/parcelset_base_fwd.hpp>
 
@@ -24,6 +25,22 @@ namespace hpx::parcelset {
     HPX_CXX_EXPORT HPX_EXPORT locality create_locality(std::string const& name);
 
     HPX_CXX_EXPORT HPX_EXPORT bool locality_was_disconnected(std::uint32_t id);
+
+    /// \brief Check if the locality associated with the given id was disconnected.
+    ///
+    /// \param id The target id to check.
+    /// \return true if the locality was disconnected, false otherwise.
+    HPX_CXX_EXPORT inline bool check_locality_disconnected(
+        hpx::id_type const& id)
+    {
+#if defined(HPX_HAVE_FORCE_DISCONNECT)
+        return parcelset::locality_was_disconnected(
+            naming::get_locality_id_from_id(id));
+#else
+        HPX_UNUSED(id);
+        return false;
+#endif
+    }
 
     ///////////////////////////////////////////////////////////////////////////
     // initialize locality interface function wrappers


### PR DESCRIPTION
Fixes #7469

## Proposed Changes

- Refactored the duplicated disconnected-locality dispatch guard.
- Added a shared locality disconnect check.
- Verified async_distributed tests with FORCE_DISCONNECT ON and OFF.

## Any background context you want to provide?

This improves code reuse and maintainability while preserving the existing behavior.

## Checklist

- [x] I have added a new feature and have added tests to go along with it.
- [x] I have fixed a bug and have added a regression test.
- [x] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.