### PR TITLE
Explicitly disable the use of TBB as the parallelization backend for libstdc++

### DIFF
--- a/cmake/HPX_CollectStdHeaders.cmake
+++ b/cmake/HPX_CollectStdHeaders.cmake
@@ -23,7 +23,6 @@ set(STANDARD_LIBRARY_HEADERS
     "<condition_variable>"
     "<deque>"
     "<exception>"
-    "<execution>"
     "<filesystem>"
     "<format>"
     "<forward_list>"

--- a/cmake/templates/std_headers.hpp.in
+++ b/cmake/templates/std_headers.hpp.in
@@ -14,6 +14,10 @@
 #include <hpx/config/modules_enabled.hpp>
 
 @cxx_standard_headers@
+#if defined(HPX_HAVE_CXX17_STD_EXECUTION_POLICES)
+# include <execution>
+#endif
+
 # if defined(HPX_GCC_VERSION)
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored "-Wall"

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -542,3 +542,11 @@ if(HPX_WITH_MODULES_AS_STATIC_LIBRARIES OR HPX_WITH_STATIC_LINKING)
     target_link_libraries(hpx_core PUBLIC Boost::filesystem)
   endif()
 endif()
+
+# We need to prevent depending on TBB, which is used as the implementation
+# platform for parallel algorithms in stdlibc++
+if(("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU") OR ("${CMAKE_CXX_COMPILER_ID}"
+                                                   STREQUAL "Clang")
+)
+  target_compile_definitions(hpx_core PUBLIC _GLIBCXX_USE_TBB_PAR_BACKEND=0)
+endif()


### PR DESCRIPTION
Fixes #7539 