### PR TITLE
debugging: add regression test for hostname_print_helper race

### DIFF
--- a/libs/core/debugging/include/hpx/debugging/print.hpp
+++ b/libs/core/debugging/include/hpx/debugging/print.hpp
@@ -318,7 +318,7 @@ namespace hpx::debug {
         // ------------------------------------------------------------------
         // helper class for printing time since start
         // ------------------------------------------------------------------
-        struct hostname_print_helper
+        HPX_CXX_CORE_EXPORT struct hostname_print_helper
         {
             [[nodiscard]] HPX_CORE_EXPORT char const* get_hostname() const;
             [[nodiscard]] HPX_CORE_EXPORT int guess_rank() const noexcept;

--- a/libs/core/debugging/tests/regressions/CMakeLists.txt
+++ b/libs/core/debugging/tests/regressions/CMakeLists.txt
@@ -3,3 +3,27 @@
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests hostname_print_helper_7520)
+
+set(hostname_print_helper_7520_PARAMETERS THREADS_PER_LOCALITY 4)
+
+# Create test cases
+foreach(test ${tests})
+  set(sources ${test}.cpp)
+
+  source_group("Source Files" FILES ${sources})
+
+  # add example executable
+  add_hpx_executable(
+    ${test}_test INTERNAL_FLAGS
+    SOURCES ${sources} ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Regressions/Modules/Core/Debugging"
+  )
+
+  target_link_libraries(${test}_test PRIVATE ${${test}_LIBRARIES})
+  add_hpx_regression_test("modules.debugging" ${test} ${${test}_PARAMETERS})
+
+endforeach()

--- a/libs/core/debugging/tests/regressions/hostname_print_helper_7520.cpp
+++ b/libs/core/debugging/tests/regressions/hostname_print_helper_7520.cpp
@@ -1,0 +1,109 @@
+//  Copyright (c) 2026 The STE||AR-Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Regression test for issue #7520.
+//
+// hostname_print_helper::get_hostname() used to lazily fill a static buffer
+// behind a plain bool flag with a trivial constant initializer, so the
+// compiler's magic-static guard did not cover it. Two threads reaching the
+// helper concurrently (e.g. from on_start_thread during worker startup)
+// could both observe the flag as false and race on the flag and the buffer.
+//
+// This test releases many OS threads onto get_hostname() at the same time so
+// that first use is genuinely contended, and checks that every thread
+// observed the same fully-formed hostname string.
+
+#include <hpx/modules/debugging.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <atomic>
+#include <shared_mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#if defined(__FreeBSD__)
+extern char** environ;
+#endif
+
+int main()
+{
+#if defined(__FreeBSD__)
+    freebsd_environ = environ;
+#endif
+
+    constexpr int num_threads = 32;
+    hpx::debug::detail::hostname_print_helper helper;
+
+    // Written from the worker threads, read after join(). The mutex only
+    // keeps ThreadSanitizer quiet about the vector element writes; the
+    // equality checks below are what actually validates the race fix.
+    std::shared_mutex results_mutex;
+    std::vector<std::string> results(num_threads);
+    std::vector<std::thread> threads;
+    threads.reserve(num_threads);
+
+    std::atomic<int> ready{0};
+    std::atomic<bool> go{false};
+
+    for (int i = 0; i != num_threads; ++i)
+    {
+        threads.emplace_back(
+            [i, &helper, &results, &results_mutex, &ready, &go]() {
+                // Hold every thread at the gate so that the first calls into
+                // get_hostname() are actually contended instead of being
+                // serialized by thread creation.
+                ready.fetch_add(1, std::memory_order_acq_rel);
+                while (!go.load(std::memory_order_acquire))
+                {
+                    std::this_thread::yield();
+                }
+
+                // The first call must return a pointer to the same, fully
+                // written buffer for every thread.
+                char const* name = helper.get_hostname();
+                if (name != nullptr)
+                {
+                    std::unique_lock<std::shared_mutex> lock(results_mutex);
+                    results[i] = name;
+                }
+            });
+    }
+
+    // Wait until all threads are parked at the gate, then release them.
+    while (ready.load(std::memory_order_acquire) != num_threads)
+    {
+        std::this_thread::yield();
+    }
+    go.store(true, std::memory_order_release);
+
+    for (auto& t : threads)
+    {
+        t.join();
+    }
+
+    // Every thread must have seen an identical hostname string; a race in
+    // the lazy initialization could otherwise hand some threads a partially
+    // written or truncated buffer.
+    std::string const& first = results[0];
+    for (int i = 1; i != num_threads; ++i)
+    {
+        HPX_TEST_EQ(results[i], first);
+    }
+
+    // The hostname itself must come out intact (not garbled by a torn
+    // write). On FreeBSD the gethostname call is skipped, so the buffer may
+    // legitimately be empty when no rank suffix is appended.
+#if !defined(__FreeBSD__)
+    HPX_TEST(!first.empty());
+    HPX_TEST(
+        first.find_first_not_of(
+            "abcdefghijklmnopqrstuvwxyz"
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789()-_.") == std::string::npos);
+#endif
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
Adds the regression test for the data race in `hostname_print_helper::get_hostname()` that @hkaiser requested during the review of #7525.

## What

- `libs/core/debugging/tests/regressions/hostname_print_helper_7520.cpp`: gates 32 OS threads on an atomic flag and releases them together, so the first call into `get_hostname()` is genuinely contended. Every thread must observe the same hostname string, which must be non-empty and well-formed on non-FreeBSD platforms (on FreeBSD `gethostname` is skipped and the buffer may legitimately be empty until a rank suffix is appended).
- `libs/core/debugging/tests/regressions/CMakeLists.txt`: registers the test with `THREADS_PER_LOCALITY 4` (the directory previously had no regression tests).

## Verification

- Test passes repeatedly (30+ consecutive runs) against the merged implementation; registered test passes via ctest.
- To confirm the test actually exercises the race, I also built it against the pre-fix check-then-act implementation of `get_hostname()`: it failed in 27 of 30 runs there.
- `clang-format` and `cmake-format` clean on both touched files.

Refs #7520