### PR TITLE
Use an HPX-aware mutex in numa_binding_allocator::initialize_pages

### DIFF
--- a/libs/core/compute_local/CMakeLists.txt
+++ b/libs/core/compute_local/CMakeLists.txt
@@ -68,6 +68,7 @@ add_hpx_module(
     hpx_resource_partitioner
     hpx_runtime_local
     hpx_serialization
+    hpx_synchronization
     hpx_threadmanager
     hpx_topology
     hpx_type_support

--- a/libs/core/compute_local/include/hpx/compute_local/host/numa_binding_allocator.hpp
+++ b/libs/core/compute_local/include/hpx/compute_local/host/numa_binding_allocator.hpp
@@ -445,6 +445,13 @@ namespace hpx::compute::host {
 
         void initialize_pages(pointer p, size_t n) const
         {
+            // initialize_pages() is expected to run on an HPX thread. The
+            // mutex is intentionally held across hpx::wait_all(), which may
+            // suspend and later resume the calling HPX thread on a different
+            // OS worker thread.
+            HPX_ASSERT_MSG(threads::get_self_ptr() != nullptr,
+                "numa_binding_allocator::initialize_pages must be called from an HPX thread");
+
             std::unique_lock<hpx::mutex> lk(init_mutex);
 
             threads::hwloc_bitmap_ptr const bitmap =

--- a/libs/core/compute_local/include/hpx/compute_local/host/numa_binding_allocator.hpp
+++ b/libs/core/compute_local/include/hpx/compute_local/host/numa_binding_allocator.hpp
@@ -450,7 +450,8 @@ namespace hpx::compute::host {
             // suspend and later resume the calling HPX thread on a different
             // OS worker thread.
             HPX_ASSERT_MSG(threads::get_self_ptr() != nullptr,
-                "numa_binding_allocator::initialize_pages must be called from an HPX thread");
+                "numa_binding_allocator::initialize_pages must be "
+                "called from an HPX thread");
 
             std::unique_lock<hpx::mutex> lk(init_mutex);
 

--- a/libs/core/compute_local/include/hpx/compute_local/host/numa_binding_allocator.hpp
+++ b/libs/core/compute_local/include/hpx/compute_local/host/numa_binding_allocator.hpp
@@ -15,6 +15,7 @@
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/runtime_local.hpp>
+#include <hpx/modules/synchronization.hpp>
 #include <hpx/modules/threadmanager.hpp>
 #include <hpx/modules/topology.hpp>
 #include <hpx/modules/type_support.hpp>
@@ -444,7 +445,7 @@ namespace hpx::compute::host {
 
         void initialize_pages(pointer p, size_t n) const
         {
-            std::unique_lock<std::mutex> lk(init_mutex);
+            std::unique_lock<hpx::mutex> lk(init_mutex);
 
             threads::hwloc_bitmap_ptr const bitmap =
                 threads::get_thread_manager().get_pool_numa_bitmap(
@@ -496,7 +497,7 @@ namespace hpx::compute::host {
 
         std::string display_binding(pointer p, numa_binding_helper_ptr helper)
         {
-            std::unique_lock<std::mutex> lk(init_mutex);
+            std::unique_lock<hpx::mutex> lk(init_mutex);
             //
             std::ostringstream display;
             auto N = helper->array_rank();
@@ -678,6 +679,11 @@ namespace hpx::compute::host {
         unsigned int flags_;
 
     private:
-        mutable std::mutex init_mutex;
+        // Must be an HPX-aware mutex: initialize_pages() holds this
+        // lock across hpx::wait_all(), which can suspend the calling
+        // HPX thread and resume it on a different OS worker thread.
+        // std::mutex ties lock ownership to the OS thread, so
+        // unlocking after such a migration is undefined behavior.
+        mutable hpx::mutex init_mutex;
     };
 }    // namespace hpx::compute::host


### PR DESCRIPTION
Fixes #6502: Use `hpx::mutex` in `numa_binding_allocator::initialize_pages`

## Summary

`initialize_pages()` took `std::unique_lock<std::mutex>` on `init_mutex` before dispatching per domain first touch tasks, then called `hpx::wait_all(tasks)` while still holding that lock.

`hpx::wait_all()` can suspend the calling HPX thread, which may later resume on a different OS worker thread. Since `std::mutex` ties lock ownership to the OS thread that acquired it, unlocking after such a migration is undefined behavior. On FreeBSD with a hardened libc++ build this was observed as an assertion failure followed by an illegal instruction trap in `std::unique_lock`'s destructor.

This change replaces `init_mutex` with `hpx::mutex`, which is safe to hold across HPX suspension points, and updates both `std::unique_lock` sites in `numa_binding_allocator` accordingly. Since `initialize_pages()` is only ever expected to run on an HPX thread, that precondition is now asserted explicitly, and the HPX lock-checking layer is told to ignore `init_mutex` there since the lock is intentionally held across the suspension point.

Fixes #6502.

## Proposed Changes

* Replace `init_mutex` from `std::mutex` to `hpx::mutex`.
* Update both `std::unique_lock` instances to use `hpx::mutex`.
* Add the required synchronization header for the HPX mutex.
* Assert that `initialize_pages()` is called from an HPX thread and document that precondition.
* Tell the HPX lock-checking layer to ignore `init_mutex` in `initialize_pages()` via `hpx::util::ignore_while_checking`, since it is intentionally held across `hpx::wait_all()`.
* Add docstrings to `initialize_pages()` and `display_binding()` covering their locking behavior and preconditions.

## Any background context you want to provide?

The issue is triggered when `initialize_pages()` holds a mutex across `hpx::wait_all()`, which is a suspension point. Using an HPX aware mutex preserves correct locking semantics even if the HPX thread resumes on a different OS worker thread. `init_mutex` serializes the entire first touch initialization sequence: there is no existing synchronization mechanism that would let it be released before the wait completes without opening a race, so it stays held for the duration, with the assertion and lock-checking exemption documenting why. The existing `numa_allocator_test` exercises this path and is what surfaced the original assertion failure in #6502, so no new test was added.

## Checklist

Not all points below apply to all pull requests.

* [ ] I have added a new feature and have added tests to go along with it.
* [ ] I have fixed a bug and have added a regression test.
* [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.